### PR TITLE
feat: Add Customer Admin role support (#49)

### DIFF
--- a/ai_ready_rag/api/admin.py
+++ b/ai_ready_rag/api/admin.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from ai_ready_rag.config import get_settings
-from ai_ready_rag.core.dependencies import require_admin
+from ai_ready_rag.core.dependencies import require_system_admin
 from ai_ready_rag.db.database import get_db
 from ai_ready_rag.db.models import User
 from ai_ready_rag.services.document_service import DocumentService
@@ -212,7 +212,7 @@ def _get_docling_version() -> str:
 @router.post("/documents/recover-stuck", response_model=RecoverResponse)
 async def recover_stuck_documents(
     max_age_hours: int = Query(2, ge=1, le=168, description="Maximum age in hours"),
-    current_user: User = Depends(require_admin),
+    current_user: User = Depends(require_system_admin),
     db: Session = Depends(get_db),
 ):
     """Recover documents stuck in processing state.
@@ -241,7 +241,7 @@ async def recover_stuck_documents(
 
 @router.get("/knowledge-base/stats", response_model=KnowledgeBaseStatsResponse)
 async def get_knowledge_base_stats(
-    current_user: User = Depends(require_admin),
+    current_user: User = Depends(require_system_admin),
     db: Session = Depends(get_db),
 ):
     """Get knowledge base statistics including per-file details.
@@ -293,7 +293,7 @@ async def get_knowledge_base_stats(
 @router.delete("/knowledge-base", response_model=ClearKnowledgeBaseResponse)
 async def clear_knowledge_base(
     request: ClearKnowledgeBaseRequest,
-    current_user: User = Depends(require_admin),
+    current_user: User = Depends(require_system_admin),
     db: Session = Depends(get_db),
 ):
     """Clear all vectors from the knowledge base.
@@ -397,7 +397,7 @@ def _get_setting_value(service: SettingsService, key: str, default: any) -> any:
 
 @router.get("/processing-options", response_model=ProcessingOptionsResponse)
 async def get_processing_options(
-    current_user: User = Depends(require_admin),
+    current_user: User = Depends(require_system_admin),
     db: Session = Depends(get_db),
 ):
     """Get current processing options.
@@ -436,7 +436,7 @@ async def get_processing_options(
 @router.patch("/processing-options", response_model=ProcessingOptionsResponse)
 async def update_processing_options(
     options: ProcessingOptionsRequest,
-    current_user: User = Depends(require_admin),
+    current_user: User = Depends(require_system_admin),
     db: Session = Depends(get_db),
 ):
     """Update processing options.
@@ -507,7 +507,7 @@ async def update_processing_options(
 
 @router.get("/architecture", response_model=ArchitectureInfoResponse)
 async def get_architecture_info(
-    current_user: User = Depends(require_admin),
+    current_user: User = Depends(require_system_admin),
 ):
     """Get comprehensive system architecture information.
 
@@ -675,7 +675,7 @@ class ChangeEmbeddingResponse(BaseModel):
 
 @router.get("/models", response_model=ModelsResponse)
 async def get_models(
-    current_user: User = Depends(require_admin),
+    current_user: User = Depends(require_system_admin),
     db: Session = Depends(get_db),
 ):
     """Get available Ollama models and current selection.
@@ -737,7 +737,7 @@ async def get_models(
 @router.patch("/models/chat", response_model=ChangeModelResponse)
 async def change_chat_model(
     request: ChangeModelRequest,
-    current_user: User = Depends(require_admin),
+    current_user: User = Depends(require_system_admin),
     db: Session = Depends(get_db),
 ):
     """Change the active chat model.
@@ -795,7 +795,7 @@ async def change_chat_model(
 @router.patch("/models/embedding", response_model=ChangeEmbeddingResponse)
 async def change_embedding_model(
     request: ChangeEmbeddingRequest,
-    current_user: User = Depends(require_admin),
+    current_user: User = Depends(require_system_admin),
     db: Session = Depends(get_db),
 ):
     """Change the embedding model used for vectorization.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,74 @@ def user_headers(user_token) -> dict:
 
 
 @pytest.fixture(scope="function")
+def customer_admin_user(db) -> User:
+    """Create a customer admin user for testing."""
+    user = User(
+        email="customer_admin@test.com",
+        display_name="Customer Admin",
+        password_hash=hash_password("CustomerAdminPassword123"),
+        role="customer_admin",
+        is_active=True,
+    )
+    db.add(user)
+    db.flush()
+    db.refresh(user)
+    return user
+
+
+@pytest.fixture(scope="function")
+def customer_admin_token(customer_admin_user) -> str:
+    """Get JWT token for customer admin user."""
+    return create_access_token(
+        data={
+            "sub": customer_admin_user.id,
+            "email": customer_admin_user.email,
+            "role": customer_admin_user.role,
+        }
+    )
+
+
+@pytest.fixture(scope="function")
+def customer_admin_headers(customer_admin_token) -> dict:
+    """Authorization headers for customer admin."""
+    return {"Authorization": f"Bearer {customer_admin_token}"}
+
+
+@pytest.fixture(scope="function")
+def system_admin_user(db) -> User:
+    """Create a system admin user for testing (explicit system_admin role)."""
+    user = User(
+        email="system_admin@test.com",
+        display_name="System Admin",
+        password_hash=hash_password("SystemAdminPassword123"),
+        role="system_admin",
+        is_active=True,
+    )
+    db.add(user)
+    db.flush()
+    db.refresh(user)
+    return user
+
+
+@pytest.fixture(scope="function")
+def system_admin_token(system_admin_user) -> str:
+    """Get JWT token for system admin user."""
+    return create_access_token(
+        data={
+            "sub": system_admin_user.id,
+            "email": system_admin_user.email,
+            "role": system_admin_user.role,
+        }
+    )
+
+
+@pytest.fixture(scope="function")
+def system_admin_headers(system_admin_token) -> dict:
+    """Authorization headers for system admin."""
+    return {"Authorization": f"Bearer {system_admin_token}"}
+
+
+@pytest.fixture(scope="function")
 def sample_tag(db, admin_user) -> Tag:
     """Create a sample tag."""
     tag = Tag(

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,160 @@
+"""Tests for role-based access control.
+
+Tests the three-role permission system:
+- system_admin: Full access including Settings/Health
+- customer_admin: Can manage users/documents/tags but NOT system settings
+- user: Chat and filtered document access only
+"""
+
+
+class TestRoleNormalization:
+    """Test role normalization for backward compatibility."""
+
+    def test_legacy_admin_treated_as_system_admin(self, client, admin_headers):
+        """Test that legacy 'admin' role has system admin access."""
+        # Legacy admin should be able to access system-admin-only endpoints
+        response = client.get("/api/admin/processing-options", headers=admin_headers)
+        assert response.status_code == 200
+
+    def test_legacy_admin_can_manage_users(self, client, admin_headers):
+        """Test that legacy 'admin' role can manage users."""
+        response = client.get("/api/users/", headers=admin_headers)
+        assert response.status_code == 200
+
+
+class TestCustomerAdminAccess:
+    """Test customer_admin role permissions."""
+
+    def test_customer_admin_can_list_users(self, client, customer_admin_headers):
+        """Customer admin can list users."""
+        response = client.get("/api/users/", headers=customer_admin_headers)
+        assert response.status_code == 200
+
+    def test_customer_admin_can_create_user(self, client, customer_admin_headers):
+        """Customer admin can create users."""
+        response = client.post(
+            "/api/users/",
+            headers=customer_admin_headers,
+            json={
+                "email": "newuser_by_customer_admin@test.com",
+                "display_name": "New User",
+                "password": "NewUserPassword123",
+                "role": "user",
+            },
+        )
+        assert response.status_code == 201
+
+    def test_customer_admin_can_list_tags(self, client, customer_admin_headers):
+        """Customer admin can list tags."""
+        response = client.get("/api/tags/", headers=customer_admin_headers)
+        assert response.status_code == 200
+
+    def test_customer_admin_can_create_tag(self, client, customer_admin_headers):
+        """Customer admin can create tags."""
+        response = client.post(
+            "/api/tags/",
+            headers=customer_admin_headers,
+            json={
+                "name": "customer_admin_tag",
+                "display_name": "Customer Admin Tag",
+            },
+        )
+        assert response.status_code == 201
+
+    def test_customer_admin_cannot_access_processing_options(self, client, customer_admin_headers):
+        """Customer admin cannot access processing options (system admin only)."""
+        response = client.get("/api/admin/processing-options", headers=customer_admin_headers)
+        assert response.status_code == 403
+        assert "system admin" in response.json()["detail"].lower()
+
+    def test_customer_admin_cannot_access_architecture(self, client, customer_admin_headers):
+        """Customer admin cannot access architecture info (system admin only)."""
+        response = client.get("/api/admin/architecture", headers=customer_admin_headers)
+        assert response.status_code == 403
+        assert "system admin" in response.json()["detail"].lower()
+
+    def test_customer_admin_cannot_access_models(self, client, customer_admin_headers):
+        """Customer admin cannot access model configuration (system admin only)."""
+        response = client.get("/api/admin/models", headers=customer_admin_headers)
+        assert response.status_code == 403
+        assert "system admin" in response.json()["detail"].lower()
+
+    def test_customer_admin_cannot_access_knowledge_base_stats(
+        self, client, customer_admin_headers
+    ):
+        """Customer admin cannot access knowledge base stats (system admin only)."""
+        response = client.get("/api/admin/knowledge-base/stats", headers=customer_admin_headers)
+        assert response.status_code == 403
+        assert "system admin" in response.json()["detail"].lower()
+
+
+class TestSystemAdminAccess:
+    """Test system_admin role permissions."""
+
+    def test_system_admin_can_access_processing_options(self, client, system_admin_headers):
+        """System admin can access processing options."""
+        response = client.get("/api/admin/processing-options", headers=system_admin_headers)
+        assert response.status_code == 200
+
+    def test_system_admin_can_list_users(self, client, system_admin_headers):
+        """System admin can list users."""
+        response = client.get("/api/users/", headers=system_admin_headers)
+        assert response.status_code == 200
+
+    def test_system_admin_can_list_tags(self, client, system_admin_headers):
+        """System admin can list tags."""
+        response = client.get("/api/tags/", headers=system_admin_headers)
+        assert response.status_code == 200
+
+
+class TestRegularUserAccess:
+    """Test regular user role permissions."""
+
+    def test_user_cannot_list_users(self, client, user_headers):
+        """Regular user cannot list users."""
+        response = client.get("/api/users/", headers=user_headers)
+        assert response.status_code == 403
+
+    def test_user_cannot_create_tag(self, client, user_headers):
+        """Regular user cannot create tags."""
+        response = client.post(
+            "/api/tags/",
+            headers=user_headers,
+            json={"name": "user_tag", "display_name": "User Tag"},
+        )
+        assert response.status_code == 403
+
+    def test_user_cannot_access_processing_options(self, client, user_headers):
+        """Regular user cannot access processing options."""
+        response = client.get("/api/admin/processing-options", headers=user_headers)
+        assert response.status_code == 403
+
+    def test_user_can_list_tags(self, client, user_headers):
+        """Regular user can list tags (read-only access)."""
+        response = client.get("/api/tags/", headers=user_headers)
+        assert response.status_code == 200
+
+
+class TestRoleConstants:
+    """Test role constant definitions."""
+
+    def test_role_constants_defined(self):
+        """Verify role constants are properly defined."""
+        from ai_ready_rag.core.dependencies import (
+            ROLE_CUSTOMER_ADMIN,
+            ROLE_SYSTEM_ADMIN,
+            ROLE_USER,
+        )
+
+        assert ROLE_SYSTEM_ADMIN == "system_admin"
+        assert ROLE_CUSTOMER_ADMIN == "customer_admin"
+        assert ROLE_USER == "user"
+
+    def test_normalize_role_maps_admin(self):
+        """Test that normalize_role maps 'admin' to 'system_admin'."""
+        from ai_ready_rag.core.dependencies import normalize_role
+
+        assert normalize_role("admin") == "system_admin"
+        assert normalize_role("system_admin") == "system_admin"
+        assert normalize_role("customer_admin") == "customer_admin"
+        assert normalize_role("user") == "user"


### PR DESCRIPTION
## Summary
- Add `customer_admin` role with permissions between admin and user
- Customer admin can manage users and tags, but not system settings
- Backward compatible with existing "admin" role

## Changes
- Added role constants and `normalize_role()` for backward compatibility
- Added `require_system_admin()` dependency for system-only endpoints
- 19 new role-specific tests

## Test Plan
- [x] All 294 tests pass
- [x] Ruff linting passes

Closes #49