### PR TITLE
fix: Load .env file before reading API_BASE_URL

### DIFF
--- a/ai_ready_rag/ui/api_client.py
+++ b/ai_ready_rag/ui/api_client.py
@@ -4,6 +4,11 @@ import os
 from typing import Any
 
 import httpx
+from dotenv import load_dotenv
+
+# Load .env file before reading environment variables
+# This is required for API_BASE_URL to be read from .env on remote deployments
+load_dotenv()
 
 # Default base URL - can be overridden via API_BASE_URL environment variable
 BASE_URL = os.environ.get("API_BASE_URL", "http://localhost:8000")


### PR DESCRIPTION
## Summary
- Add `load_dotenv()` call in api_client.py before reading `API_BASE_URL`
- Fixes connection refused errors on remote deployments

## Problem
`os.environ.get()` doesn't automatically read `.env` files. When deploying to a remote server with `API_BASE_URL` configured in `.env`, the Gradio UI still tried to connect to `localhost:8000` instead of the configured URL.

## Test plan
- [x] Verified on Spark server - login now works with `API_BASE_URL=http://localhost:8502`

🤖 Generated with [Claude Code](https://claude.com/claude-code)