### PR TITLE
fix: Show filename only in KB Statistics indexed files list

### DIFF
--- a/ai_ready_rag/ui/gradio_app.py
+++ b/ai_ready_rag/ui/gradio_app.py
@@ -1192,9 +1192,11 @@ def create_app() -> gr.Blocks:
 """
 
                 if files:
-                    # Show first 10 files, indicate if more
+                    # Show first 10 files (filename only), indicate if more
+                    from pathlib import Path
+
                     file_list = files[:10]
-                    files_md = "\n".join(f"- {f}" for f in file_list)
+                    files_md = "\n".join(f"- {Path(f).name}" for f in file_list)
                     if len(files) > 10:
                         files_md += f"\n\n*...and {len(files) - 10} more files*"
                 else:


### PR DESCRIPTION
## Summary
Display only the filename (not full path) in the Knowledge Base Statistics "Indexed Files" section.

## Changes
- Use `Path(f).name` to extract filename from file paths
- Cleaner display for users

## Test plan
- [x] All 247 tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)