### PR TITLE
feat: Add detailed health endpoint for admin dashboard (#50)

### DIFF
--- a/ai_ready_rag/main.py
+++ b/ai_ready_rag/main.py
@@ -1,6 +1,7 @@
 """FastAPI application entry point."""
 
 import logging
+import time
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -31,6 +32,10 @@ async def lifespan(app: FastAPI):
     print(f"Starting {settings.app_name} v{settings.app_version}")
     print(f"Debug mode: {settings.debug}")
     print(f"RAG enabled: {settings.enable_rag}")
+
+    # Track server start time for uptime calculation
+    app.state.start_time = time.time()
+
     init_db()
 
     # Recover stuck documents from previous crashes

--- a/frontend/src/api/health.ts
+++ b/frontend/src/api/health.ts
@@ -1,11 +1,19 @@
 import { apiClient } from './client';
-import type { HealthResponse } from '../types';
+import type { HealthResponse, DetailedHealthResponse } from '../types';
 
 /**
  * Get basic health status.
  */
 export async function getHealth(): Promise<HealthResponse> {
   return apiClient.get<HealthResponse>('/api/health');
+}
+
+/**
+ * Get detailed health status for admin dashboard.
+ * Requires admin authentication.
+ */
+export async function getDetailedHealth(): Promise<DetailedHealthResponse> {
+  return apiClient.get<DetailedHealthResponse>('/api/admin/health/detailed');
 }
 
 /**

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -268,3 +268,45 @@ export interface HealthResponse {
     ocr_enabled: boolean;
   };
 }
+
+export interface ComponentHealth {
+  name: string;
+  status: 'healthy' | 'unhealthy' | 'degraded';
+  version?: string;
+  details?: Record<string, unknown>;
+}
+
+export interface RAGPipelineStatus {
+  embedding_model: string;
+  chat_model: string;
+  chunker: string;
+  stages: string[];
+  all_stages_healthy: boolean;
+}
+
+export interface KnowledgeBaseSummary {
+  total_documents: number;
+  total_chunks: number;
+  storage_size_mb?: number;
+}
+
+export interface ProcessingQueueStatus {
+  pending: number;
+  processing: number;
+  failed: number;
+  ready: number;
+}
+
+export interface DetailedHealthResponse {
+  status: 'healthy' | 'unhealthy' | 'degraded';
+  version: string;
+  profile: string;
+  api_server: ComponentHealth;
+  ollama_llm: ComponentHealth;
+  vector_db: ComponentHealth;
+  rag_pipeline: RAGPipelineStatus;
+  knowledge_base: KnowledgeBaseSummary;
+  processing_queue: ProcessingQueueStatus;
+  uptime_seconds: number;
+  last_checked: string;
+}


### PR DESCRIPTION
## Summary
- Add `/api/admin/health/detailed` endpoint with comprehensive system status
- Track server uptime via `app.state.start_time` in main.py
- Update HealthView.tsx to use single detailed endpoint instead of 3 separate calls

## Changes
### Backend
- **ai_ready_rag/main.py**: Added `app.state.start_time = time.time()` in lifespan for uptime tracking
- **ai_ready_rag/api/admin.py**: Added detailed health endpoint with:
  - Component health (API, Ollama, VectorDB) with status and version
  - RAG pipeline status (embedding model, chat model, chunker, stages)
  - Knowledge base summary (documents, chunks, storage)
  - Processing queue status (pending, processing, ready, failed)
  - Server uptime in seconds

### Frontend
- **frontend/src/api/health.ts**: Added `getDetailedHealth()` API function
- **frontend/src/types/index.ts**: Added TypeScript types for detailed health response
- **frontend/src/views/HealthView.tsx**: Refactored to use single detailed endpoint

## Test plan
- [x] All 294 backend tests pass
- [x] Frontend compiles without errors
- [ ] Manual test: Login and navigate to Health view
- [ ] Verify uptime displays correctly
- [ ] Verify all component health cards show correct status

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)