### PR TITLE
feat: Make Gradio API client BASE_URL configurable (#36)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ ADMIN_DISPLAY_NAME=Administrator
 # JWT_SECRET_KEY=dev-secret-key-change-in-production
 # JWT_EXPIRATION_HOURS=24
 
+# API Base URL (for Gradio UI API client)
+# API_BASE_URL=http://localhost:8000
+
 # Vector Service
 # QDRANT_URL=http://localhost:6333
 # QDRANT_COLLECTION=documents

--- a/ai_ready_rag/config.py
+++ b/ai_ready_rag/config.py
@@ -75,6 +75,9 @@ class Settings(BaseSettings):
     vector_backend: Literal["chroma", "qdrant"] | None = None
     chunker_backend: Literal["simple", "docling"] | None = None
 
+    # API
+    api_base_url: str = "http://localhost:8000"
+
     # Vector Service
     qdrant_url: str = "http://localhost:6333"
     qdrant_collection: str = "documents"

--- a/ai_ready_rag/ui/api_client.py
+++ b/ai_ready_rag/ui/api_client.py
@@ -1,11 +1,12 @@
 """Stateless API client for Gradio UI - uses Bearer tokens from gr.State."""
 
+import os
 from typing import Any
 
 import httpx
 
-# Default base URL - can be overridden via environment
-BASE_URL = "http://localhost:8000"
+# Default base URL - can be overridden via API_BASE_URL environment variable
+BASE_URL = os.environ.get("API_BASE_URL", "http://localhost:8000")
 
 
 ERROR_RESPONSES: dict[int, dict[str, str]] = {


### PR DESCRIPTION
## Summary
- Makes `BASE_URL` in Gradio API client configurable via environment variable
- Enables remote Spark deployment where FastAPI backend runs on different host

## Changes
- `ai_ready_rag/ui/api_client.py`: Uses `os.environ.get("API_BASE_URL", "http://localhost:8000")`
- `ai_ready_rag/config.py`: Added `api_base_url` setting for consistency
- `.env.example`: Added `API_BASE_URL` documentation

## Test plan
- [x] Functional test: `API_BASE_URL=http://test:9000 python -c "from ai_ready_rag.ui.api_client import BASE_URL; print(BASE_URL)"` → outputs `http://test:9000`
- [x] Test suite: 259 passed, 7 skipped

Closes #36

🤖 Generated with [Claude Code](https://claude.ai/code)