### PR TITLE
feat: Add admin_settings persistence layer (#2)

### DIFF
--- a/ai_ready_rag/db/models.py
+++ b/ai_ready_rag/db/models.py
@@ -143,3 +143,13 @@ class AuditLog(Base):
     ip_address = Column(String, nullable=True)
     user_agent = Column(String, nullable=True)
     request_id = Column(String, nullable=True)
+
+
+class AdminSetting(Base):
+    __tablename__ = "admin_settings"
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    key = Column(String, unique=True, nullable=False, index=True)
+    value = Column(Text, nullable=False)  # JSON encoded
+    updated_by = Column(String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/ai_ready_rag/services/__init__.py
+++ b/ai_ready_rag/services/__init__.py
@@ -11,6 +11,7 @@ from ai_ready_rag.services.rag_service import (
     RouteTarget,
     TokenBudget,
 )
+from ai_ready_rag.services.settings_service import SettingsService
 from ai_ready_rag.services.vector_service import (
     CollectionStats,
     HealthStatus,
@@ -41,6 +42,8 @@ __all__ = [
     "ConfidenceScore",
     "RouteTarget",
     "TokenBudget",
+    # Settings Service
+    "SettingsService",
     # Utilities
     "generate_chunk_id",
     "validate_tag",

--- a/ai_ready_rag/services/settings_service.py
+++ b/ai_ready_rag/services/settings_service.py
@@ -1,0 +1,66 @@
+"""Admin settings persistence service."""
+
+import json
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from ai_ready_rag.db.models import AdminSetting
+
+
+class SettingsService:
+    """Service for admin settings CRUD operations."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get(self, key: str) -> Any | None:
+        """Get setting value by key. Returns None if not found."""
+        setting = self.db.query(AdminSetting).filter(AdminSetting.key == key).first()
+        if setting is None:
+            return None
+        return json.loads(setting.value)
+
+    def set(self, key: str, value: Any, updated_by: str | None = None) -> AdminSetting:
+        """Set setting value (create or update)."""
+        setting = self.db.query(AdminSetting).filter(AdminSetting.key == key).first()
+
+        json_value = json.dumps(value)
+
+        if setting is None:
+            # Create new
+            setting = AdminSetting(
+                key=key,
+                value=json_value,
+                updated_by=updated_by,
+            )
+            self.db.add(setting)
+        else:
+            # Update existing
+            setting.value = json_value
+            setting.updated_by = updated_by
+
+        self.db.commit()
+        self.db.refresh(setting)
+        return setting
+
+    def get_all(self) -> dict[str, Any]:
+        """Get all settings as dictionary."""
+        settings = self.db.query(AdminSetting).all()
+        return {s.key: json.loads(s.value) for s in settings}
+
+    def delete(self, key: str) -> bool:
+        """Delete setting by key. Returns True if deleted, False if not found."""
+        setting = self.db.query(AdminSetting).filter(AdminSetting.key == key).first()
+        if setting is None:
+            return False
+        self.db.delete(setting)
+        self.db.commit()
+        return True
+
+    def get_with_defaults(self, defaults: dict[str, Any]) -> dict[str, Any]:
+        """Get all settings, filling in defaults for missing keys."""
+        stored = self.get_all()
+        result = defaults.copy()
+        result.update(stored)
+        return result

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -1,0 +1,114 @@
+"""Tests for SettingsService."""
+
+from ai_ready_rag.services.settings_service import SettingsService
+
+
+class TestSettingsService:
+    """Test SettingsService CRUD operations."""
+
+    def test_get_nonexistent_returns_none(self, db):
+        """Getting nonexistent key returns None."""
+        service = SettingsService(db)
+        assert service.get("nonexistent") is None
+
+    def test_set_creates_new_setting(self, db, admin_user):
+        """Set creates new setting when key doesn't exist."""
+        service = SettingsService(db)
+        setting = service.set("chat_model", "llama3.2", updated_by=admin_user.id)
+
+        assert setting.key == "chat_model"
+        assert setting.updated_by == admin_user.id
+
+        # Verify persisted
+        value = service.get("chat_model")
+        assert value == "llama3.2"
+
+    def test_set_updates_existing_setting(self, db, admin_user):
+        """Set updates existing setting when key exists."""
+        service = SettingsService(db)
+
+        # Create initial
+        service.set("enable_ocr", True, updated_by=admin_user.id)
+
+        # Update
+        service.set("enable_ocr", False, updated_by=admin_user.id)
+
+        assert service.get("enable_ocr") is False
+
+    def test_get_all_returns_dict(self, db, admin_user):
+        """get_all returns all settings as dict."""
+        service = SettingsService(db)
+
+        service.set("key1", "value1")
+        service.set("key2", 123)
+        service.set("key3", {"nested": True})
+
+        all_settings = service.get_all()
+
+        assert all_settings == {
+            "key1": "value1",
+            "key2": 123,
+            "key3": {"nested": True},
+        }
+
+    def test_delete_removes_setting(self, db):
+        """delete removes existing setting."""
+        service = SettingsService(db)
+
+        service.set("to_delete", "value")
+        assert service.get("to_delete") == "value"
+
+        result = service.delete("to_delete")
+
+        assert result is True
+        assert service.get("to_delete") is None
+
+    def test_delete_nonexistent_returns_false(self, db):
+        """delete returns False for nonexistent key."""
+        service = SettingsService(db)
+        assert service.delete("nonexistent") is False
+
+    def test_get_with_defaults(self, db):
+        """get_with_defaults merges stored with defaults."""
+        service = SettingsService(db)
+
+        # Store one setting
+        service.set("chat_model", "deepseek-r1:32b")
+
+        defaults = {
+            "chat_model": "qwen3:8b",
+            "enable_ocr": True,
+            "ocr_language": "eng",
+        }
+
+        result = service.get_with_defaults(defaults)
+
+        # Stored value overrides default
+        assert result["chat_model"] == "deepseek-r1:32b"
+        # Defaults fill in missing
+        assert result["enable_ocr"] is True
+        assert result["ocr_language"] == "eng"
+
+    def test_json_encoding_types(self, db):
+        """Various Python types are correctly JSON encoded/decoded."""
+        service = SettingsService(db)
+
+        # String
+        service.set("str_val", "hello")
+        assert service.get("str_val") == "hello"
+
+        # Integer
+        service.set("int_val", 42)
+        assert service.get("int_val") == 42
+
+        # Boolean
+        service.set("bool_val", True)
+        assert service.get("bool_val") is True
+
+        # List
+        service.set("list_val", [1, 2, 3])
+        assert service.get("list_val") == [1, 2, 3]
+
+        # Dict
+        service.set("dict_val", {"a": 1, "b": 2})
+        assert service.get("dict_val") == {"a": 1, "b": 2}


### PR DESCRIPTION
## Summary
- Add `AdminSetting` SQLAlchemy model for persisting admin configuration
- Create `SettingsService` with CRUD operations (get, set, get_all, delete, get_with_defaults)
- JSON encode/decode for flexible value storage (strings, numbers, bools, lists, dicts)
- Audit trail support via `updated_by` and `updated_at` fields

## Test plan
- [x] Unit tests for all service methods (8 tests)
- [x] Full test suite passes (201 passed, 7 skipped)
- [x] Linting passes (ruff check)

## References
- Closes #2
- Spec: `specs/ADMIN_DASHBOARD_SPEC.md` (lines 560-578)
- Blocks: #4 (Processing Options API), #6 (Model Configuration API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)