### PR TITLE
fix: Use factory pattern for vector service in documents.py (#44)

### DIFF
--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -426,15 +426,15 @@ class TestDocumentTagUpdate:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    @patch("ai_ready_rag.services.vector_service.VectorService")
+    @patch("ai_ready_rag.services.factory.get_vector_service")
     def test_tag_update_success(
-        self, mock_vector_class, client, admin_headers, test_document, second_tag, db
+        self, mock_factory, client, admin_headers, test_document, second_tag, db
     ):
         """Test successful tag update."""
-        # Mock VectorService
+        # Mock the factory to return a mock vector service
         mock_instance = AsyncMock()
         mock_instance.update_document_tags = AsyncMock(return_value=5)
-        mock_vector_class.return_value = mock_instance
+        mock_factory.return_value = mock_instance
 
         response = client.patch(
             f"/api/documents/{test_document.id}/tags",


### PR DESCRIPTION
## Summary
- Replace direct `VectorService` (Qdrant) imports with `get_vector_service()` factory function
- Ensures documents.py respects `vector_backend` setting (laptop=chroma, spark=qdrant)
- Update test mock to patch factory function instead of class

## Problem
**Current State**: `documents.py` bypassed the factory pattern by directly importing `VectorService` (Qdrant), causing failures when using laptop profile with ChromaDB.

**Root Cause**: When profile is `laptop` (vector_backend=chroma), document upload/delete/tag operations failed because code tried to connect to Qdrant directly.

## Changes
| File | Change |
|------|--------|
| `ai_ready_rag/api/documents.py` | Replace 5 direct `VectorService` instantiations with `get_vector_service(settings)` |
| `tests/test_documents.py` | Update mock to patch factory function |

## Test plan
- [x] All 275 tests pass (pytest tests/ -v)
- [x] Pre-commit hooks pass (ruff check, ruff format)
- [ ] Verify on Spark server after deployment

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)