### PR TITLE
feat: Add setup wizard for first-run admin password change (#37)

### DIFF
--- a/ai_ready_rag/api/setup.py
+++ b/ai_ready_rag/api/setup.py
@@ -1,0 +1,141 @@
+"""Setup wizard API endpoints for first-run admin password change."""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, field_validator
+from sqlalchemy.orm import Session
+
+from ai_ready_rag.config import get_settings
+from ai_ready_rag.core.dependencies import get_current_user
+from ai_ready_rag.core.security import hash_password, verify_password
+from ai_ready_rag.db.database import get_db
+from ai_ready_rag.db.models import SystemSetup, User
+
+router = APIRouter()
+settings = get_settings()
+
+
+class SetupStatusResponse(BaseModel):
+    """Response for setup status check."""
+
+    setup_complete: bool
+    setup_required: bool  # True if not complete AND not bypassed
+
+
+class CompleteSetupRequest(BaseModel):
+    """Request to complete setup by changing admin password."""
+
+    current_password: str
+    new_password: str
+    confirm_password: str
+
+    @field_validator("new_password")
+    @classmethod
+    def password_min_length(cls, v: str) -> str:
+        if len(v) < 12:
+            raise ValueError("Password must be at least 12 characters long")
+        return v
+
+    @field_validator("confirm_password")
+    @classmethod
+    def passwords_must_match(cls, v: str, info) -> str:
+        if "new_password" in info.data and v != info.data["new_password"]:
+            raise ValueError("Passwords do not match")
+        return v
+
+
+class CompleteSetupResponse(BaseModel):
+    """Response after completing setup."""
+
+    success: bool
+    message: str
+
+
+def get_or_create_setup(db: Session) -> SystemSetup:
+    """Get or create the SystemSetup record."""
+    setup = db.query(SystemSetup).first()
+    if not setup:
+        setup = SystemSetup(setup_complete=False, admin_password_changed=False)
+        db.add(setup)
+        db.commit()
+        db.refresh(setup)
+    return setup
+
+
+def is_setup_required(db: Session) -> bool:
+    """Check if setup is required (not complete and not bypassed)."""
+    if settings.skip_setup_wizard:
+        return False
+    setup = get_or_create_setup(db)
+    return not setup.setup_complete
+
+
+@router.get("/status", response_model=SetupStatusResponse)
+async def get_setup_status(db: Session = Depends(get_db)):
+    """Check if system setup is required.
+
+    This endpoint is PUBLIC - no authentication required.
+    Returns whether the setup wizard needs to be completed.
+    """
+    setup = get_or_create_setup(db)
+    setup_required = not setup.setup_complete and not settings.skip_setup_wizard
+
+    return SetupStatusResponse(setup_complete=setup.setup_complete, setup_required=setup_required)
+
+
+@router.post("/complete", response_model=CompleteSetupResponse)
+async def complete_setup(
+    request: CompleteSetupRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Complete the setup wizard by changing the admin password.
+
+    Requires authentication as an admin user.
+    """
+    # Only admin can complete setup
+    if current_user.role != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only administrators can complete system setup",
+        )
+
+    # Check if setup is already complete
+    setup = get_or_create_setup(db)
+    if setup.setup_complete:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Setup has already been completed",
+        )
+
+    # Verify current password
+    if not verify_password(request.current_password, current_user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Current password is incorrect",
+        )
+
+    # Ensure new password is different from current
+    if request.current_password == request.new_password:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="New password must be different from current password",
+        )
+
+    # Update admin password
+    current_user.password_hash = hash_password(request.new_password)
+    current_user.must_reset_password = False
+
+    # Mark setup as complete
+    setup.setup_complete = True
+    setup.admin_password_changed = True
+    setup.setup_completed_at = datetime.utcnow()
+    setup.setup_completed_by = current_user.id
+
+    db.commit()
+
+    return CompleteSetupResponse(
+        success=True,
+        message="Setup completed successfully. Default password has been changed.",
+    )

--- a/ai_ready_rag/config.py
+++ b/ai_ready_rag/config.py
@@ -68,6 +68,9 @@ class Settings(BaseSettings):
     enable_rag: bool = True  # Enabled for RAG functionality
     enable_gradio: bool = True
 
+    # Setup Wizard
+    skip_setup_wizard: bool = False  # Set to True to bypass setup check for automated deployments
+
     # Profile Selection
     env_profile: Literal["laptop", "spark"] = "laptop"
 

--- a/ai_ready_rag/db/models.py
+++ b/ai_ready_rag/db/models.py
@@ -153,3 +153,16 @@ class AdminSetting(Base):
     value = Column(Text, nullable=False)  # JSON encoded
     updated_by = Column(String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class SystemSetup(Base):
+    """Tracks system setup state for first-run wizard."""
+
+    __tablename__ = "system_setup"
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    setup_complete = Column(Boolean, default=False)
+    admin_password_changed = Column(Boolean, default=False)
+    setup_completed_at = Column(DateTime, nullable=True)
+    setup_completed_by = Column(String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/ai_ready_rag/main.py
+++ b/ai_ready_rag/main.py
@@ -6,7 +6,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from ai_ready_rag.api import admin, auth, chat, documents, health, tags, users
+from ai_ready_rag.api import admin, auth, chat, documents, health, setup, tags, users
 from ai_ready_rag.config import get_settings
 from ai_ready_rag.db.database import SessionLocal, init_db
 from ai_ready_rag.db.models import Document
@@ -73,6 +73,7 @@ app.add_middleware(
 
 # API Routes
 app.include_router(health.router, prefix="/api", tags=["Health"])
+app.include_router(setup.router, prefix="/api/setup", tags=["Setup"])
 app.include_router(auth.router, prefix="/api/auth", tags=["Authentication"])
 app.include_router(users.router, prefix="/api/users", tags=["Users"])
 app.include_router(tags.router, prefix="/api/tags", tags=["Tags"])

--- a/ai_ready_rag/ui/api_client.py
+++ b/ai_ready_rag/ui/api_client.py
@@ -564,3 +564,47 @@ class GradioAPIClient:
             )
             response.raise_for_status()
             return response.json()
+
+    # --- Setup Wizard APIs (#37) ---
+
+    @staticmethod
+    def get_setup_status() -> dict[str, Any]:
+        """Check if system setup is required.
+
+        This endpoint is PUBLIC - no authentication required.
+
+        Returns:
+            Dict with setup_complete and setup_required flags.
+        """
+        with httpx.Client(base_url=BASE_URL, timeout=30.0) as client:
+            response = client.get("/api/setup/status")
+            response.raise_for_status()
+            return response.json()
+
+    @staticmethod
+    def complete_setup(
+        token: str, current_password: str, new_password: str, confirm_password: str
+    ) -> dict[str, Any]:
+        """Complete system setup by changing admin password.
+
+        Args:
+            token: JWT access token (must be admin)
+            current_password: Current admin password
+            new_password: New password (min 12 chars)
+            confirm_password: Confirm new password (must match)
+
+        Returns:
+            Dict with success and message.
+        """
+        with httpx.Client(base_url=BASE_URL, timeout=30.0) as client:
+            response = client.post(
+                "/api/setup/complete",
+                json={
+                    "current_password": current_password,
+                    "new_password": new_password,
+                    "confirm_password": confirm_password,
+                },
+                headers=GradioAPIClient._headers(token),
+            )
+            response.raise_for_status()
+            return response.json()

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,0 +1,231 @@
+"""Tests for setup wizard API endpoints."""
+
+from ai_ready_rag.db.models import SystemSetup
+
+
+class TestSetupStatus:
+    """Tests for GET /api/setup/status endpoint."""
+
+    def test_status_returns_required_when_fresh_db(self, client):
+        """Setup is required when SystemSetup table is empty."""
+        response = client.get("/api/setup/status")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["setup_required"] is True
+        assert data["setup_complete"] is False
+
+    def test_status_returns_complete_after_setup(self, client, db):
+        """Setup is not required when already completed."""
+        # Create completed setup record
+        setup = SystemSetup(setup_complete=True, admin_password_changed=True)
+        db.add(setup)
+        db.flush()
+
+        response = client.get("/api/setup/status")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["setup_required"] is False
+        assert data["setup_complete"] is True
+
+    def test_status_no_auth_required(self, client):
+        """Setup status endpoint does not require authentication."""
+        # No auth header - should still work
+        response = client.get("/api/setup/status")
+        assert response.status_code == 200
+
+
+class TestCompleteSetup:
+    """Tests for POST /api/setup/complete endpoint."""
+
+    def test_complete_setup_success(self, client, db, admin_user, admin_headers):
+        """Admin can complete setup by changing password."""
+        response = client.post(
+            "/api/setup/complete",
+            headers=admin_headers,
+            json={
+                "current_password": "AdminPassword123",
+                "new_password": "NewSecurePassword123",
+                "confirm_password": "NewSecurePassword123",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert "completed" in data["message"].lower()
+
+        # Verify setup is marked complete
+        setup = db.query(SystemSetup).first()
+        assert setup is not None
+        assert setup.setup_complete is True
+        assert setup.admin_password_changed is True
+        assert setup.setup_completed_by == admin_user.id
+
+    def test_complete_setup_wrong_current_password(self, client, admin_headers):
+        """Setup fails with wrong current password."""
+        response = client.post(
+            "/api/setup/complete",
+            headers=admin_headers,
+            json={
+                "current_password": "WrongPassword123",
+                "new_password": "NewSecurePassword123",
+                "confirm_password": "NewSecurePassword123",
+            },
+        )
+        assert response.status_code == 401
+        assert "current password" in response.json()["detail"].lower()
+
+    def test_complete_setup_passwords_dont_match(self, client, admin_headers):
+        """Setup fails when passwords don't match."""
+        response = client.post(
+            "/api/setup/complete",
+            headers=admin_headers,
+            json={
+                "current_password": "AdminPassword123",
+                "new_password": "NewSecurePassword123",
+                "confirm_password": "DifferentPassword123",
+            },
+        )
+        assert response.status_code == 422  # Validation error
+
+    def test_complete_setup_password_too_short(self, client, admin_headers):
+        """Setup fails when new password is too short."""
+        response = client.post(
+            "/api/setup/complete",
+            headers=admin_headers,
+            json={
+                "current_password": "AdminPassword123",
+                "new_password": "Short123",  # Less than 12 chars
+                "confirm_password": "Short123",
+            },
+        )
+        assert response.status_code == 422  # Validation error
+
+    def test_complete_setup_non_admin_rejected(self, client, user_headers):
+        """Non-admin users cannot complete setup."""
+        response = client.post(
+            "/api/setup/complete",
+            headers=user_headers,
+            json={
+                "current_password": "UserPassword123",
+                "new_password": "NewSecurePassword123",
+                "confirm_password": "NewSecurePassword123",
+            },
+        )
+        assert response.status_code == 403
+        assert "administrator" in response.json()["detail"].lower()
+
+    def test_complete_setup_only_once(self, client, db, admin_headers):
+        """Setup can only be completed once."""
+        # First, create a completed setup record
+        setup = SystemSetup(setup_complete=True, admin_password_changed=True)
+        db.add(setup)
+        db.flush()
+
+        response = client.post(
+            "/api/setup/complete",
+            headers=admin_headers,
+            json={
+                "current_password": "AdminPassword123",
+                "new_password": "NewSecurePassword123",
+                "confirm_password": "NewSecurePassword123",
+            },
+        )
+        assert response.status_code == 400
+        assert "already" in response.json()["detail"].lower()
+
+    def test_complete_setup_requires_auth(self, client):
+        """Setup completion requires authentication."""
+        response = client.post(
+            "/api/setup/complete",
+            json={
+                "current_password": "AdminPassword123",
+                "new_password": "NewSecurePassword123",
+                "confirm_password": "NewSecurePassword123",
+            },
+        )
+        assert response.status_code == 401
+
+    def test_complete_setup_same_password_rejected(self, client, admin_headers):
+        """New password must be different from current password."""
+        response = client.post(
+            "/api/setup/complete",
+            headers=admin_headers,
+            json={
+                "current_password": "AdminPassword123",
+                "new_password": "AdminPassword123",
+                "confirm_password": "AdminPassword123",
+            },
+        )
+        assert response.status_code == 400
+        assert "different" in response.json()["detail"].lower()
+
+
+class TestLoginWithSetupRequired:
+    """Tests for login response with setup_required flag."""
+
+    def test_login_returns_setup_required_for_admin(self, client, admin_user):
+        """Login response includes setup_required=True for admin when setup not complete."""
+        response = client.post(
+            "/api/auth/login",
+            json={"email": "admin@test.com", "password": "AdminPassword123"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "setup_required" in data
+        assert data["setup_required"] is True
+
+    def test_login_returns_no_setup_required_for_regular_user(self, client, regular_user):
+        """Login response has setup_required=False for regular users."""
+        response = client.post(
+            "/api/auth/login",
+            json={"email": "user@test.com", "password": "UserPassword123"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "setup_required" in data
+        assert data["setup_required"] is False
+
+    def test_login_returns_no_setup_required_when_complete(self, client, db, admin_user):
+        """Login response has setup_required=False when setup is complete."""
+        # Mark setup as complete
+        setup = SystemSetup(setup_complete=True, admin_password_changed=True)
+        db.add(setup)
+        db.flush()
+
+        response = client.post(
+            "/api/auth/login",
+            json={"email": "admin@test.com", "password": "AdminPassword123"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["setup_required"] is False
+
+
+class TestSkipSetupWizard:
+    """Tests for SKIP_SETUP_WIZARD environment variable.
+
+    Note: Due to how Pydantic settings are cached at module import time,
+    testing the SKIP_SETUP_WIZARD env var requires special handling.
+    The config is loaded at app startup, so changing env vars mid-test
+    doesn't affect the already-loaded settings. These tests verify the
+    logic exists but may require manual testing or integration tests
+    to fully validate the env var behavior.
+    """
+
+    def test_skip_setting_exists_in_config(self):
+        """Verify skip_setup_wizard setting exists in config."""
+        from ai_ready_rag.config import Settings
+
+        # Verify the setting exists with correct default
+        settings = Settings()
+        assert hasattr(settings, "skip_setup_wizard")
+        assert settings.skip_setup_wizard is False  # Default should be False
+
+    def test_is_setup_required_respects_skip_setting(self, db):
+        """Verify is_setup_required logic respects skip setting when True."""
+        from ai_ready_rag.api.setup import is_setup_required
+
+        # This test verifies the logic, though the actual env var
+        # behavior would need integration testing
+        # When skip is False (default), setup should be required
+        assert is_setup_required(db) is True


### PR DESCRIPTION
## Summary
Forces admin to change default password on first login for production security.

## Changes

### New Files
- `ai_ready_rag/api/setup.py` - Setup wizard API endpoints
- `tests/test_setup_wizard.py` - 16 comprehensive tests

### Modified Files
- `ai_ready_rag/db/models.py` - Added `SystemSetup` model
- `ai_ready_rag/config.py` - Added `skip_setup_wizard` setting
- `ai_ready_rag/main.py` - Registered setup router
- `ai_ready_rag/api/auth.py` - Added `setup_required` to login response
- `ai_ready_rag/ui/gradio_app.py` - Added setup wizard UI
- `ai_ready_rag/ui/api_client.py` - Added setup API methods

## Features
- `GET /api/setup/status` - Check if setup required (public)
- `POST /api/setup/complete` - Complete setup (admin only)
- Password validation (min 12 chars, must match)
- Current password verification
- One-time completion enforcement
- `SKIP_SETUP_WIZARD=true` for automated deployments

## Test Plan
- [x] 16 setup wizard tests pass
- [x] Full suite: 275 passed, 7 skipped

Closes #37

🤖 Generated with [Claude Code](https://claude.ai/code)