### PR TITLE
feat: Add dark mode enhancements and keyboard shortcuts (#54)

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,11 +1,13 @@
-import { Moon, Sun, LogOut, User } from 'lucide-react';
+import { Moon, Sun, LogOut, User, Keyboard } from 'lucide-react';
 import { useAuthStore } from '../../stores/authStore';
 import { useUIStore } from '../../stores/uiStore';
 import { BridgeLogo } from './BridgeLogo';
+import { usePlatformModifier } from '../../hooks';
 
 export function Header() {
   const { user, logout } = useAuthStore();
-  const { darkMode, toggleDarkMode } = useUIStore();
+  const { darkMode, toggleDarkMode, toggleShortcutsModal } = useUIStore();
+  const { modSymbol } = usePlatformModifier();
 
   return (
     <header className="sticky top-0 z-50 bg-white/95 dark:bg-gray-900/95 backdrop-blur border-b border-gray-200 dark:border-gray-800">
@@ -22,11 +24,20 @@ export function Header() {
 
         {/* Right side controls */}
         <div className="flex items-center gap-4">
+          {/* Keyboard shortcuts */}
+          <button
+            onClick={toggleShortcutsModal}
+            className="p-2 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            title={`Keyboard shortcuts (${modSymbol}+/)`}
+          >
+            <Keyboard size={20} />
+          </button>
+
           {/* Dark mode toggle */}
           <button
             onClick={toggleDarkMode}
             className="p-2 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-            title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+            title={`${darkMode ? 'Switch to light mode' : 'Switch to dark mode'} (${modSymbol}+D)`}
           >
             {darkMode ? <Sun size={20} /> : <Moon size={20} />}
           </button>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,12 +1,21 @@
 import type { ReactNode } from 'react';
 import { Header } from './Header';
 import { Nav } from './Nav';
+import { useUIStore } from '../../stores/uiStore';
+import { KeyboardShortcutsModal } from '../ui';
+import { useKeyboardShortcuts } from '../../hooks';
 
 interface LayoutProps {
   children: ReactNode;
 }
 
 export function Layout({ children }: LayoutProps) {
+  const { shortcutsModalOpen, setShortcutsModalOpen } = useUIStore();
+
+  // Initialize global keyboard shortcuts
+  // Note: ChatView registers its own handler for Cmd+N to create new sessions
+  useKeyboardShortcuts();
+
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
       <Header />
@@ -14,6 +23,12 @@ export function Layout({ children }: LayoutProps) {
       <main className="max-w-7xl mx-auto px-4 py-6">
         {children}
       </main>
+
+      {/* Keyboard Shortcuts Modal */}
+      <KeyboardShortcutsModal
+        isOpen={shortcutsModalOpen}
+        onClose={() => setShortcutsModalOpen(false)}
+      />
     </div>
   );
 }

--- a/frontend/src/components/ui/KeyboardShortcutsModal.tsx
+++ b/frontend/src/components/ui/KeyboardShortcutsModal.tsx
@@ -1,0 +1,101 @@
+import { Modal } from './Modal';
+import { usePlatformModifier } from '../../hooks';
+
+interface KeyboardShortcutsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface ShortcutItem {
+  keys: string[];
+  description: string;
+  scope?: string;
+}
+
+export function KeyboardShortcutsModal({
+  isOpen,
+  onClose,
+}: KeyboardShortcutsModalProps) {
+  const { modSymbol } = usePlatformModifier();
+
+  const shortcuts: ShortcutItem[] = [
+    {
+      keys: [modSymbol, 'K'],
+      description: 'Focus search',
+      scope: 'Global',
+    },
+    {
+      keys: [modSymbol, 'D'],
+      description: 'Toggle dark mode',
+      scope: 'Global',
+    },
+    {
+      keys: [modSymbol, '/'],
+      description: 'Show keyboard shortcuts',
+      scope: 'Global',
+    },
+    {
+      keys: [modSymbol, 'N'],
+      description: 'New chat session',
+      scope: 'Chat',
+    },
+    {
+      keys: [modSymbol, 'Enter'],
+      description: 'Send message',
+      scope: 'Chat Input',
+    },
+    {
+      keys: ['Esc'],
+      description: 'Close modal',
+      scope: 'Any Modal',
+    },
+  ];
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Keyboard Shortcuts" size="md">
+      <div className="space-y-4">
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          Use these shortcuts to navigate faster.
+        </p>
+
+        <div className="divide-y divide-gray-200 dark:divide-gray-700">
+          {shortcuts.map((shortcut, index) => (
+            <div
+              key={index}
+              className="flex items-center justify-between py-3 first:pt-0 last:pb-0"
+            >
+              <div className="flex-1">
+                <span className="text-sm text-gray-900 dark:text-white">
+                  {shortcut.description}
+                </span>
+                {shortcut.scope && (
+                  <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">
+                    ({shortcut.scope})
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-1">
+                {shortcut.keys.map((key, keyIndex) => (
+                  <span key={keyIndex}>
+                    <kbd className="inline-flex items-center justify-center min-w-[24px] px-2 py-1 text-xs font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm">
+                      {key}
+                    </kbd>
+                    {keyIndex < shortcut.keys.length - 1 && (
+                      <span className="mx-1 text-gray-400">+</span>
+                    )}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Tip: Press <kbd className="px-1.5 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded">{modSymbol}</kbd> + <kbd className="px-1.5 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded">/</kbd> anytime to show this help.
+          </p>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -7,3 +7,4 @@ export { Select } from './Select';
 export { Modal } from './Modal';
 export { Checkbox } from './Checkbox';
 export { Pagination } from './Pagination';
+export { KeyboardShortcutsModal } from './KeyboardShortcutsModal';

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useKeyboardShortcuts, usePlatformModifier } from './useKeyboardShortcuts';

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,96 @@
+import { useEffect, useCallback } from 'react';
+import { useUIStore } from '../stores/uiStore';
+
+interface KeyboardShortcutsOptions {
+  onFocusSearch?: () => void;
+}
+
+/**
+ * Global keyboard shortcuts hook
+ *
+ * Shortcuts:
+ * - Cmd/Ctrl + K: Focus search
+ * - Cmd/Ctrl + D: Toggle dark mode
+ * - Cmd/Ctrl + / or ?: Show keyboard shortcuts help
+ * - Escape: Close modals (handled by Modal component)
+ *
+ * Note: Cmd/Ctrl + N for new session is handled locally by ChatView
+ * Note: Cmd/Ctrl + Enter for send is handled locally by ChatInput
+ */
+export function useKeyboardShortcuts(options: KeyboardShortcutsOptions = {}) {
+  const { onFocusSearch } = options;
+  const { toggleDarkMode, toggleShortcutsModal } = useUIStore();
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      const isMod = event.metaKey || event.ctrlKey;
+      const isShift = event.shiftKey;
+      const target = event.target as HTMLElement;
+      const tagName = target.tagName.toLowerCase();
+
+      // Don't trigger shortcuts when typing in input fields (except for specific shortcuts)
+      const isInputField =
+        tagName === 'input' ||
+        tagName === 'textarea' ||
+        target.isContentEditable;
+
+      // Cmd/Ctrl + K: Focus search
+      if (isMod && event.key === 'k') {
+        event.preventDefault();
+        if (onFocusSearch) {
+          onFocusSearch();
+        } else {
+          // Default: focus the first search input on the page
+          const searchInput = document.querySelector<HTMLInputElement>(
+            'input[placeholder*="Search"], input[type="search"]'
+          );
+          if (searchInput) {
+            searchInput.focus();
+            searchInput.select();
+          }
+        }
+        return;
+      }
+
+      // Cmd/Ctrl + D: Toggle dark mode
+      if (isMod && event.key === 'd') {
+        event.preventDefault();
+        toggleDarkMode();
+        return;
+      }
+
+      // Cmd/Ctrl + / or ?: Show keyboard shortcuts
+      if ((isMod && event.key === '/') || (isShift && event.key === '?')) {
+        // Allow ? in input fields
+        if (isShift && event.key === '?' && isInputField) {
+          return;
+        }
+        event.preventDefault();
+        toggleShortcutsModal();
+        return;
+      }
+    },
+    [toggleDarkMode, toggleShortcutsModal, onFocusSearch]
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleKeyDown]);
+}
+
+/**
+ * Hook to get platform-specific modifier key display
+ */
+export function usePlatformModifier() {
+  const isMac =
+    typeof navigator !== 'undefined' &&
+    /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+
+  return {
+    mod: isMac ? 'Cmd' : 'Ctrl',
+    modSymbol: isMac ? '\u2318' : 'Ctrl',
+  };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,7 +2,18 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { useUIStore } from './stores/uiStore';
 import './styles/index.css';
+
+// Initialize dark mode before render to prevent flash
+// Add no-transitions class to prevent transition flash on initial load
+document.documentElement.classList.add('no-transitions');
+useUIStore.getState().initDarkMode();
+
+// Remove no-transitions class after a short delay
+setTimeout(() => {
+  document.documentElement.classList.remove('no-transitions');
+}, 100);
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -4,15 +4,20 @@ import { persist } from 'zustand/middleware';
 interface UIState {
   darkMode: boolean;
   sidebarCollapsed: boolean;
+  shortcutsModalOpen: boolean;
   toggleDarkMode: () => void;
   toggleSidebar: () => void;
+  toggleShortcutsModal: () => void;
+  setShortcutsModalOpen: (open: boolean) => void;
+  initDarkMode: () => void;
 }
 
 export const useUIStore = create<UIState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       darkMode: false,
       sidebarCollapsed: false,
+      shortcutsModalOpen: false,
 
       toggleDarkMode: () => {
         set((state) => {
@@ -29,9 +34,44 @@ export const useUIStore = create<UIState>()(
       toggleSidebar: () => {
         set((state) => ({ sidebarCollapsed: !state.sidebarCollapsed }));
       },
+
+      toggleShortcutsModal: () => {
+        set((state) => ({ shortcutsModalOpen: !state.shortcutsModalOpen }));
+      },
+
+      setShortcutsModalOpen: (open: boolean) => {
+        set({ shortcutsModalOpen: open });
+      },
+
+      initDarkMode: () => {
+        // Check if we already have a stored preference (handled by persist middleware)
+        const currentState = get();
+        const stored = localStorage.getItem('ui-storage');
+
+        if (stored) {
+          // If there's a stored preference, persist middleware has already applied it
+          // Just ensure the DOM reflects the stored state
+          if (currentState.darkMode) {
+            document.documentElement.classList.add('dark');
+          } else {
+            document.documentElement.classList.remove('dark');
+          }
+        } else {
+          // No stored preference - check system preference
+          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          if (prefersDark) {
+            document.documentElement.classList.add('dark');
+            set({ darkMode: true });
+          }
+        }
+      },
     }),
     {
       name: 'ui-storage',
+      partialize: (state) => ({
+        darkMode: state.darkMode,
+        sidebarCollapsed: state.sidebarCollapsed
+      }),
       onRehydrateStorage: () => (state) => {
         // Apply dark mode on rehydration
         if (state?.darkMode) {

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -14,6 +14,24 @@
   --color-primary-light: #4ECDC4;
 }
 
+/* Smooth dark mode transition */
+html {
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+html *,
+html *::before,
+html *::after {
+  transition: background-color 0.3s ease, border-color 0.3s ease;
+}
+
+/* Disable transitions during page load to prevent flash */
+html.no-transitions *,
+html.no-transitions *::before,
+html.no-transitions *::after {
+  transition: none !important;
+}
+
 body {
   font-family: 'Inter', system-ui, sans-serif;
 }

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -105,13 +105,35 @@ export function ChatView() {
     }
   };
 
-  const handleNewSession = async () => {
+  const handleNewSession = useCallback(async () => {
     const sessionId = await createSession();
     if (sessionId) {
       setActiveSessionId(sessionId);
       setMessages([]);
     }
-  };
+  }, []);
+
+  // Handle Cmd/Ctrl + N keyboard shortcut for new session in chat view
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const isMod = e.metaKey || e.ctrlKey;
+      const target = e.target as HTMLElement;
+      const tagName = target.tagName.toLowerCase();
+      const isInputField =
+        tagName === 'input' ||
+        tagName === 'textarea' ||
+        target.isContentEditable;
+
+      // Cmd/Ctrl + N: New session (only when not in input field)
+      if (isMod && e.key === 'n' && !isInputField) {
+        e.preventDefault();
+        handleNewSession();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [handleNewSession]);
 
   const handleSelectSession = useCallback((sessionId: string) => {
     setActiveSessionId(sessionId);


### PR DESCRIPTION
## Summary
- Dark mode with system preference detection
- Smooth color transitions (0.3s)
- Keyboard shortcuts: Cmd+K (search), Cmd+D (dark mode), Cmd+/ (help), Cmd+N (new chat)
- KeyboardShortcutsModal with platform-aware key display

## Files Added/Modified
- useKeyboardShortcuts hook
- KeyboardShortcutsModal component
- Enhanced uiStore with initDarkMode

## Test Plan
- [x] TypeScript compilation passes
- [x] Dark mode toggle works
- [x] Shortcuts work on Mac/Windows

Closes #54