### PR TITLE
feat: Add support for spreadsheet and presentation file types (#27)

### DIFF
--- a/.claude/rules/frontend-patterns.md
+++ b/.claude/rules/frontend-patterns.md
@@ -120,7 +120,7 @@ return gr.update(choices=[("Display", "value"), ...])
 ```python
 file_input = gr.File(
     label="Select File",
-    file_types=[".pdf", ".docx", ".txt", ".md"],
+    file_types=[".pdf", ".docx", ".xlsx", ".pptx", ".txt", ".md", ".html", ".csv"],
 )
 
 # In handler, file.name gives the path

--- a/ai_ready_rag/config.py
+++ b/ai_ready_rag/config.py
@@ -111,7 +111,17 @@ class Settings(BaseSettings):
     upload_dir: str = "./data/uploads"
     max_upload_size_mb: int = 100
     max_storage_gb: int = 10
-    allowed_extensions: list[str] = ["pdf", "docx", "xlsx", "pptx", "txt", "md", "html", "csv"]
+    allowed_extensions: list[str] = [
+        "pdf",
+        "docx",
+        "xlsx",
+        "pptx",
+        "txt",
+        "md",
+        "html",
+        "htm",
+        "csv",
+    ]
 
     # Document Processing
     enable_ocr: bool | None = None  # None = use profile default

--- a/ai_ready_rag/services/chunker_simple.py
+++ b/ai_ready_rag/services/chunker_simple.py
@@ -104,7 +104,7 @@ class SimpleChunker:
             return self._extract_text_file(path)
         elif ext == ".csv":
             return self._extract_csv(path)
-        elif ext == ".html":
+        elif ext in (".html", ".htm"):
             return self._extract_html(path)
         elif ext == ".xlsx":
             return self._extract_xlsx(path)

--- a/ai_ready_rag/ui/document_components.py
+++ b/ai_ready_rag/ui/document_components.py
@@ -293,7 +293,7 @@ def handle_upload(
         elif e.response.status_code == 413:
             return "**File too large.** Please upload a smaller file."
         elif e.response.status_code == 415:
-            return "**Unsupported file type.** Allowed types: PDF, DOCX, TXT, MD."
+            return "**Unsupported file type.** Allowed types: PDF, DOCX, XLSX, PPTX, TXT, MD, HTML, CSV."
         elif e.response.status_code == 401:
             return "**Session expired.** Please log in again."
         elif e.response.status_code == 403:

--- a/ai_ready_rag/ui/gradio_app.py
+++ b/ai_ready_rag/ui/gradio_app.py
@@ -152,7 +152,17 @@ def create_app() -> gr.Blocks:
                             # Upload section
                             doc_file_input = gr.File(
                                 label="Select Files",
-                                file_types=[".pdf", ".docx", ".txt", ".md"],
+                                file_types=[
+                                    ".pdf",
+                                    ".docx",
+                                    ".txt",
+                                    ".md",
+                                    ".csv",
+                                    ".xlsx",
+                                    ".pptx",
+                                    ".html",
+                                    ".htm",
+                                ],
                                 file_count="multiple",
                             )
                             doc_tag_dropdown = gr.Dropdown(


### PR DESCRIPTION
## Summary
- Add .csv, .xlsx, .pptx, .html, .htm to upload file types in UI
- Add .htm to allowed_extensions in config.py
- Update chunker to handle .htm files as HTML
- Update error messages with complete format list

## File types now supported
- Documents: `.pdf`, `.docx`, `.txt`, `.md`
- Spreadsheets: `.csv`, `.xlsx`
- Presentations: `.pptx`
- Web: `.html`, `.htm`

## Test plan
- [x] All 259 tests pass
- [x] Linting passes
- [ ] Manual test: Upload .csv file
- [ ] Manual test: Upload .xlsx file
- [ ] Manual test: Upload .pptx file

Closes #27

🤖 Generated with [Claude Code](https://claude.ai/claude-code)