### PR TITLE
feat: Add Embedding Model Configuration to Admin Panel (#21)

### DIFF
--- a/ai_ready_rag/services/model_service.py
+++ b/ai_ready_rag/services/model_service.py
@@ -150,3 +150,39 @@ class ModelService:
         if match:
             return f"{match.group(1)}B"
         return None
+
+    @staticmethod
+    def is_embedding_model(model_name: str) -> bool:
+        """Check if model name indicates an embedding model.
+
+        Args:
+            model_name: Name of the model to check
+
+        Returns:
+            True if model is an embedding model (contains 'embed' in name)
+        """
+        return "embed" in model_name.lower()
+
+    async def list_embedding_models(self) -> list[dict]:
+        """Query Ollama for available embedding models only.
+
+        Returns:
+            List of embedding model info dicts (models with 'embed' in name)
+
+        Raises:
+            OllamaUnavailableError: If Ollama is not reachable
+        """
+        models = await self.list_models()
+        return [m for m in models if self.is_embedding_model(m["name"])]
+
+    async def list_chat_models(self) -> list[dict]:
+        """Query Ollama for available chat/LLM models only.
+
+        Returns:
+            List of chat model info dicts (excludes embedding models)
+
+        Raises:
+            OllamaUnavailableError: If Ollama is not reachable
+        """
+        models = await self.list_models()
+        return [m for m in models if not self.is_embedding_model(m["name"])]

--- a/ai_ready_rag/ui/api_client.py
+++ b/ai_ready_rag/ui/api_client.py
@@ -538,3 +538,28 @@ class GradioAPIClient:
             )
             response.raise_for_status()
             return response.json()
+
+    @staticmethod
+    def change_embedding_model(
+        token: str, model_name: str, confirm_reindex: bool = True
+    ) -> dict[str, Any]:
+        """Change the embedding model used for vectorization.
+
+        WARNING: This invalidates all existing vectors. Documents must be re-indexed.
+
+        Args:
+            token: JWT access token
+            model_name: Name of the embedding model to switch to
+            confirm_reindex: Must be True to acknowledge re-indexing impact
+
+        Returns:
+            Result dict with message, reindex_required, and documents_affected.
+        """
+        with httpx.Client(base_url=BASE_URL, timeout=30.0) as client:
+            response = client.patch(
+                "/api/admin/models/embedding",
+                json={"model_name": model_name, "confirm_reindex": confirm_reindex},
+                headers=GradioAPIClient._headers(token),
+            )
+            response.raise_for_status()
+            return response.json()


### PR DESCRIPTION
## Summary
Allow admins to switch the embedding model at runtime for testing purposes. Complements existing chat model switching capability.

## Changes

### Backend
- **ModelService**: Add `is_embedding_model()`, `list_embedding_models()`, `list_chat_models()` for filtering
- **GET /api/admin/models**: Now returns `embedding_models` and `chat_models` filtered lists
- **PATCH /api/admin/models/embedding**: New endpoint with `confirm_reindex` requirement

### Frontend
- Split Model Configuration accordion into two sections:
  - **Embedding Model (Vectorization)**: dropdown with warning, Apply button
  - **Chat Model (RAG)**: dropdown, Apply button
- Warning displayed for embedding model changes

## API Changes
```
GET /api/admin/models → adds embedding_models, chat_models arrays

PATCH /api/admin/models/embedding
  Request:  {"model_name": "...", "confirm_reindex": true}
  Response: {"previous_model", "current_model", "reindex_required", "documents_affected"}
```

## Test plan
- [x] All 247 tests pass
- [x] Lint checks pass
- [ ] Manual: Load models shows filtered dropdowns
- [ ] Manual: Embedding change requires confirmation
- [ ] Manual: Chat model change works as before

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)