### PR TITLE
feat: Add reindex failure handling with pause/resume workflow (#68)

### DIFF
--- a/ai_ready_rag/api/admin.py
+++ b/ai_ready_rag/api/admin.py
@@ -1557,6 +1557,13 @@ class ReindexJobResponse(BaseModel):
     completed_at: datetime | None = None
     created_at: datetime
     settings_changed: dict | None = None
+    # Phase 3: Failure handling fields
+    last_error: str | None = None
+    retry_count: int = 0
+    max_retries: int = 3
+    paused_at: datetime | None = None
+    paused_reason: str | None = None
+    auto_skip_failures: bool = False
 
 
 class ReindexEstimate(BaseModel):
@@ -1572,6 +1579,29 @@ class StartReindexRequest(BaseModel):
     """Request to start reindex operation."""
 
     confirm: bool = False
+
+
+class ResumeReindexRequest(BaseModel):
+    """Request to resume a paused reindex."""
+
+    action: Literal["skip", "retry", "skip_all"]
+
+
+class ReindexFailureInfo(BaseModel):
+    """Information about a failed document during reindex."""
+
+    document_id: str
+    filename: str
+    status: str
+    error_message: str | None = None
+
+
+class ReindexFailuresResponse(BaseModel):
+    """Response containing reindex failure details."""
+
+    job_id: str
+    failures: list[ReindexFailureInfo]
+    total_failures: int
 
 
 @router.get("/settings/advanced", response_model=AdvancedSettingsResponse)
@@ -1860,4 +1890,198 @@ def _job_to_response(job) -> ReindexJobResponse:
         completed_at=job.completed_at,
         created_at=job.created_at,
         settings_changed=settings_changed,
+        # Phase 3 fields
+        last_error=job.last_error,
+        retry_count=job.retry_count or 0,
+        max_retries=job.max_retries or 3,
+        paused_at=job.paused_at,
+        paused_reason=job.paused_reason,
+        auto_skip_failures=job.auto_skip_failures or False,
     )
+
+
+# =============================================================================
+# Phase 3: Reindex Failure Handling
+# =============================================================================
+
+
+@router.post("/reindex/pause", response_model=ReindexJobResponse)
+async def pause_reindex(
+    current_user: User = Depends(require_system_admin),
+    db: Session = Depends(get_db),
+):
+    """Pause the current reindex operation.
+
+    Pauses a running reindex job. Use resume to continue.
+
+    Admin only.
+    """
+    from ai_ready_rag.services.reindex_service import ReindexService
+
+    service = ReindexService(db)
+    job = service.get_active_job()
+
+    if not job:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No active reindex job to pause.",
+        )
+
+    if job.status != "running":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot pause job in status '{job.status}'. Only running jobs can be paused.",
+        )
+
+    job = service.pause_job(job.id, reason="user_request")
+    logger.info(f"Admin {current_user.email} paused reindex job {job.id}")
+
+    return _job_to_response(job)
+
+
+@router.post("/reindex/resume", response_model=ReindexJobResponse)
+async def resume_reindex(
+    request: ResumeReindexRequest,
+    current_user: User = Depends(require_system_admin),
+    db: Session = Depends(get_db),
+):
+    """Resume a paused reindex operation.
+
+    Actions:
+    - skip: Skip the failed document and continue
+    - retry: Retry the failed document (up to max_retries)
+    - skip_all: Enable auto-skip mode for all future failures
+
+    Admin only.
+    """
+    from ai_ready_rag.services.reindex_service import ReindexService, ResumeAction
+
+    service = ReindexService(db)
+    job = service.get_active_job()
+
+    if not job:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No active reindex job to resume.",
+        )
+
+    if job.status != "paused":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot resume job in status '{job.status}'. Only paused jobs can be resumed.",
+        )
+
+    # Convert string action to enum
+    action = ResumeAction(request.action)
+
+    # Check retry limit before allowing retry
+    if action == ResumeAction.RETRY and job.retry_count >= job.max_retries:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Max retries ({job.max_retries}) reached. Use 'skip' to continue.",
+        )
+
+    job = service.resume_job(job.id, action)
+    logger.info(f"Admin {current_user.email} resumed reindex job {job.id} with action '{action}'")
+
+    return _job_to_response(job)
+
+
+@router.get("/reindex/failures", response_model=ReindexFailuresResponse)
+async def get_reindex_failures(
+    current_user: User = Depends(require_system_admin),
+    db: Session = Depends(get_db),
+):
+    """Get details about failed documents in the current reindex.
+
+    Returns information about all documents that have failed during
+    the current or most recent reindex job.
+
+    Admin only.
+    """
+    from ai_ready_rag.services.reindex_service import ReindexService
+
+    service = ReindexService(db)
+
+    # Get active job or most recent completed job with failures
+    job = service.get_active_job()
+    if not job:
+        # Get most recent job
+        history = service.get_job_history(limit=1)
+        job = history[0] if history else None
+
+    if not job:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No reindex job found.",
+        )
+
+    failures = service.get_failures(job.id)
+
+    return ReindexFailuresResponse(
+        job_id=job.id,
+        failures=[
+            ReindexFailureInfo(
+                document_id=f["document_id"],
+                filename=f["filename"],
+                status=f["status"],
+                error_message=f.get("error_message"),
+            )
+            for f in failures
+        ],
+        total_failures=len(failures),
+    )
+
+
+@router.post("/reindex/retry/{document_id}", response_model=ReindexJobResponse)
+async def retry_reindex_document(
+    document_id: str,
+    current_user: User = Depends(require_system_admin),
+    db: Session = Depends(get_db),
+):
+    """Retry a specific failed document.
+
+    Removes the document from the failed list and marks it for reprocessing.
+
+    Admin only.
+    """
+    import json
+
+    from ai_ready_rag.services.reindex_service import ReindexService
+
+    service = ReindexService(db)
+    job = service.get_active_job()
+
+    if not job:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No active reindex job.",
+        )
+
+    # Check if document is in failed list before attempting retry
+    failed_ids = []
+    if job.failed_document_ids:
+        try:
+            failed_ids = json.loads(job.failed_document_ids)
+        except json.JSONDecodeError:
+            pass
+
+    if document_id not in failed_ids:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Document {document_id} not in failed list for this job.",
+        )
+
+    job = service.retry_document(job.id, document_id)
+
+    if not job:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Job not found.",
+        )
+
+    logger.info(
+        f"Admin {current_user.email} marked document {document_id} for retry in job {job.id}"
+    )
+
+    return _job_to_response(job)

--- a/ai_ready_rag/core/exceptions.py
+++ b/ai_ready_rag/core/exceptions.py
@@ -127,3 +127,28 @@ class TokenBudgetExceededError(RAGServiceError):
     """
 
     pass
+
+
+# -----------------------------------------------------------------------------
+# Reindex Service Exceptions
+# -----------------------------------------------------------------------------
+
+
+class ReindexError(Exception):
+    """Base exception for reindex service errors."""
+
+    pass
+
+
+class ReindexPausedError(ReindexError):
+    """Raised when reindex pauses due to document failure.
+
+    Allows callers to handle pause state and present options
+    to the user (skip, retry, abort).
+    """
+
+    def __init__(self, job_id: str, document_id: str, error: str):
+        self.job_id = job_id
+        self.document_id = document_id
+        self.error = error
+        super().__init__(f"Reindex paused on document {document_id}: {error}")

--- a/ai_ready_rag/db/models.py
+++ b/ai_ready_rag/db/models.py
@@ -202,3 +202,12 @@ class ReindexJob(Base):
     settings_changed = Column(Text, nullable=True)  # JSON encoded dict of changed settings
     temp_collection_name = Column(String, nullable=True)  # Temp collection being built
     created_at = Column(DateTime, default=datetime.utcnow)
+
+    # Phase 3: Failure handling fields
+    failed_document_ids = Column(Text, nullable=True)  # JSON list of failed doc IDs
+    last_error = Column(Text, nullable=True)  # Last error message
+    retry_count = Column(Integer, default=0)  # Retries for current document
+    max_retries = Column(Integer, default=3)  # Max retries before skip
+    paused_at = Column(DateTime, nullable=True)  # When job was paused
+    paused_reason = Column(String, nullable=True)  # 'failure' or 'user_request'
+    auto_skip_failures = Column(Boolean, default=False)  # Skip-all mode

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -11,6 +11,8 @@ import type {
   AdvancedSettings,
   ReindexJob,
   ReindexEstimate,
+  ResumeAction,
+  ReindexFailuresResponse,
 } from '../types';
 
 /**
@@ -242,4 +244,50 @@ export async function abortReindex(): Promise<ReindexJob> {
 export async function getReindexHistory(limit?: number): Promise<ReindexJob[]> {
   const url = limit ? `/api/admin/reindex/history?limit=${limit}` : '/api/admin/reindex/history';
   return apiClient.get<ReindexJob[]>(url);
+}
+
+// =============================================================================
+// Reindex Failure Handling (Phase 3)
+// =============================================================================
+
+/**
+ * Pause a running reindex job (system admin only).
+ * Use this to manually pause a reindex operation.
+ */
+export async function pauseReindex(): Promise<ReindexJob> {
+  return apiClient.post<ReindexJob>('/api/admin/reindex/pause', {});
+}
+
+/**
+ * Resume a paused reindex job (system admin only).
+ * @param action - What to do: 'skip' (skip failed doc), 'retry' (retry failed doc), or 'skip_all' (auto-skip all failures)
+ */
+export async function resumeReindex(action: ResumeAction): Promise<ReindexJob> {
+  return apiClient.post<ReindexJob>('/api/admin/reindex/resume', { action });
+}
+
+/**
+ * Get details about failed documents in a reindex job (system admin only).
+ * @param jobId - Optional job ID. If not provided, returns failures for active job.
+ */
+export async function getReindexFailures(jobId?: string): Promise<ReindexFailuresResponse> {
+  const url = jobId
+    ? `/api/admin/reindex/failures?job_id=${jobId}`
+    : '/api/admin/reindex/failures';
+  return apiClient.get<ReindexFailuresResponse>(url);
+}
+
+/**
+ * Retry a specific failed document in a reindex job (system admin only).
+ * @param documentId - ID of the document to retry
+ * @param jobId - Optional job ID. If not provided, uses active job.
+ */
+export async function retryReindexDocument(
+  documentId: string,
+  jobId?: string
+): Promise<ReindexJob> {
+  const url = jobId
+    ? `/api/admin/reindex/retry/${documentId}?job_id=${jobId}`
+    : `/api/admin/reindex/retry/${documentId}`;
+  return apiClient.post<ReindexJob>(url, {});
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -387,6 +387,13 @@ export interface ReindexJob {
   completed_at: string | null;
   created_at: string;
   settings_changed: Record<string, unknown> | null;
+  // Phase 3: Failure handling fields
+  last_error: string | null;
+  retry_count: number;
+  max_retries: number;
+  paused_at: string | null;
+  paused_reason: string | null;
+  auto_skip_failures: boolean;
 }
 
 export interface ReindexEstimate {
@@ -394,4 +401,20 @@ export interface ReindexEstimate {
   avg_processing_time_ms: number;
   estimated_total_seconds: number;
   estimated_time_str: string;
+}
+
+// Phase 3: Failure handling
+export type ResumeAction = 'skip' | 'retry' | 'skip_all';
+
+export interface ReindexFailureInfo {
+  document_id: string;
+  filename: string;
+  status: string;
+  error_message: string | null;
+}
+
+export interface ReindexFailuresResponse {
+  job_id: string;
+  failures: ReindexFailureInfo[];
+  total_failures: number;
 }


### PR DESCRIPTION
## Summary
- Implements Phase 3 reindex failure handling with pause/resume workflow
- Extends ReindexJob model with failure tracking fields
- Adds 4 new API endpoints for failure management
- Includes frontend TypeScript types and API functions
- 16 new tests, all 37 advanced settings tests pass

## Changes

### Backend
- Add `ReindexPausedError` exception
- Extend `ReindexJob` model with:
  - `failed_document_ids` (JSON list)
  - `last_error`, `retry_count`, `max_retries`
  - `paused_at`, `paused_reason`, `auto_skip_failures`
- Extend `ReindexService` with pause/resume methods

### API Endpoints
| Endpoint | Description |
|----------|-------------|
| `POST /api/admin/reindex/pause` | Pause running reindex |
| `POST /api/admin/reindex/resume` | Resume with action (skip/retry/skip_all) |
| `GET /api/admin/reindex/failures` | List failed documents |
| `POST /api/admin/reindex/retry/{document_id}` | Retry specific doc |

### Frontend
- TypeScript types for failure handling
- API functions: `pauseReindex`, `resumeReindex`, `getReindexFailures`, `retryReindexDocument`

## Test plan
- [x] All 37 advanced settings tests pass
- [x] New failure handling tests pass
- [x] Ruff linting passes

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)