### PR TITLE
feat: Add model-aware settings validation (#66)

### DIFF
--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -7,6 +7,7 @@ import type {
   RetrievalSettings,
   LLMSettings,
   SettingsAuditResponse,
+  ModelLimitsResponse,
 } from '../types';
 
 /**
@@ -77,6 +78,14 @@ export async function changeEmbeddingModel(
     model_name: modelName,
     confirm_reindex: confirmReindex,
   });
+}
+
+/**
+ * Get model-specific limits for settings validation (system admin only).
+ * Returns current model limits and all known model limits.
+ */
+export async function getModelLimits(): Promise<ModelLimitsResponse> {
+  return apiClient.get<ModelLimitsResponse>('/api/admin/model-limits');
 }
 
 /**

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -340,3 +340,17 @@ export interface SettingsAuditResponse {
   limit: number;
   offset: number;
 }
+
+// Model Limits (for settings validation)
+export interface ModelLimits {
+  context_window: number;
+  max_response: number;
+  temperature_min: number;
+  temperature_max: number;
+}
+
+export interface ModelLimitsResponse {
+  current_model: string;
+  limits: ModelLimits;
+  all_models: Record<string, ModelLimits>;
+}


### PR DESCRIPTION
## Summary

- Add backend enforcement: `max_response_tokens` capped to current model's limit at generation time
- Add `GET /api/admin/model-limits` endpoint for frontend to fetch model constraints
- Add frontend TypeScript types and API function
- Add comprehensive tests (10 new tests)

## Changes

### Backend
- `rag_service.py`: Add `_get_effective_max_tokens()` and `_get_current_chat_model()` methods
- `admin.py`: Add `ModelLimits`, `ModelLimitsResponse` models and `/model-limits` endpoint

### Frontend
- `types/index.ts`: Add `ModelLimits` and `ModelLimitsResponse` interfaces
- `api/admin.ts`: Add `getModelLimits()` function

### Tests
- `test_admin_models.py`: Add `TestGetModelLimits` class (6 tests)
- `test_rag_service.py`: Add `TestMaxResponseTokensCapping` class (4 tests)

## Test plan
- [x] All 56 related tests pass
- [x] Linting passes
- [x] Endpoint returns correct model limits
- [x] Capping logs warning when applied

Closes #66

---
Generated with [Claude Code](https://claude.com/claude-code)