### PR TITLE
fix: Handle FileStats dict in KB Statistics indexed files list

### DIFF
--- a/ai_ready_rag/ui/gradio_app.py
+++ b/ai_ready_rag/ui/gradio_app.py
@@ -1193,10 +1193,9 @@ def create_app() -> gr.Blocks:
 
                 if files:
                     # Show first 10 files (filename only), indicate if more
-                    from pathlib import Path
-
                     file_list = files[:10]
-                    files_md = "\n".join(f"- {Path(f).name}" for f in file_list)
+                    # Files are dicts with 'filename' key from FileStats model
+                    files_md = "\n".join(f"- {f.get('filename', 'Unknown')}" for f in file_list)
                     if len(files) > 10:
                         files_md += f"\n\n*...and {len(files) - 10} more files*"
                 else:


### PR DESCRIPTION
Fixes the error where files from the API are FileStats objects (dicts) not strings. Accesses the 'filename' field correctly.