### PR TITLE
feat: Add reindex failure handling with pause/resume workflow (#68)

### DIFF
--- a/ai_ready_rag/core/exceptions.py
+++ b/ai_ready_rag/core/exceptions.py
@@ -127,3 +127,28 @@ class TokenBudgetExceededError(RAGServiceError):
     """
 
     pass
+
+
+# -----------------------------------------------------------------------------
+# Reindex Service Exceptions
+# -----------------------------------------------------------------------------
+
+
+class ReindexError(Exception):
+    """Base exception for reindex service errors."""
+
+    pass
+
+
+class ReindexPausedError(ReindexError):
+    """Raised when reindex pauses due to document failure.
+
+    Allows callers to handle pause state and present options
+    to the user (skip, retry, abort).
+    """
+
+    def __init__(self, job_id: str, document_id: str, error: str):
+        self.job_id = job_id
+        self.document_id = document_id
+        self.error = error
+        super().__init__(f"Reindex paused on document {document_id}: {error}")

--- a/ai_ready_rag/db/models.py
+++ b/ai_ready_rag/db/models.py
@@ -202,3 +202,12 @@ class ReindexJob(Base):
     settings_changed = Column(Text, nullable=True)  # JSON encoded dict of changed settings
     temp_collection_name = Column(String, nullable=True)  # Temp collection being built
     created_at = Column(DateTime, default=datetime.utcnow)
+
+    # Phase 3: Failure handling fields
+    failed_document_ids = Column(Text, nullable=True)  # JSON list of failed doc IDs
+    last_error = Column(Text, nullable=True)  # Last error message
+    retry_count = Column(Integer, default=0)  # Retries for current document
+    max_retries = Column(Integer, default=3)  # Max retries before skip
+    paused_at = Column(DateTime, nullable=True)  # When job was paused
+    paused_reason = Column(String, nullable=True)  # 'failure' or 'user_request'
+    auto_skip_failures = Column(Boolean, default=False)  # Skip-all mode

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -373,6 +373,13 @@ export interface ReindexJob {
   completed_at: string | null;
   created_at: string;
   settings_changed: Record<string, unknown> | null;
+  // Phase 3: Failure handling fields
+  last_error: string | null;
+  retry_count: number;
+  max_retries: number;
+  paused_at: string | null;
+  paused_reason: string | null;
+  auto_skip_failures: boolean;
 }
 
 export interface ReindexEstimate {
@@ -380,4 +387,20 @@ export interface ReindexEstimate {
   avg_processing_time_ms: number;
   estimated_total_seconds: number;
   estimated_time_str: string;
+}
+
+// Phase 3: Failure handling
+export type ResumeAction = 'skip' | 'retry' | 'skip_all';
+
+export interface ReindexFailureInfo {
+  document_id: string;
+  filename: string;
+  status: string;
+  error_message: string | null;
+}
+
+export interface ReindexFailuresResponse {
+  job_id: string;
+  failures: ReindexFailureInfo[];
+  total_failures: number;
 }


### PR DESCRIPTION
## Summary
- Implements Phase 3 reindex failure handling with pause/resume workflow
- Extends ReindexJob model with failure tracking fields
- Adds 4 new API endpoints for failure management
- Includes frontend TypeScript types and API functions
- 16 new tests, all 37 advanced settings tests pass

## Changes

### Backend
- Add `ReindexPausedError` exception
- Extend `ReindexJob` model with:
  - `failed_document_ids` (JSON list)
  - `last_error`, `retry_count`, `max_retries`
  - `paused_at`, `paused_reason`, `auto_skip_failures`
- Extend `ReindexService` with pause/resume methods

### API Endpoints
| Endpoint | Description |
|----------|-------------|
| `POST /api/admin/reindex/pause` | Pause running reindex |
| `POST /api/admin/reindex/resume` | Resume with action (skip/retry/skip_all) |
| `GET /api/admin/reindex/failures` | List failed documents |
| `POST /api/admin/reindex/retry/{document_id}` | Retry specific doc |

### Frontend
- TypeScript types for failure handling
- API functions: `pauseReindex`, `resumeReindex`, `getReindexFailures`, `retryReindexDocument`

## Test plan
- [x] All 37 advanced settings tests pass
- [x] New failure handling tests pass
- [x] Ruff linting passes

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)