### PR TITLE
feat: Add Knowledge Base Statistics and Processing Options APIs (#3, #4)

### DIFF
--- a/ai_ready_rag/api/admin.py
+++ b/ai_ready_rag/api/admin.py
@@ -1,8 +1,10 @@
 """Admin endpoints for system management."""
 
 import logging
+from datetime import UTC, datetime
+from typing import Literal
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -11,6 +13,8 @@ from ai_ready_rag.core.dependencies import require_admin
 from ai_ready_rag.db.database import get_db
 from ai_ready_rag.db.models import User
 from ai_ready_rag.services.document_service import DocumentService
+from ai_ready_rag.services.settings_service import SettingsService
+from ai_ready_rag.services.vector_service import VectorService
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -19,6 +23,42 @@ router = APIRouter()
 class RecoverResponse(BaseModel):
     recovered: int
     message: str
+
+
+class FileStats(BaseModel):
+    """Per-file statistics."""
+
+    document_id: str
+    filename: str
+    chunk_count: int
+    status: str | None = None
+
+
+class KnowledgeBaseStatsResponse(BaseModel):
+    """Knowledge base statistics response."""
+
+    total_chunks: int
+    unique_files: int
+    total_vectors: int
+    collection_name: str
+    files: list[FileStats]
+    storage_size_bytes: int | None = None
+    last_updated: datetime
+
+
+class ClearKnowledgeBaseRequest(BaseModel):
+    """Request to clear knowledge base."""
+
+    confirm: bool
+    delete_source_files: bool = False
+
+
+class ClearKnowledgeBaseResponse(BaseModel):
+    """Response after clearing knowledge base."""
+
+    deleted_chunks: int
+    deleted_files: int
+    success: bool
 
 
 @router.post("/documents/recover-stuck", response_model=RecoverResponse)
@@ -48,4 +88,251 @@ async def recover_stuck_documents(
     return RecoverResponse(
         recovered=recovered,
         message=f"Reset {recovered} stuck documents to pending status",
+    )
+
+
+@router.get("/knowledge-base/stats", response_model=KnowledgeBaseStatsResponse)
+async def get_knowledge_base_stats(
+    current_user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Get knowledge base statistics including per-file details.
+
+    Returns total chunks, unique files, collection info, and
+    per-file statistics with chunk counts.
+
+    Admin only.
+    """
+    settings = get_settings()
+    vector_service = VectorService(
+        qdrant_url=settings.qdrant_url,
+        ollama_url=settings.ollama_base_url,
+        collection_name=settings.qdrant_collection,
+        embedding_model=settings.embedding_model,
+    )
+
+    try:
+        stats = await vector_service.get_extended_stats()
+    except Exception as e:
+        logger.error(f"Failed to get knowledge base stats: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to retrieve knowledge base statistics: {e}",
+        ) from e
+
+    # Convert files to FileStats models
+    files = [
+        FileStats(
+            document_id=f["document_id"],
+            filename=f["filename"],
+            chunk_count=f["chunk_count"],
+            status=None,  # Could join with Document table for status if needed
+        )
+        for f in stats.get("files", [])
+    ]
+
+    return KnowledgeBaseStatsResponse(
+        total_chunks=stats.get("total_chunks", 0),
+        unique_files=stats.get("unique_files", 0),
+        total_vectors=stats.get("total_chunks", 0),  # Same as total_chunks for now
+        collection_name=stats.get("collection_name", ""),
+        files=files,
+        storage_size_bytes=stats.get("collection_size_bytes"),
+        last_updated=datetime.now(UTC),
+    )
+
+
+@router.delete("/knowledge-base", response_model=ClearKnowledgeBaseResponse)
+async def clear_knowledge_base(
+    request: ClearKnowledgeBaseRequest,
+    current_user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Clear all vectors from the knowledge base.
+
+    Requires `confirm: true` in request body to proceed.
+    Optionally delete source files from SQLite as well.
+
+    Admin only. This is a destructive operation.
+    """
+    if not request.confirm:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Confirmation required. Set 'confirm: true' to proceed.",
+        )
+
+    settings = get_settings()
+    vector_service = VectorService(
+        qdrant_url=settings.qdrant_url,
+        ollama_url=settings.ollama_base_url,
+        collection_name=settings.qdrant_collection,
+        embedding_model=settings.embedding_model,
+    )
+
+    # Get stats before clearing to report deleted counts
+    try:
+        stats_before = await vector_service.get_extended_stats()
+        chunks_before = stats_before.get("total_chunks", 0)
+        files_before = stats_before.get("unique_files", 0)
+    except Exception:
+        chunks_before = 0
+        files_before = 0
+
+    # Clear vectors
+    logger.warning(
+        f"DESTRUCTIVE OPERATION: Admin {current_user.email} clearing knowledge base "
+        f"(delete_source_files={request.delete_source_files})"
+    )
+
+    try:
+        success = await vector_service.clear_collection()
+    except Exception as e:
+        logger.error(f"Failed to clear knowledge base: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to clear knowledge base: {e}",
+        ) from e
+
+    # Optionally delete source files from SQLite
+    deleted_files = 0
+    if request.delete_source_files and success:
+        document_service = DocumentService(db, settings)
+        deleted_files = document_service.delete_all_documents()
+        logger.warning(f"Deleted {deleted_files} documents from database")
+
+    return ClearKnowledgeBaseResponse(
+        deleted_chunks=chunks_before if success else 0,
+        deleted_files=deleted_files if request.delete_source_files else files_before,
+        success=success,
+    )
+
+
+# Processing Options Models and Endpoints
+class ProcessingOptionsRequest(BaseModel):
+    """Request model for processing options update."""
+
+    enable_ocr: bool | None = None
+    force_full_page_ocr: bool | None = None
+    ocr_language: str | None = None
+    table_extraction_mode: Literal["accurate", "fast"] | None = None
+    include_image_descriptions: bool | None = None
+
+
+class ProcessingOptionsResponse(BaseModel):
+    """Response model for processing options."""
+
+    enable_ocr: bool
+    force_full_page_ocr: bool
+    ocr_language: str
+    table_extraction_mode: str
+    include_image_descriptions: bool
+
+
+# Default values for processing options
+PROCESSING_DEFAULTS = {
+    "enable_ocr": True,
+    "force_full_page_ocr": False,
+    "ocr_language": "eng",
+    "table_extraction_mode": "accurate",
+    "include_image_descriptions": True,
+}
+
+
+def _get_setting_value(service: SettingsService, key: str, default: any) -> any:
+    """Get setting value with fallback to default if None."""
+    value = service.get(key)
+    return value if value is not None else default
+
+
+@router.get("/processing-options", response_model=ProcessingOptionsResponse)
+async def get_processing_options(
+    current_user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Get current processing options.
+
+    Returns stored settings merged with defaults for any missing values.
+    Admin only.
+    """
+    service = SettingsService(db)
+
+    return ProcessingOptionsResponse(
+        enable_ocr=_get_setting_value(service, "enable_ocr", PROCESSING_DEFAULTS["enable_ocr"]),
+        force_full_page_ocr=_get_setting_value(
+            service, "force_full_page_ocr", PROCESSING_DEFAULTS["force_full_page_ocr"]
+        ),
+        ocr_language=_get_setting_value(
+            service, "ocr_language", PROCESSING_DEFAULTS["ocr_language"]
+        ),
+        table_extraction_mode=_get_setting_value(
+            service,
+            "table_extraction_mode",
+            PROCESSING_DEFAULTS["table_extraction_mode"],
+        ),
+        include_image_descriptions=_get_setting_value(
+            service,
+            "include_image_descriptions",
+            PROCESSING_DEFAULTS["include_image_descriptions"],
+        ),
+    )
+
+
+@router.patch("/processing-options", response_model=ProcessingOptionsResponse)
+async def update_processing_options(
+    options: ProcessingOptionsRequest,
+    current_user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Update processing options.
+
+    Only updates fields that are provided (not None).
+    Settings persist to admin_settings table.
+    Admin only.
+    """
+    service = SettingsService(db)
+
+    # Update only provided fields
+    if options.enable_ocr is not None:
+        service.set("enable_ocr", options.enable_ocr, updated_by=current_user.id)
+    if options.force_full_page_ocr is not None:
+        service.set("force_full_page_ocr", options.force_full_page_ocr, updated_by=current_user.id)
+    if options.ocr_language is not None:
+        service.set("ocr_language", options.ocr_language, updated_by=current_user.id)
+    if options.table_extraction_mode is not None:
+        service.set(
+            "table_extraction_mode",
+            options.table_extraction_mode,
+            updated_by=current_user.id,
+        )
+    if options.include_image_descriptions is not None:
+        service.set(
+            "include_image_descriptions",
+            options.include_image_descriptions,
+            updated_by=current_user.id,
+        )
+
+    logger.info(
+        f"Admin {current_user.email} updated processing options: "
+        f"{options.model_dump(exclude_none=True)}"
+    )
+
+    # Return current state (same as GET)
+    return ProcessingOptionsResponse(
+        enable_ocr=_get_setting_value(service, "enable_ocr", PROCESSING_DEFAULTS["enable_ocr"]),
+        force_full_page_ocr=_get_setting_value(
+            service, "force_full_page_ocr", PROCESSING_DEFAULTS["force_full_page_ocr"]
+        ),
+        ocr_language=_get_setting_value(
+            service, "ocr_language", PROCESSING_DEFAULTS["ocr_language"]
+        ),
+        table_extraction_mode=_get_setting_value(
+            service,
+            "table_extraction_mode",
+            PROCESSING_DEFAULTS["table_extraction_mode"],
+        ),
+        include_image_descriptions=_get_setting_value(
+            service,
+            "include_image_descriptions",
+            PROCESSING_DEFAULTS["include_image_descriptions"],
+        ),
     )

--- a/ai_ready_rag/config.py
+++ b/ai_ready_rag/config.py
@@ -116,6 +116,9 @@ class Settings(BaseSettings):
     # Document Processing
     enable_ocr: bool | None = None  # None = use profile default
     ocr_language: str = "eng"
+    force_full_page_ocr: bool = False
+    table_extraction_mode: Literal["accurate", "fast"] = "accurate"
+    include_image_descriptions: bool = True
     chunk_size: int = 200  # Smaller chunks = more precise matching
     chunk_overlap: int = 40  # ~20% overlap for context continuity
 

--- a/ai_ready_rag/services/chunker_docling.py
+++ b/ai_ready_rag/services/chunker_docling.py
@@ -19,10 +19,16 @@ class DoclingChunker:
         enable_ocr: bool = True,
         ocr_language: str = "eng",
         max_tokens: int = 512,
+        force_full_page_ocr: bool = False,
+        table_extraction_mode: str = "accurate",
+        include_image_descriptions: bool = True,
     ):
         self.enable_ocr = enable_ocr
         self.ocr_language = ocr_language
         self.max_tokens = max_tokens
+        self.force_full_page_ocr = force_full_page_ocr
+        self.table_extraction_mode = table_extraction_mode
+        self.include_image_descriptions = include_image_descriptions
 
         self._converter = None
         self._chunker = None
@@ -51,13 +57,14 @@ class DoclingChunker:
 
             table_options = TableStructureOptions(
                 do_cell_matching=True,
-                mode="accurate",
+                mode=self.table_extraction_mode,
             )
 
             pipeline_options = PdfPipelineOptions(
                 do_ocr=self.enable_ocr,
                 do_table_structure=True,
                 table_structure_options=table_options,
+                generate_picture_images=self.include_image_descriptions,
             )
 
             if self.enable_ocr:
@@ -66,7 +73,7 @@ class DoclingChunker:
 
                     ocr_options = TesseractOcrOptions(
                         lang=[self.ocr_language],
-                        force_full_page_ocr=False,
+                        force_full_page_ocr=self.force_full_page_ocr,
                     )
                     pipeline_options.ocr_options = ocr_options
                 except ImportError:

--- a/ai_ready_rag/services/document_service.py
+++ b/ai_ready_rag/services/document_service.py
@@ -340,3 +340,28 @@ class DocumentService:
         )
         self.db.commit()
         return count
+
+    def delete_all_documents(self) -> int:
+        """Delete all documents and their files from storage.
+
+        Returns:
+            Count of deleted documents
+
+        Warning:
+            This is a destructive operation. Intended for knowledge base reset.
+        """
+        # Get all documents
+        documents = self.db.query(Document).all()
+        count = len(documents)
+
+        # Delete files from storage
+        for doc in documents:
+            doc_dir = self.storage_path / doc.id
+            if doc_dir.exists():
+                shutil.rmtree(doc_dir)
+
+        # Delete all documents from database
+        self.db.query(Document).delete()
+        self.db.commit()
+
+        return count

--- a/ai_ready_rag/services/factory.py
+++ b/ai_ready_rag/services/factory.py
@@ -82,6 +82,9 @@ def get_chunker(settings: Settings) -> "ChunkerProtocol":
             enable_ocr=settings.enable_ocr or False,
             ocr_language=settings.ocr_language,
             max_tokens=settings.chunk_size,
+            force_full_page_ocr=settings.force_full_page_ocr,
+            table_extraction_mode=settings.table_extraction_mode,
+            include_image_descriptions=settings.include_image_descriptions,
         )
     elif backend == "simple":
         from ai_ready_rag.services.chunker_simple import SimpleChunker

--- a/tests/test_admin_kb_stats.py
+++ b/tests/test_admin_kb_stats.py
@@ -1,0 +1,219 @@
+"""Tests for admin knowledge base statistics and clearing endpoints."""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi import status
+
+
+class TestKnowledgeBaseStats:
+    """Tests for GET /api/admin/knowledge-base/stats endpoint."""
+
+    @patch("ai_ready_rag.api.admin.VectorService")
+    def test_stats_returns_data(self, mock_vector_class, client, admin_headers):
+        """Test that endpoint returns knowledge base statistics."""
+        # Mock VectorService
+        mock_instance = AsyncMock()
+        mock_instance.get_extended_stats = AsyncMock(
+            return_value={
+                "total_chunks": 150,
+                "unique_files": 3,
+                "collection_name": "documents",
+                "collection_size_bytes": 1024000,
+                "files": [
+                    {
+                        "document_id": "doc-1",
+                        "filename": "report.pdf",
+                        "chunk_count": 50,
+                    },
+                    {
+                        "document_id": "doc-2",
+                        "filename": "guide.docx",
+                        "chunk_count": 75,
+                    },
+                    {
+                        "document_id": "doc-3",
+                        "filename": "notes.txt",
+                        "chunk_count": 25,
+                    },
+                ],
+            }
+        )
+        mock_vector_class.return_value = mock_instance
+
+        response = client.get("/api/admin/knowledge-base/stats", headers=admin_headers)
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["total_chunks"] == 150
+        assert data["unique_files"] == 3
+        assert data["total_vectors"] == 150
+        assert data["collection_name"] == "documents"
+        assert data["storage_size_bytes"] == 1024000
+        assert len(data["files"]) == 3
+        assert data["files"][0]["document_id"] == "doc-1"
+        assert data["files"][0]["filename"] == "report.pdf"
+        assert data["files"][0]["chunk_count"] == 50
+        assert "last_updated" in data
+
+    def test_stats_requires_admin(self, client, user_headers):
+        """Test that non-admin users cannot access stats endpoint."""
+        response = client.get("/api/admin/knowledge-base/stats", headers=user_headers)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_stats_unauthorized(self, client):
+        """Test that unauthenticated users cannot access stats endpoint."""
+        response = client.get("/api/admin/knowledge-base/stats")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @patch("ai_ready_rag.api.admin.VectorService")
+    def test_stats_empty_collection(self, mock_vector_class, client, admin_headers):
+        """Test stats endpoint with empty collection."""
+        mock_instance = AsyncMock()
+        mock_instance.get_extended_stats = AsyncMock(
+            return_value={
+                "total_chunks": 0,
+                "unique_files": 0,
+                "collection_name": "documents",
+                "collection_size_bytes": 0,
+                "files": [],
+            }
+        )
+        mock_vector_class.return_value = mock_instance
+
+        response = client.get("/api/admin/knowledge-base/stats", headers=admin_headers)
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["total_chunks"] == 0
+        assert data["unique_files"] == 0
+        assert data["files"] == []
+
+
+class TestClearKnowledgeBase:
+    """Tests for DELETE /api/admin/knowledge-base endpoint."""
+
+    @patch("ai_ready_rag.api.admin.VectorService")
+    def test_clear_success(self, mock_vector_class, client, admin_headers):
+        """Test successful knowledge base clearing with confirmation."""
+        mock_instance = AsyncMock()
+        mock_instance.get_extended_stats = AsyncMock(
+            return_value={
+                "total_chunks": 100,
+                "unique_files": 5,
+                "collection_name": "documents",
+                "collection_size_bytes": 512000,
+                "files": [],
+            }
+        )
+        mock_instance.clear_collection = AsyncMock(return_value=True)
+        mock_vector_class.return_value = mock_instance
+
+        response = client.request(
+            "DELETE",
+            "/api/admin/knowledge-base",
+            json={"confirm": True},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["deleted_chunks"] == 100
+        assert data["deleted_files"] == 5
+        assert data["success"] is True
+
+    def test_clear_requires_confirmation(self, client, admin_headers):
+        """Test that clearing requires confirmation flag."""
+        response = client.request(
+            "DELETE",
+            "/api/admin/knowledge-base",
+            json={"confirm": False},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "confirmation required" in response.json()["detail"].lower()
+
+    def test_clear_requires_admin(self, client, user_headers):
+        """Test that non-admin users cannot clear knowledge base."""
+        response = client.request(
+            "DELETE",
+            "/api/admin/knowledge-base",
+            json={"confirm": True},
+            headers=user_headers,
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_clear_unauthorized(self, client):
+        """Test that unauthenticated users cannot clear knowledge base."""
+        response = client.request(
+            "DELETE",
+            "/api/admin/knowledge-base",
+            json={"confirm": True},
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @patch("ai_ready_rag.api.admin.DocumentService")
+    @patch("ai_ready_rag.api.admin.VectorService")
+    def test_clear_with_source_files(
+        self, mock_vector_class, mock_doc_class, client, admin_headers
+    ):
+        """Test clearing with delete_source_files option."""
+        # Mock VectorService
+        mock_vector_instance = AsyncMock()
+        mock_vector_instance.get_extended_stats = AsyncMock(
+            return_value={
+                "total_chunks": 50,
+                "unique_files": 2,
+                "collection_name": "documents",
+                "collection_size_bytes": 256000,
+                "files": [],
+            }
+        )
+        mock_vector_instance.clear_collection = AsyncMock(return_value=True)
+        mock_vector_class.return_value = mock_vector_instance
+
+        # Mock DocumentService
+        mock_doc_instance = mock_doc_class.return_value
+        mock_doc_instance.delete_all_documents.return_value = 2
+
+        response = client.request(
+            "DELETE",
+            "/api/admin/knowledge-base",
+            json={"confirm": True, "delete_source_files": True},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["success"] is True
+        assert data["deleted_files"] == 2
+
+    @patch("ai_ready_rag.api.admin.VectorService")
+    def test_clear_failure(self, mock_vector_class, client, admin_headers):
+        """Test handling of clear operation failure."""
+        mock_instance = AsyncMock()
+        mock_instance.get_extended_stats = AsyncMock(
+            return_value={
+                "total_chunks": 100,
+                "unique_files": 5,
+                "collection_name": "documents",
+                "collection_size_bytes": 512000,
+                "files": [],
+            }
+        )
+        mock_instance.clear_collection = AsyncMock(return_value=False)
+        mock_vector_class.return_value = mock_instance
+
+        response = client.request(
+            "DELETE",
+            "/api/admin/knowledge-base",
+            json={"confirm": True},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["success"] is False
+        assert data["deleted_chunks"] == 0

--- a/tests/test_admin_processing.py
+++ b/tests/test_admin_processing.py
@@ -1,0 +1,101 @@
+"""Tests for admin processing options endpoints."""
+
+
+class TestGetProcessingOptions:
+    """Tests for GET /api/admin/processing-options."""
+
+    def test_get_returns_defaults(self, client, admin_headers):
+        """GET returns default values when nothing stored."""
+        response = client.get("/api/admin/processing-options", headers=admin_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enable_ocr"] is True
+        assert data["force_full_page_ocr"] is False
+        assert data["ocr_language"] == "eng"
+        assert data["table_extraction_mode"] == "accurate"
+        assert data["include_image_descriptions"] is True
+
+    def test_get_requires_admin(self, client, user_headers):
+        """GET requires admin role."""
+        response = client.get("/api/admin/processing-options", headers=user_headers)
+        assert response.status_code == 403
+
+    def test_get_requires_auth(self, client):
+        """GET requires authentication."""
+        response = client.get("/api/admin/processing-options")
+        assert response.status_code == 401
+
+
+class TestUpdateProcessingOptions:
+    """Tests for PATCH /api/admin/processing-options."""
+
+    def test_update_single_field(self, client, admin_headers):
+        """PATCH updates single field."""
+        response = client.patch(
+            "/api/admin/processing-options",
+            headers=admin_headers,
+            json={"force_full_page_ocr": True},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["force_full_page_ocr"] is True
+        # Other fields unchanged
+        assert data["enable_ocr"] is True
+        assert data["table_extraction_mode"] == "accurate"
+
+    def test_update_multiple_fields(self, client, admin_headers):
+        """PATCH updates multiple fields."""
+        response = client.patch(
+            "/api/admin/processing-options",
+            headers=admin_headers,
+            json={
+                "table_extraction_mode": "fast",
+                "ocr_language": "fra",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["table_extraction_mode"] == "fast"
+        assert data["ocr_language"] == "fra"
+
+    def test_update_persists(self, client, admin_headers):
+        """PATCH values persist across requests."""
+        # Update
+        client.patch(
+            "/api/admin/processing-options",
+            headers=admin_headers,
+            json={"include_image_descriptions": False},
+        )
+
+        # Verify with GET
+        response = client.get("/api/admin/processing-options", headers=admin_headers)
+        assert response.json()["include_image_descriptions"] is False
+
+    def test_update_requires_admin(self, client, user_headers):
+        """PATCH requires admin role."""
+        response = client.patch(
+            "/api/admin/processing-options",
+            headers=user_headers,
+            json={"enable_ocr": False},
+        )
+        assert response.status_code == 403
+
+    def test_update_requires_auth(self, client):
+        """PATCH requires authentication."""
+        response = client.patch(
+            "/api/admin/processing-options",
+            json={"enable_ocr": False},
+        )
+        assert response.status_code == 401
+
+    def test_update_validates_table_mode(self, client, admin_headers):
+        """PATCH validates table_extraction_mode enum."""
+        response = client.patch(
+            "/api/admin/processing-options",
+            headers=admin_headers,
+            json={"table_extraction_mode": "invalid"},
+        )
+        assert response.status_code == 422  # Validation error


### PR DESCRIPTION
## Summary

### Issue #3 - Knowledge Base Statistics API
- Add `VectorService.get_extended_stats()` with per-file details (document_id, filename, chunk_count)
- Add `GET /api/admin/knowledge-base/stats` - returns stats + file list
- Add `DELETE /api/admin/knowledge-base` - clear vectors with confirmation requirement
- Add `DocumentService.delete_all_documents()` for optional source file cleanup

### Issue #4 - Processing Options API  
- Add 3 new config settings: `force_full_page_ocr`, `table_extraction_mode`, `include_image_descriptions`
- Update `DoclingChunker` to use configurable values instead of hardcoded defaults
- Add `GET /api/admin/processing-options` - returns current settings
- Add `PATCH /api/admin/processing-options` - update settings at runtime
- Persist settings via `SettingsService` (admin_settings table)

## Test plan
- [x] 10 tests for KB stats endpoints (admin auth, confirmation, empty collection, etc.)
- [x] 9 tests for processing options endpoints (defaults, persistence, validation, etc.)
- [x] Full test suite: 220 passed, 7 skipped
- [x] Linting: ruff check passes

## References
- Closes #3
- Closes #4
- Spec: `specs/ADMIN_DASHBOARD_SPEC.md` (lines 107-299)

🤖 Generated with [Claude Code](https://claude.com/claude-code)