### PR TITLE
feat: Add Model Configuration and Architecture Info APIs (#6, #7)

### DIFF
--- a/ai_ready_rag/api/chat.py
+++ b/ai_ready_rag/api/chat.py
@@ -26,7 +26,11 @@ from ai_ready_rag.services.rag_service import (
     RAGRequest,
     RAGService,
 )
+from ai_ready_rag.services.settings_service import SettingsService
 from ai_ready_rag.services.vector_service import VectorService
+
+# Settings key for runtime chat model override
+CHAT_MODEL_KEY = "chat_model"
 
 router = APIRouter()
 
@@ -560,7 +564,11 @@ async def send_message(
         )
         await vector_service.initialize()
 
-        rag_service = RAGService(settings, vector_service)
+        # Check for runtime model override from admin settings
+        settings_service = SettingsService(db)
+        chat_model = settings_service.get(CHAT_MODEL_KEY) or settings.chat_model
+
+        rag_service = RAGService(settings, vector_service, default_model=chat_model)
         response = await rag_service.generate(rag_request, db)
 
     except ModelNotAllowedError as e:

--- a/ai_ready_rag/services/model_service.py
+++ b/ai_ready_rag/services/model_service.py
@@ -1,0 +1,152 @@
+"""Service for Ollama model discovery and validation."""
+
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Display name mapping: model_name -> (display_name, parameters, recommended)
+MODEL_DISPLAY_NAMES: dict[str, tuple[str, str, bool]] = {
+    "qwen3:8b": ("Qwen3 8B (Recommended)", "8B", True),
+    "qwen3:latest": ("Qwen3 Latest", "8B", True),
+    "llama3.2:latest": ("Llama 3.2", "3B", False),
+    "llama3.2:3b": ("Llama 3.2 3B", "3B", False),
+    "llama3.1:8b": ("Llama 3.1 8B", "8B", False),
+    "deepseek-r1:32b": ("DeepSeek R1 32B", "32B", False),
+    "deepseek-r1:14b": ("DeepSeek R1 14B", "14B", False),
+    "deepseek-r1:8b": ("DeepSeek R1 8B", "8B", False),
+    "mistral:7b": ("Mistral 7B", "7B", False),
+    "mistral:latest": ("Mistral", "7B", False),
+    "gemma2:9b": ("Gemma2 9B", "9B", False),
+    "gemma2:2b": ("Gemma2 2B", "2B", False),
+}
+
+
+class ModelServiceError(Exception):
+    """Base exception for model service errors."""
+
+    pass
+
+
+class OllamaUnavailableError(ModelServiceError):
+    """Raised when Ollama is not reachable."""
+
+    pass
+
+
+class ModelService:
+    """Service for discovering and validating Ollama models."""
+
+    def __init__(self, ollama_url: str):
+        """Initialize model service.
+
+        Args:
+            ollama_url: Base URL for Ollama API (e.g., http://localhost:11434)
+        """
+        self.ollama_url = ollama_url.rstrip("/")
+
+    async def list_models(self) -> list[dict]:
+        """Query Ollama for available models.
+
+        Returns:
+            List of model info dicts with keys:
+            - name: Model name (e.g., "qwen3:8b")
+            - display_name: Human-friendly name
+            - size_gb: Size in gigabytes
+            - parameters: Parameter count (e.g., "8B")
+            - quantization: Quantization type if known
+            - recommended: Whether this model is recommended
+
+        Raises:
+            OllamaUnavailableError: If Ollama is not reachable
+        """
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(f"{self.ollama_url}/api/tags")
+                response.raise_for_status()
+        except httpx.ConnectError as e:
+            logger.error(f"Cannot connect to Ollama at {self.ollama_url}: {e}")
+            raise OllamaUnavailableError(f"Cannot connect to Ollama at {self.ollama_url}") from e
+        except httpx.TimeoutException as e:
+            logger.error(f"Timeout connecting to Ollama: {e}")
+            raise OllamaUnavailableError("Ollama connection timed out") from e
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Ollama returned error: {e}")
+            raise OllamaUnavailableError(f"Ollama error: {e.response.status_code}") from e
+
+        models_data = response.json().get("models", [])
+        result = []
+
+        for model in models_data:
+            name = model.get("name", "")
+            size_bytes = model.get("size", 0)
+            size_gb = round(size_bytes / (1024**3), 2)
+
+            # Look up display info or generate from name
+            if name in MODEL_DISPLAY_NAMES:
+                display_name, parameters, recommended = MODEL_DISPLAY_NAMES[name]
+            else:
+                # Generate display name from model name
+                display_name = name.replace(":", " ").replace("-", " ").title()
+                parameters = self._extract_parameters(name)
+                recommended = False
+
+            # Try to extract quantization from model details
+            quantization = model.get("details", {}).get("quantization_level")
+
+            result.append(
+                {
+                    "name": name,
+                    "display_name": display_name,
+                    "size_gb": size_gb,
+                    "parameters": parameters,
+                    "quantization": quantization,
+                    "recommended": recommended,
+                }
+            )
+
+        return result
+
+    async def validate_model(self, model_name: str) -> bool:
+        """Check if a model exists in Ollama.
+
+        Args:
+            model_name: Name of the model to validate
+
+        Returns:
+            True if model exists, False otherwise
+
+        Raises:
+            OllamaUnavailableError: If Ollama is not reachable
+        """
+        models = await self.list_models()
+        available_names = {m["name"] for m in models}
+
+        # Check exact match
+        if model_name in available_names:
+            return True
+
+        # Check base name match (e.g., "qwen3" matches "qwen3:8b")
+        for available in available_names:
+            if available.startswith(model_name + ":") or available == model_name:
+                return True
+
+        return False
+
+    def _extract_parameters(self, model_name: str) -> str | None:
+        """Extract parameter count from model name.
+
+        Args:
+            model_name: Model name like "llama3.2:3b" or "mistral:7b"
+
+        Returns:
+            Parameter string like "3B" or "7B", or None if not found
+        """
+        # Common patterns: :3b, :7b, :8b, :14b, :32b
+        import re
+
+        match = re.search(r":(\d+)b", model_name.lower())
+        if match:
+            return f"{match.group(1)}B"
+        return None

--- a/tests/test_admin_architecture.py
+++ b/tests/test_admin_architecture.py
@@ -1,0 +1,203 @@
+"""Tests for admin architecture endpoint."""
+
+from unittest.mock import AsyncMock, patch
+
+
+class TestArchitectureInfo:
+    """Tests for GET /api/admin/architecture endpoint."""
+
+    def test_architecture_requires_admin(self, client, user_headers):
+        """Non-admin users cannot access architecture endpoint."""
+        response = client.get("/api/admin/architecture", headers=user_headers)
+        assert response.status_code == 403
+
+    def test_architecture_unauthorized(self, client):
+        """Unauthenticated requests are rejected."""
+        response = client.get("/api/admin/architecture")
+        assert response.status_code == 401
+
+    def test_architecture_returns_structure(self, client, admin_headers):
+        """Admin can get architecture info with correct structure."""
+        # Mock health check to avoid actual service calls
+        with patch("ai_ready_rag.api.admin.VectorService") as mock_vs_class:
+            mock_vs = mock_vs_class.return_value
+            mock_health = AsyncMock()
+            mock_health.ollama_healthy = True
+            mock_health.qdrant_healthy = True
+            mock_vs.health_check = AsyncMock(return_value=mock_health)
+
+            # Clear cache to force fresh response
+            import ai_ready_rag.api.admin as admin_module
+
+            admin_module._architecture_cache = {}
+
+            response = client.get("/api/admin/architecture", headers=admin_headers)
+
+        assert response.status_code == 200
+
+        data = response.json()
+        assert "document_parsing" in data
+        assert "embeddings" in data
+        assert "chat_model" in data
+        assert "infrastructure" in data
+        assert "ocr_status" in data
+        assert "profile" in data
+
+    def test_architecture_document_parsing(self, client, admin_headers):
+        """Document parsing section has required fields."""
+        with patch("ai_ready_rag.api.admin.VectorService") as mock_vs_class:
+            mock_vs = mock_vs_class.return_value
+            mock_health = AsyncMock()
+            mock_health.ollama_healthy = True
+            mock_health.qdrant_healthy = True
+            mock_vs.health_check = AsyncMock(return_value=mock_health)
+
+            import ai_ready_rag.api.admin as admin_module
+
+            admin_module._architecture_cache = {}
+
+            response = client.get("/api/admin/architecture", headers=admin_headers)
+
+        data = response.json()
+
+        doc = data["document_parsing"]
+        assert doc["engine"] == "Docling"
+        assert "version" in doc
+        assert "type" in doc
+        assert "capabilities" in doc
+        assert isinstance(doc["capabilities"], list)
+
+    def test_architecture_embeddings(self, client, admin_headers):
+        """Embeddings section has required fields."""
+        with patch("ai_ready_rag.api.admin.VectorService") as mock_vs_class:
+            mock_vs = mock_vs_class.return_value
+            mock_health = AsyncMock()
+            mock_health.ollama_healthy = True
+            mock_health.qdrant_healthy = True
+            mock_vs.health_check = AsyncMock(return_value=mock_health)
+
+            import ai_ready_rag.api.admin as admin_module
+
+            admin_module._architecture_cache = {}
+
+            response = client.get("/api/admin/architecture", headers=admin_headers)
+
+        data = response.json()
+
+        emb = data["embeddings"]
+        assert "model" in emb
+        assert "dimensions" in emb
+        assert "vector_store" in emb
+        assert "vector_store_url" in emb
+
+    def test_architecture_chat_model(self, client, admin_headers):
+        """Chat model section has required fields."""
+        with patch("ai_ready_rag.api.admin.VectorService") as mock_vs_class:
+            mock_vs = mock_vs_class.return_value
+            mock_health = AsyncMock()
+            mock_health.ollama_healthy = True
+            mock_health.qdrant_healthy = True
+            mock_vs.health_check = AsyncMock(return_value=mock_health)
+
+            import ai_ready_rag.api.admin as admin_module
+
+            admin_module._architecture_cache = {}
+
+            response = client.get("/api/admin/architecture", headers=admin_headers)
+
+        data = response.json()
+
+        chat = data["chat_model"]
+        assert "name" in chat
+        assert chat["provider"] == "Ollama"
+        assert "capabilities" in chat
+        assert isinstance(chat["capabilities"], list)
+
+    def test_architecture_infrastructure(self, client, admin_headers):
+        """Infrastructure section has required fields."""
+        with patch("ai_ready_rag.api.admin.VectorService") as mock_vs_class:
+            mock_vs = mock_vs_class.return_value
+            mock_health = AsyncMock()
+            mock_health.ollama_healthy = True
+            mock_health.qdrant_healthy = True
+            mock_vs.health_check = AsyncMock(return_value=mock_health)
+
+            import ai_ready_rag.api.admin as admin_module
+
+            admin_module._architecture_cache = {}
+
+            response = client.get("/api/admin/architecture", headers=admin_headers)
+
+        data = response.json()
+
+        infra = data["infrastructure"]
+        assert "ollama_url" in infra
+        assert "ollama_status" in infra
+        assert "vector_db_status" in infra
+        assert infra["ollama_status"] in ["healthy", "unhealthy"]
+        assert infra["vector_db_status"] in ["healthy", "unhealthy"]
+
+    def test_architecture_ocr_status(self, client, admin_headers):
+        """OCR status has tesseract and easyocr sections."""
+        with patch("ai_ready_rag.api.admin.VectorService") as mock_vs_class:
+            mock_vs = mock_vs_class.return_value
+            mock_health = AsyncMock()
+            mock_health.ollama_healthy = True
+            mock_health.qdrant_healthy = True
+            mock_vs.health_check = AsyncMock(return_value=mock_health)
+
+            import ai_ready_rag.api.admin as admin_module
+
+            admin_module._architecture_cache = {}
+
+            response = client.get("/api/admin/architecture", headers=admin_headers)
+
+        data = response.json()
+
+        ocr = data["ocr_status"]
+        assert "tesseract" in ocr
+        assert "easyocr" in ocr
+        assert "available" in ocr["tesseract"]
+        assert "available" in ocr["easyocr"]
+
+    def test_architecture_cache_works(self, client, admin_headers):
+        """Response is cached for subsequent requests."""
+        with patch("ai_ready_rag.api.admin.VectorService") as mock_vs_class:
+            mock_vs = mock_vs_class.return_value
+            mock_health = AsyncMock()
+            mock_health.ollama_healthy = True
+            mock_health.qdrant_healthy = True
+            mock_vs.health_check = AsyncMock(return_value=mock_health)
+
+            import ai_ready_rag.api.admin as admin_module
+
+            admin_module._architecture_cache = {}
+
+            # First request
+            response1 = client.get("/api/admin/architecture", headers=admin_headers)
+            assert response1.status_code == 200
+
+            # Second request should use cache (VectorService not called again)
+            mock_vs_class.reset_mock()
+            response2 = client.get("/api/admin/architecture", headers=admin_headers)
+            assert response2.status_code == 200
+
+            # VectorService should not be instantiated for cached response
+            # (it was called once for first request, then cache is used)
+
+    def test_architecture_handles_health_check_failure(self, client, admin_headers):
+        """Endpoint handles health check failure gracefully."""
+        with patch("ai_ready_rag.api.admin.VectorService") as mock_vs_class:
+            mock_vs = mock_vs_class.return_value
+            mock_vs.health_check = AsyncMock(side_effect=Exception("Connection failed"))
+
+            import ai_ready_rag.api.admin as admin_module
+
+            admin_module._architecture_cache = {}
+
+            response = client.get("/api/admin/architecture", headers=admin_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["infrastructure"]["ollama_status"] == "unhealthy"
+        assert data["infrastructure"]["vector_db_status"] == "unhealthy"

--- a/tests/test_admin_models.py
+++ b/tests/test_admin_models.py
@@ -1,0 +1,216 @@
+"""Tests for admin model configuration endpoints."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class TestGetModels:
+    """Tests for GET /api/admin/models."""
+
+    @pytest.fixture
+    def mock_ollama_models(self):
+        """Mock ModelService.list_models response."""
+        return [
+            {
+                "name": "qwen3:8b",
+                "display_name": "Qwen3 8B (Recommended)",
+                "size_gb": 4.92,
+                "parameters": "8B",
+                "quantization": "Q4_K_M",
+                "recommended": True,
+            },
+            {
+                "name": "llama3.2:latest",
+                "display_name": "Llama 3.2",
+                "size_gb": 2.0,
+                "parameters": "3B",
+                "quantization": None,
+                "recommended": False,
+            },
+        ]
+
+    def test_get_returns_models_list(self, client, admin_headers, mock_ollama_models):
+        """GET returns list of available models from Ollama."""
+        with patch(
+            "ai_ready_rag.api.admin.ModelService.list_models",
+            new_callable=AsyncMock,
+            return_value=mock_ollama_models,
+        ):
+            response = client.get("/api/admin/models", headers=admin_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "available_models" in data
+        assert len(data["available_models"]) == 2
+        assert data["available_models"][0]["name"] == "qwen3:8b"
+        assert data["available_models"][0]["recommended"] is True
+
+    def test_get_includes_current_model(self, client, admin_headers, mock_ollama_models):
+        """GET includes current chat and embedding model."""
+        with patch(
+            "ai_ready_rag.api.admin.ModelService.list_models",
+            new_callable=AsyncMock,
+            return_value=mock_ollama_models,
+        ):
+            response = client.get("/api/admin/models", headers=admin_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "current_chat_model" in data
+        assert "current_embedding_model" in data
+        # Should have default values from config
+        assert data["current_chat_model"] is not None
+        assert data["current_embedding_model"] is not None
+
+    def test_get_requires_admin(self, client, user_headers):
+        """GET requires admin role."""
+        response = client.get("/api/admin/models", headers=user_headers)
+        assert response.status_code == 403
+
+    def test_get_requires_auth(self, client):
+        """GET requires authentication."""
+        response = client.get("/api/admin/models")
+        assert response.status_code == 401
+
+    def test_get_handles_ollama_unavailable(self, client, admin_headers):
+        """GET returns 503 when Ollama is unavailable."""
+        from ai_ready_rag.services.model_service import OllamaUnavailableError
+
+        with patch(
+            "ai_ready_rag.api.admin.ModelService.list_models",
+            new_callable=AsyncMock,
+            side_effect=OllamaUnavailableError("Cannot connect to Ollama"),
+        ):
+            response = client.get("/api/admin/models", headers=admin_headers)
+
+        assert response.status_code == 503
+        assert "Ollama" in response.json()["detail"]
+
+
+class TestChangeModel:
+    """Tests for PATCH /api/admin/models/chat."""
+
+    def test_change_valid_model(self, client, admin_headers):
+        """PATCH successfully changes to a valid model."""
+        with patch(
+            "ai_ready_rag.api.admin.ModelService.validate_model",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            response = client.patch(
+                "/api/admin/models/chat",
+                headers=admin_headers,
+                json={"model_name": "llama3.2:latest"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["current_model"] == "llama3.2:latest"
+        assert data["success"] is True
+        assert "message" in data
+
+    def test_change_persists(self, client, admin_headers):
+        """PATCH model change persists across requests."""
+        # First change the model
+        with patch(
+            "ai_ready_rag.api.admin.ModelService.validate_model",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            client.patch(
+                "/api/admin/models/chat",
+                headers=admin_headers,
+                json={"model_name": "mistral:7b"},
+            )
+
+        # Verify with GET
+        mock_models = [
+            {
+                "name": "mistral:7b",
+                "display_name": "Mistral 7B",
+                "size_gb": 4.1,
+                "parameters": "7B",
+                "quantization": None,
+                "recommended": False,
+            }
+        ]
+        with patch(
+            "ai_ready_rag.api.admin.ModelService.list_models",
+            new_callable=AsyncMock,
+            return_value=mock_models,
+        ):
+            response = client.get("/api/admin/models", headers=admin_headers)
+
+        assert response.json()["current_chat_model"] == "mistral:7b"
+
+    def test_change_invalid_model(self, client, admin_headers):
+        """PATCH returns 400 for model not in Ollama."""
+        with patch(
+            "ai_ready_rag.api.admin.ModelService.validate_model",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            response = client.patch(
+                "/api/admin/models/chat",
+                headers=admin_headers,
+                json={"model_name": "nonexistent:model"},
+            )
+
+        assert response.status_code == 400
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_change_requires_admin(self, client, user_headers):
+        """PATCH requires admin role."""
+        response = client.patch(
+            "/api/admin/models/chat",
+            headers=user_headers,
+            json={"model_name": "qwen3:8b"},
+        )
+        assert response.status_code == 403
+
+    def test_change_requires_auth(self, client):
+        """PATCH requires authentication."""
+        response = client.patch(
+            "/api/admin/models/chat",
+            json={"model_name": "qwen3:8b"},
+        )
+        assert response.status_code == 401
+
+    def test_change_handles_ollama_unavailable(self, client, admin_headers):
+        """PATCH returns 503 when Ollama is unavailable."""
+        from ai_ready_rag.services.model_service import OllamaUnavailableError
+
+        with patch(
+            "ai_ready_rag.api.admin.ModelService.validate_model",
+            new_callable=AsyncMock,
+            side_effect=OllamaUnavailableError("Cannot connect to Ollama"),
+        ):
+            response = client.patch(
+                "/api/admin/models/chat",
+                headers=admin_headers,
+                json={"model_name": "qwen3:8b"},
+            )
+
+        assert response.status_code == 503
+        assert "Ollama" in response.json()["detail"]
+
+    def test_change_logs_audit(self, client, admin_headers, caplog):
+        """PATCH logs model change for audit trail."""
+        import logging
+
+        with patch(
+            "ai_ready_rag.api.admin.ModelService.validate_model",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            with caplog.at_level(logging.INFO, logger="ai_ready_rag.api.admin"):
+                client.patch(
+                    "/api/admin/models/chat",
+                    headers=admin_headers,
+                    json={"model_name": "gemma2:9b"},
+                )
+
+        # Check that the change was logged
+        assert any("changed chat model" in record.message for record in caplog.records)
+        assert any("gemma2:9b" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary

- **Issue #6**: Model Configuration API - allows admins to list available Ollama models and change the active chat model at runtime
- **Issue #7**: Architecture Info API - provides comprehensive system architecture information

## Changes

### Issue #6 - Model Configuration API

- New `ModelService` for Ollama model discovery and validation
- `GET /api/admin/models` - returns available models with current selection
- `PATCH /api/admin/models/chat` - validates and changes active model
- Model changes persist to database via SettingsService
- Integrated with chat.py for dynamic model selection

### Issue #7 - Architecture Info API

- `GET /api/admin/architecture` endpoint with:
  - Document parsing info (Docling engine, version, capabilities)
  - Embeddings configuration (model, dimensions, vector store)
  - Chat model info (name, provider, capabilities)
  - Infrastructure status (Ollama, Qdrant health)
  - OCR availability (Tesseract and EasyOCR detection)
  - Profile information
- 60-second cache TTL to avoid repeated health checks

## Test Plan

- [x] 12 new tests for Model Configuration API
- [x] 10 new tests for Architecture Info API
- [x] Full test suite passes: 247 passed, 7 skipped
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)