### PR TITLE
feat: Add additional OCR languages (Italian, Portuguese, Japanese) (#28)

### DIFF
--- a/ai_ready_rag/ui/gradio_app.py
+++ b/ai_ready_rag/ui/gradio_app.py
@@ -270,8 +270,17 @@ def create_app() -> gr.Blocks:
                             )
                             proc_ocr_lang = gr.Dropdown(
                                 label="OCR Language",
-                                choices=["English", "Spanish", "French", "German", "Chinese"],
-                                value="English",
+                                choices=[
+                                    ("English", "eng"),
+                                    ("Spanish", "spa"),
+                                    ("French", "fra"),
+                                    ("German", "deu"),
+                                    ("Italian", "ita"),
+                                    ("Portuguese", "por"),
+                                    ("Chinese Simplified", "chi_sim"),
+                                    ("Japanese", "jpn"),
+                                ],
+                                value="eng",
                             )
                             proc_table_mode = gr.Radio(
                                 label="Table Extraction Mode",
@@ -1185,7 +1194,7 @@ def create_app() -> gr.Blocks:
                     "Not authenticated.",
                     False,
                     False,
-                    "English",
+                    "eng",
                     "accurate",
                     False,
                     "retrieve_only",
@@ -1207,13 +1216,13 @@ def create_app() -> gr.Blocks:
                     f"Failed to load (HTTP {e.response.status_code})",
                     False,
                     False,
-                    "English",
+                    "eng",
                     "accurate",
                     False,
                     "retrieve_only",
                 )
             except Exception as e:
-                return (f"Error: {e}", False, False, "English", "accurate", False, "retrieve_only")
+                return (f"Error: {e}", False, False, "eng", "accurate", False, "retrieve_only")
 
         def save_processing_options(
             auth: dict,


### PR DESCRIPTION
## Summary
- Add Italian (ita), Portuguese (por), Japanese (jpn) to OCR language dropdown
- Use tuple format `("Display Name", "code")` for proper API values
- Update defaults from display names to Tesseract codes

## Languages now supported (8 total)
| Language | Code |
|----------|------|
| English | eng |
| Spanish | spa |
| French | fra |
| German | deu |
| Italian | ita |
| Portuguese | por |
| Chinese | chi_sim |
| Japanese | jpn |

## Test plan
- [x] All 259 tests pass
- [x] Linting passes
- [ ] Manual test: Verify dropdown shows 8 languages
- [ ] Manual test: Select Italian, verify OCR works

Closes #28

🤖 Generated with [Claude Code](https://claude.ai/claude-code)