### PR TITLE
feat: Add configurable query routing (RETRIEVE/DIRECT) (#23)

### DIFF
--- a/ai_ready_rag/api/admin.py
+++ b/ai_ready_rag/api/admin.py
@@ -364,6 +364,7 @@ class ProcessingOptionsRequest(BaseModel):
     ocr_language: str | None = None
     table_extraction_mode: Literal["accurate", "fast"] | None = None
     include_image_descriptions: bool | None = None
+    query_routing_mode: Literal["retrieve_only", "retrieve_and_direct"] | None = None
 
 
 class ProcessingOptionsResponse(BaseModel):
@@ -374,6 +375,7 @@ class ProcessingOptionsResponse(BaseModel):
     ocr_language: str
     table_extraction_mode: str
     include_image_descriptions: bool
+    query_routing_mode: str
 
 
 # Default values for processing options
@@ -383,6 +385,7 @@ PROCESSING_DEFAULTS = {
     "ocr_language": "eng",
     "table_extraction_mode": "accurate",
     "include_image_descriptions": True,
+    "query_routing_mode": "retrieve_only",  # Default: always search documents
 }
 
 
@@ -422,6 +425,11 @@ async def get_processing_options(
             "include_image_descriptions",
             PROCESSING_DEFAULTS["include_image_descriptions"],
         ),
+        query_routing_mode=_get_setting_value(
+            service,
+            "query_routing_mode",
+            PROCESSING_DEFAULTS["query_routing_mode"],
+        ),
     )
 
 
@@ -458,6 +466,12 @@ async def update_processing_options(
             options.include_image_descriptions,
             updated_by=current_user.id,
         )
+    if options.query_routing_mode is not None:
+        service.set(
+            "query_routing_mode",
+            options.query_routing_mode,
+            updated_by=current_user.id,
+        )
 
     logger.info(
         f"Admin {current_user.email} updated processing options: "
@@ -482,6 +496,11 @@ async def update_processing_options(
             service,
             "include_image_descriptions",
             PROCESSING_DEFAULTS["include_image_descriptions"],
+        ),
+        query_routing_mode=_get_setting_value(
+            service,
+            "query_routing_mode",
+            PROCESSING_DEFAULTS["query_routing_mode"],
         ),
     )
 

--- a/ai_ready_rag/api/chat.py
+++ b/ai_ready_rag/api/chat.py
@@ -143,6 +143,7 @@ class SendMessageResponse(BaseModel):
     user_message: MessageResponse
     assistant_message: MessageResponse
     generation_time_ms: float
+    routing_decision: str | None = None  # "RETRIEVE" | "DIRECT" | None
 
 
 class MessageListResponse(BaseModel):
@@ -658,4 +659,5 @@ async def send_message(
             assistant_msg, is_assistant=True, rag_response=response
         ),
         generation_time_ms=response.generation_time_ms,
+        routing_decision=response.routing_decision,
     )

--- a/ai_ready_rag/services/rag_constants.py
+++ b/ai_ready_rag/services/rag_constants.py
@@ -124,3 +124,20 @@ STOPWORDS: frozenset[str] = frozenset(
         "them",
     }
 )
+
+# Query routing constants
+ROUTING_DIRECT = "DIRECT"
+ROUTING_RETRIEVE = "RETRIEVE"
+
+# Router prompt for classifying queries (ported from Spark app.py)
+ROUTER_PROMPT = """You are a routing agent. Analyze the user's question and decide if it requires retrieving information from documents.
+
+Respond with ONLY one of these two words:
+- RETRIEVE: if the question asks about company data, business information, customers, employees, financials, products, policies, procedures, or anything that would be in business documents. Questions containing "our", "we", "company" almost always need RETRIEVE.
+- DIRECT: ONLY for general knowledge questions completely unrelated to the business (like "what is the capital of France")
+
+When in doubt, choose RETRIEVE.
+
+Question: {question}
+
+Your routing decision (RETRIEVE or DIRECT):"""


### PR DESCRIPTION
## Summary
- Add `query_routing_mode` setting to Processing Options (`retrieve_only`/`retrieve_and_direct`)
- Add ROUTER_PROMPT constant for query classification
- Add `run_router()` and `_generate_direct_response()` methods to RAGService
- Add `routing_decision` field to RAGResponse and SendMessageResponse
- Add UI toggle in Admin Processing Options accordion
- Add 11 tests for routing logic

Default is `retrieve_only` to preserve existing behavior.

## Test plan
- [x] All 259 tests pass
- [x] Linting passes
- [x] Manual UI testing complete

Closes #23

🤖 Generated with [Claude Code](https://claude.ai/claude-code)