### PR TITLE
feat: Add upload summary modal with duplicate detection (#80)

### DIFF
--- a/ai_ready_rag/ui/gradio_app.py
+++ b/ai_ready_rag/ui/gradio_app.py
@@ -520,7 +520,6 @@ def create_app() -> gr.Blocks:
                                     datatype=["str", "str", "str", "str"],
                                     interactive=False,
                                     wrap=True,
-                                    height=200,
                                 )
 
                                 # Per-document retry section (#74)

--- a/frontend/src/components/features/documents/UploadErrorMessage.tsx
+++ b/frontend/src/components/features/documents/UploadErrorMessage.tsx
@@ -1,0 +1,71 @@
+import { AlertTriangle, Copy } from 'lucide-react';
+import type { UploadErrorResponse } from '../../../types';
+
+interface UploadErrorMessageProps {
+  error: string;
+  duplicateInfo?: UploadErrorResponse;
+}
+
+/**
+ * Display upload error with detailed info for duplicates.
+ */
+export function UploadErrorMessage({ error, duplicateInfo }: UploadErrorMessageProps) {
+  const isDuplicate = duplicateInfo?.error_code === 'DUPLICATE_FILE';
+
+  if (isDuplicate && duplicateInfo) {
+    return (
+      <div className="flex items-start gap-2 text-xs text-red-600 dark:text-red-400 mt-1">
+        <Copy size={14} className="flex-shrink-0 mt-0.5" />
+        <div>
+          <span className="font-medium">Duplicate file</span>
+          <span className="text-gray-500 dark:text-gray-400">
+            {' '}
+            - matches &quot;{duplicateInfo.existing_filename}&quot;
+          </span>
+          {duplicateInfo.uploaded_at && (
+            <span className="text-gray-400 dark:text-gray-500 text-[10px] block">
+              Uploaded {new Date(duplicateInfo.uploaded_at).toLocaleDateString()}
+            </span>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-start gap-2 text-xs text-red-600 dark:text-red-400 mt-1">
+      <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
+      <span className="truncate">{error}</span>
+    </div>
+  );
+}
+
+/**
+ * Map error code to user-friendly message.
+ */
+export function getErrorMessage(errorResponse?: UploadErrorResponse): string {
+  if (!errorResponse) return 'Upload failed';
+
+  switch (errorResponse.error_code) {
+    case 'DUPLICATE_FILE':
+      return `Duplicate of "${errorResponse.existing_filename}"`;
+    case 'INVALID_FILE_TYPE':
+      return 'File type not allowed';
+    case 'FILE_TOO_LARGE':
+      return 'File exceeds size limit';
+    case 'NO_TAGS':
+      return 'At least one tag required';
+    case 'INVALID_TAGS':
+      return 'One or more tags not found';
+    case 'STORAGE_QUOTA_EXCEEDED':
+      return 'Storage limit reached';
+    case 'OCR_NOT_CONFIGURED':
+      return 'OCR not available';
+    case 'PROCESSING_FAILED':
+      return 'Document processing error';
+    default:
+      return typeof errorResponse.detail === 'string'
+        ? errorResponse.detail
+        : 'Upload failed';
+  }
+}

--- a/frontend/src/components/features/documents/UploadModal.tsx
+++ b/frontend/src/components/features/documents/UploadModal.tsx
@@ -2,8 +2,10 @@ import { useState, useCallback } from 'react';
 import { Modal, Button, Alert } from '../../ui';
 import { UploadDropZone } from './UploadDropZone';
 import { UploadQueue, type QueuedFile, type UploadStatus } from './UploadQueue';
-import { uploadDocument } from '../../../api/documents';
-import type { Tag } from '../../../types';
+import { UploadSummaryModal } from './UploadSummaryModal';
+import { UploadResultsModal } from './UploadResultsModal';
+import { uploadDocument, checkDuplicates } from '../../../api/documents';
+import type { Tag, CheckDuplicatesResponse, UploadResult, UploadErrorResponse } from '../../../types';
 
 interface UploadModalProps {
   isOpen: boolean;
@@ -26,6 +28,14 @@ export function UploadModal({
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
   const [isUploading, setIsUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Duplicate check state
+  const [showSummary, setShowSummary] = useState(false);
+  const [duplicateCheck, setDuplicateCheck] = useState<CheckDuplicatesResponse | null>(null);
+
+  // Results state
+  const [showResults, setShowResults] = useState(false);
+  const [uploadResults, setUploadResults] = useState<UploadResult[]>([]);
 
   const handleFilesSelected = useCallback((files: File[]) => {
     const newFiles: QueuedFile[] = files.map((file) => ({
@@ -51,6 +61,64 @@ export function UploadModal({
     setError(null);
   }, []);
 
+  // Upload files with optional replace mode
+  const uploadFiles = async (files: QueuedFile[], replaceMode: boolean) => {
+    const results: UploadResult[] = [];
+
+    for (const qf of files) {
+      // Mark as uploading
+      setQueuedFiles((prev) =>
+        prev.map((f) =>
+          f.id === qf.id ? { ...f, status: 'uploading' as UploadStatus, progress: 0 } : f
+        )
+      );
+
+      try {
+        const doc = await uploadDocument(qf.file, selectedTagIds, (progress) => {
+          setQueuedFiles((prev) =>
+            prev.map((f) => (f.id === qf.id ? { ...f, progress } : f))
+          );
+        }, replaceMode);
+
+        // Mark as done
+        setQueuedFiles((prev) =>
+          prev.map((f) =>
+            f.id === qf.id ? { ...f, status: 'done' as UploadStatus, progress: 100 } : f
+          )
+        );
+
+        results.push({
+          filename: qf.file.name,
+          status: replaceMode ? 'replaced' : 'success',
+          documentId: doc.id,
+        });
+      } catch (err) {
+        // Extract structured error if available
+        const errorResponse = (err as Error & { response?: UploadErrorResponse }).response;
+        const errorMessage = err instanceof Error ? err.message : 'Upload failed';
+
+        // Mark as failed
+        setQueuedFiles((prev) =>
+          prev.map((f) =>
+            f.id === qf.id
+              ? { ...f, status: 'failed' as UploadStatus, error: errorMessage }
+              : f
+          )
+        );
+
+        results.push({
+          filename: qf.file.name,
+          status: 'failed',
+          error: errorResponse?.error_code === 'DUPLICATE_FILE'
+            ? `Duplicate of "${errorResponse.existing_filename}"`
+            : errorMessage,
+        });
+      }
+    }
+
+    return results;
+  };
+
   const handleUploadAll = async () => {
     if (selectedTagIds.length === 0) {
       setError('Please select at least one tag');
@@ -65,128 +133,194 @@ export function UploadModal({
     setIsUploading(true);
     setError(null);
 
-    for (const qf of filesToUpload) {
-      // Mark as uploading
-      setQueuedFiles((prev) =>
-        prev.map((f) =>
-          f.id === qf.id ? { ...f, status: 'uploading' as UploadStatus, progress: 0 } : f
-        )
-      );
+    try {
+      // Pre-upload duplicate check
+      const filenames = filesToUpload.map((f) => f.file.name);
+      const checkResult = await checkDuplicates(filenames);
 
-      try {
-        await uploadDocument(qf.file, selectedTagIds, (progress) => {
-          setQueuedFiles((prev) =>
-            prev.map((f) => (f.id === qf.id ? { ...f, progress } : f))
-          );
-        });
-
-        // Mark as done
-        setQueuedFiles((prev) =>
-          prev.map((f) =>
-            f.id === qf.id ? { ...f, status: 'done' as UploadStatus, progress: 100 } : f
-          )
-        );
-      } catch (err) {
-        // Mark as failed
-        setQueuedFiles((prev) =>
-          prev.map((f) =>
-            f.id === qf.id
-              ? {
-                  ...f,
-                  status: 'failed' as UploadStatus,
-                  error: err instanceof Error ? err.message : 'Upload failed',
-                }
-              : f
-          )
-        );
+      if (checkResult.duplicates.length > 0) {
+        setDuplicateCheck(checkResult);
+        setShowSummary(true);
+        setIsUploading(false);
+        return;
       }
-    }
 
+      // No duplicates - proceed with upload
+      const results = await uploadFiles(filesToUpload, false);
+      setUploadResults(results);
+      setIsUploading(false);
+      onUploadComplete();
+      setShowResults(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to check duplicates');
+      setIsUploading(false);
+    }
+  };
+
+  const handleSkipDuplicates = async () => {
+    if (!duplicateCheck) return;
+
+    setShowSummary(false);
+    setIsUploading(true);
+
+    // Get unique files only
+    const uniqueFilenames = new Set(duplicateCheck.unique);
+    const filesToUpload = queuedFiles.filter(
+      (f) => f.status === 'queued' && uniqueFilenames.has(f.file.name)
+    );
+
+    // Mark skipped files
+    const skippedResults: UploadResult[] = duplicateCheck.duplicates.map((dup) => ({
+      filename: dup.filename,
+      status: 'skipped' as const,
+    }));
+
+    const uploadedResults = await uploadFiles(filesToUpload, false);
+    setUploadResults([...uploadedResults, ...skippedResults]);
     setIsUploading(false);
     onUploadComplete();
+    setShowResults(true);
+  };
 
-    // Close modal immediately - document table shows processing status
+  const handleReplaceAll = async () => {
+    if (!duplicateCheck) return;
+
+    setShowSummary(false);
+    setIsUploading(true);
+
+    // Upload all files with replace=true
+    const filesToUpload = queuedFiles.filter((f) => f.status === 'queued');
+    const results = await uploadFiles(filesToUpload, true);
+    setUploadResults(results);
+    setIsUploading(false);
+    onUploadComplete();
+    setShowResults(true);
+  };
+
+  const handleCancelSummary = () => {
+    setShowSummary(false);
+    setDuplicateCheck(null);
+  };
+
+  const handleViewDocuments = () => {
+    setShowResults(false);
+    resetAndClose();
+  };
+
+  const handleResultsClose = () => {
+    setShowResults(false);
+    resetAndClose();
+  };
+
+  const resetAndClose = () => {
     setQueuedFiles([]);
     setSelectedTagIds([]);
     setError(null);
+    setDuplicateCheck(null);
+    setUploadResults([]);
     onClose();
   };
 
   const handleClose = () => {
     if (!isUploading) {
-      setQueuedFiles([]);
-      setSelectedTagIds([]);
-      setError(null);
-      onClose();
+      resetAndClose();
     }
   };
 
   const hasQueuedFiles = queuedFiles.some((f) => f.status === 'queued');
-  const allDone = queuedFiles.length > 0 && queuedFiles.every((f) => f.status === 'done');
+
+  // Get unique files for summary modal
+  const getUniqueFiles = (): File[] => {
+    if (!duplicateCheck) return [];
+    const uniqueFilenames = new Set(duplicateCheck.unique);
+    return queuedFiles
+      .filter((qf) => uniqueFilenames.has(qf.file.name))
+      .map((qf) => qf.file);
+  };
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} title="Upload Documents" size="lg">
-      <div className="space-y-6">
-        {/* Drop Zone */}
-        <UploadDropZone
-          onFilesSelected={handleFilesSelected}
-          disabled={isUploading}
-        />
+    <>
+      <Modal isOpen={isOpen && !showSummary && !showResults} onClose={handleClose} title="Upload Documents" size="lg">
+        <div className="space-y-6">
+          {/* Drop Zone */}
+          <UploadDropZone
+            onFilesSelected={handleFilesSelected}
+            disabled={isUploading}
+          />
 
-        {/* Tag Selection */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            Tags <span className="text-red-500">*</span>
-          </label>
-          <div className="flex flex-wrap gap-2">
-            {tags.map((tag) => (
-              <button
-                key={tag.id}
-                onClick={() => handleTagToggle(tag.id)}
-                disabled={isUploading}
-                className={`
-                  px-3 py-1.5 rounded-full text-sm font-medium transition-all
-                  ${selectedTagIds.includes(tag.id)
-                    ? 'bg-primary text-white'
-                    : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
-                  }
-                  disabled:opacity-50 disabled:cursor-not-allowed
-                `}
-              >
-                {tag.display_name}
-              </button>
-            ))}
-            {tags.length === 0 && (
-              <span className="text-sm text-gray-500">No tags available</span>
-            )}
+          {/* Tag Selection */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Tags <span className="text-red-500">*</span>
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {tags.map((tag) => (
+                <button
+                  key={tag.id}
+                  onClick={() => handleTagToggle(tag.id)}
+                  disabled={isUploading}
+                  className={`
+                    px-3 py-1.5 rounded-full text-sm font-medium transition-all
+                    ${selectedTagIds.includes(tag.id)
+                      ? 'bg-primary text-white'
+                      : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
+                    }
+                    disabled:opacity-50 disabled:cursor-not-allowed
+                  `}
+                >
+                  {tag.display_name}
+                </button>
+              ))}
+              {tags.length === 0 && (
+                <span className="text-sm text-gray-500">No tags available</span>
+              )}
+            </div>
           </div>
-        </div>
 
-        {/* Error */}
-        {error && (
-          <Alert variant="danger" onClose={() => setError(null)}>
-            {error}
-          </Alert>
-        )}
+          {/* Error */}
+          {error && (
+            <Alert variant="danger" onClose={() => setError(null)}>
+              {error}
+            </Alert>
+          )}
 
-        {/* Upload Queue */}
-        <UploadQueue files={queuedFiles} onRemove={handleRemoveFile} />
+          {/* Upload Queue */}
+          <UploadQueue files={queuedFiles} onRemove={handleRemoveFile} />
 
-        {/* Actions */}
-        <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
-          <Button variant="secondary" onClick={handleClose} disabled={isUploading}>
-            {allDone ? 'Close' : 'Cancel'}
-          </Button>
-          {!allDone && (
+          {/* Actions */}
+          <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+            <Button variant="secondary" onClick={handleClose} disabled={isUploading}>
+              Cancel
+            </Button>
             <Button
               onClick={handleUploadAll}
               disabled={!hasQueuedFiles || isUploading || selectedTagIds.length === 0}
             >
-              {isUploading ? 'Uploading...' : 'Upload All'}
+              {isUploading ? 'Checking...' : 'Upload All'}
             </Button>
-          )}
+          </div>
         </div>
-      </div>
-    </Modal>
+      </Modal>
+
+      {/* Summary Modal */}
+      <UploadSummaryModal
+        isOpen={showSummary}
+        onClose={handleCancelSummary}
+        duplicates={duplicateCheck?.duplicates ?? []}
+        uniqueFiles={getUniqueFiles()}
+        onSkipDuplicates={handleSkipDuplicates}
+        onReplaceAll={handleReplaceAll}
+        onCancel={handleCancelSummary}
+        isLoading={isUploading}
+      />
+
+      {/* Results Modal */}
+      <UploadResultsModal
+        isOpen={showResults}
+        onClose={handleResultsClose}
+        results={uploadResults}
+        onViewDocuments={handleViewDocuments}
+      />
+    </>
   );
 }

--- a/frontend/src/components/features/documents/UploadResultsModal.tsx
+++ b/frontend/src/components/features/documents/UploadResultsModal.tsx
@@ -1,0 +1,180 @@
+import { CheckCircle, XCircle, RefreshCw, SkipForward } from 'lucide-react';
+import { Modal, Button, Alert } from '../../ui';
+import type { UploadResult } from '../../../types';
+
+interface UploadResultsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  results: UploadResult[];
+  onViewDocuments: () => void;
+}
+
+/**
+ * Modal showing upload results after all files are processed.
+ */
+export function UploadResultsModal({
+  isOpen,
+  onClose,
+  results,
+  onViewDocuments,
+}: UploadResultsModalProps) {
+  const successful = results.filter((r) => r.status === 'success');
+  const replaced = results.filter((r) => r.status === 'replaced');
+  const failed = results.filter((r) => r.status === 'failed');
+  const skipped = results.filter((r) => r.status === 'skipped');
+
+  const totalUploaded = successful.length + replaced.length;
+  const hasFailures = failed.length > 0;
+
+  const getStatusIcon = (status: UploadResult['status']) => {
+    switch (status) {
+      case 'success':
+        return <CheckCircle size={16} className="text-green-500" />;
+      case 'replaced':
+        return <RefreshCw size={16} className="text-amber-500" />;
+      case 'failed':
+        return <XCircle size={16} className="text-red-500" />;
+      case 'skipped':
+        return <SkipForward size={16} className="text-gray-400" />;
+    }
+  };
+
+  const getStatusLabel = (status: UploadResult['status']) => {
+    switch (status) {
+      case 'success':
+        return 'Uploaded';
+      case 'replaced':
+        return 'Replaced';
+      case 'failed':
+        return 'Failed';
+      case 'skipped':
+        return 'Skipped';
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Upload Results" size="lg">
+      <div className="space-y-6">
+        {/* Summary */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <div className="text-center p-3 bg-green-50 dark:bg-green-900/20 rounded-lg">
+            <div className="text-2xl font-bold text-green-600 dark:text-green-400">
+              {successful.length}
+            </div>
+            <div className="text-xs text-green-700 dark:text-green-300">Uploaded</div>
+          </div>
+          <div className="text-center p-3 bg-amber-50 dark:bg-amber-900/20 rounded-lg">
+            <div className="text-2xl font-bold text-amber-600 dark:text-amber-400">
+              {replaced.length}
+            </div>
+            <div className="text-xs text-amber-700 dark:text-amber-300">Replaced</div>
+          </div>
+          <div className="text-center p-3 bg-red-50 dark:bg-red-900/20 rounded-lg">
+            <div className="text-2xl font-bold text-red-600 dark:text-red-400">
+              {failed.length}
+            </div>
+            <div className="text-xs text-red-700 dark:text-red-300">Failed</div>
+          </div>
+          <div className="text-center p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
+            <div className="text-2xl font-bold text-gray-600 dark:text-gray-400">
+              {skipped.length}
+            </div>
+            <div className="text-xs text-gray-700 dark:text-gray-300">Skipped</div>
+          </div>
+        </div>
+
+        {/* Status Message */}
+        {hasFailures ? (
+          <Alert variant="warning" title="Some uploads failed">
+            {failed.length} file{failed.length !== 1 ? 's' : ''} could not be uploaded.
+            {totalUploaded > 0 && ` ${totalUploaded} file${totalUploaded !== 1 ? 's' : ''} uploaded successfully.`}
+          </Alert>
+        ) : totalUploaded > 0 ? (
+          <Alert variant="success" title="Upload complete">
+            All {totalUploaded} file{totalUploaded !== 1 ? 's' : ''} uploaded successfully.
+          </Alert>
+        ) : (
+          <Alert variant="info" title="No files uploaded">
+            All files were skipped.
+          </Alert>
+        )}
+
+        {/* Failed Files List */}
+        {failed.length > 0 && (
+          <div>
+            <h4 className="text-sm font-medium text-red-600 dark:text-red-400 mb-2">
+              Failed Uploads
+            </h4>
+            <div className="border border-red-200 dark:border-red-800 rounded-lg divide-y divide-red-100 dark:divide-red-800/50">
+              {failed.map((result) => (
+                <div
+                  key={result.filename}
+                  className="px-3 py-2 flex items-start gap-2"
+                >
+                  <XCircle size={16} className="text-red-500 flex-shrink-0 mt-0.5" />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                      {result.filename}
+                    </div>
+                    {result.error && (
+                      <div className="text-xs text-red-600 dark:text-red-400 mt-0.5">
+                        {result.error}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* All Results (collapsible if many) */}
+        {results.length > 0 && results.length <= 10 && (
+          <div>
+            <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              All Files
+            </h4>
+            <div className="border border-gray-200 dark:border-gray-700 rounded-lg divide-y divide-gray-100 dark:divide-gray-800">
+              {results.map((result) => (
+                <div
+                  key={result.filename}
+                  className="px-3 py-2 flex items-center justify-between gap-2"
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    {getStatusIcon(result.status)}
+                    <span className="text-sm text-gray-900 dark:text-gray-100 truncate">
+                      {result.filename}
+                    </span>
+                  </div>
+                  <span
+                    className={`
+                      text-xs px-2 py-0.5 rounded-full flex-shrink-0
+                      ${result.status === 'success' ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300' : ''}
+                      ${result.status === 'replaced' ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300' : ''}
+                      ${result.status === 'failed' ? 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300' : ''}
+                      ${result.status === 'skipped' ? 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400' : ''}
+                    `}
+                  >
+                    {getStatusLabel(result.status)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+          <Button variant="secondary" onClick={onClose}>
+            Close
+          </Button>
+          {totalUploaded > 0 && (
+            <Button variant="primary" onClick={onViewDocuments}>
+              View Documents
+            </Button>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/features/documents/UploadSummaryModal.tsx
+++ b/frontend/src/components/features/documents/UploadSummaryModal.tsx
@@ -1,0 +1,134 @@
+import { AlertTriangle, Copy, FileText } from 'lucide-react';
+import { Modal, Button, Alert } from '../../ui';
+import type { DuplicateInfo } from '../../../types';
+
+interface UploadSummaryModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  duplicates: DuplicateInfo[];
+  uniqueFiles: File[];
+  onSkipDuplicates: () => void;
+  onReplaceAll: () => void;
+  onCancel: () => void;
+  isLoading?: boolean;
+}
+
+/**
+ * Modal shown when duplicates are detected during pre-upload check.
+ * User can choose to skip duplicates, replace all, or cancel.
+ */
+export function UploadSummaryModal({
+  isOpen,
+  onClose,
+  duplicates,
+  uniqueFiles,
+  onSkipDuplicates,
+  onReplaceAll,
+  onCancel,
+  isLoading = false,
+}: UploadSummaryModalProps) {
+  const hasUnique = uniqueFiles.length > 0;
+  const hasDuplicates = duplicates.length > 0;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Duplicate Files Detected" size="lg">
+      <div className="space-y-6">
+        {/* Warning Alert */}
+        <Alert variant="warning" title="Duplicates Found">
+          {duplicates.length} file{duplicates.length !== 1 ? 's' : ''} already exist
+          {duplicates.length !== 1 ? '' : 's'} in the system.
+          {hasUnique && (
+            <span>
+              {' '}
+              {uniqueFiles.length} unique file{uniqueFiles.length !== 1 ? 's' : ''} will be uploaded.
+            </span>
+          )}
+        </Alert>
+
+        {/* Duplicates List */}
+        {hasDuplicates && (
+          <div>
+            <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2">
+              <Copy size={16} />
+              Duplicate Files ({duplicates.length})
+            </h4>
+            <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50 dark:bg-gray-800">
+                  <tr>
+                    <th className="text-left px-3 py-2 text-gray-600 dark:text-gray-400">
+                      Your File
+                    </th>
+                    <th className="text-left px-3 py-2 text-gray-600 dark:text-gray-400">
+                      Existing File
+                    </th>
+                    <th className="text-left px-3 py-2 text-gray-600 dark:text-gray-400">
+                      Uploaded
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                  {duplicates.map((dup) => (
+                    <tr key={dup.filename} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                      <td className="px-3 py-2 text-gray-900 dark:text-gray-100 truncate max-w-[150px]">
+                        {dup.filename}
+                      </td>
+                      <td className="px-3 py-2 text-gray-600 dark:text-gray-400 truncate max-w-[150px]">
+                        {dup.existing_filename}
+                      </td>
+                      <td className="px-3 py-2 text-gray-500 dark:text-gray-500 text-xs">
+                        {new Date(dup.uploaded_at).toLocaleDateString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {/* Unique Files List */}
+        {hasUnique && (
+          <div>
+            <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2">
+              <FileText size={16} />
+              New Files ({uniqueFiles.length})
+            </h4>
+            <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-3 max-h-32 overflow-y-auto">
+              <ul className="space-y-1">
+                {uniqueFiles.map((file) => (
+                  <li
+                    key={file.name}
+                    className="text-sm text-gray-600 dark:text-gray-400 truncate"
+                  >
+                    {file.name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex flex-col sm:flex-row justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+          <Button variant="secondary" onClick={onCancel} disabled={isLoading}>
+            Cancel
+          </Button>
+          {hasUnique && (
+            <Button variant="primary" onClick={onSkipDuplicates} disabled={isLoading}>
+              {isLoading ? 'Uploading...' : `Upload ${uniqueFiles.length} New File${uniqueFiles.length !== 1 ? 's' : ''}`}
+            </Button>
+          )}
+          <Button
+            variant="warning"
+            onClick={onReplaceAll}
+            disabled={isLoading}
+            icon={AlertTriangle}
+          >
+            {isLoading ? 'Replacing...' : 'Replace All'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/features/documents/index.ts
+++ b/frontend/src/components/features/documents/index.ts
@@ -5,5 +5,8 @@ export { BulkActions } from './BulkActions';
 export { UploadDropZone } from './UploadDropZone';
 export { UploadQueue, type QueuedFile, type UploadStatus } from './UploadQueue';
 export { UploadModal } from './UploadModal';
+export { UploadSummaryModal } from './UploadSummaryModal';
+export { UploadResultsModal } from './UploadResultsModal';
+export { UploadErrorMessage, getErrorMessage } from './UploadErrorMessage';
 export { TagEditModal } from './TagEditModal';
 export { ConfirmModal } from './ConfirmModal';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -418,3 +418,44 @@ export interface ReindexFailuresResponse {
   failures: ReindexFailureInfo[];
   total_failures: number;
 }
+
+// Duplicate check types
+export interface DuplicateInfo {
+  filename: string;
+  existing_id: string;
+  existing_filename: string;
+  uploaded_at: string; // ISO 8601
+}
+
+export interface CheckDuplicatesResponse {
+  duplicates: DuplicateInfo[];
+  unique: string[];
+}
+
+// Structured 409 error response for duplicates
+export interface DuplicateErrorDetail {
+  detail: string;
+  error_code: string;
+  existing_id: string;
+  existing_filename: string;
+  uploaded_at: string; // ISO 8601
+}
+
+// Standard error response structure
+export interface UploadErrorResponse {
+  detail: string;
+  error_code?: string;
+  existing_id?: string;
+  existing_filename?: string;
+  uploaded_at?: string;
+}
+
+// Upload results for modal
+export type UploadResultStatus = 'success' | 'failed' | 'replaced' | 'skipped';
+
+export interface UploadResult {
+  filename: string;
+  status: UploadResultStatus;
+  error?: string;
+  documentId?: string;
+}


### PR DESCRIPTION
## Summary
- Add pre-upload duplicate detection with user options (Skip/Replace/Cancel)
- Add post-upload results modal showing success/failed/skipped/replaced counts
- Enhance 409 error responses with structured details
- Add `replace=true` parameter to overwrite existing documents

## Changes

### Backend
- New `POST /api/documents/check-duplicates` endpoint
- Enhanced 409 response with `error_code`, `existing_id`, `existing_filename`, `uploaded_at`
- `replace` query parameter on upload endpoint for atomic replacement

### Frontend
- `UploadSummaryModal` - Pre-upload duplicate review
- `UploadResultsModal` - Post-upload status display  
- `UploadErrorMessage` - User-friendly error mapping
- Integrated duplicate check flow into `UploadModal`

### Tests
- 8 new tests for duplicate detection and replace functionality

## Test plan
- [x] Upload new files (no duplicates) - shows results modal
- [x] Upload duplicate files - shows summary modal
- [x] Skip Duplicates action works
- [x] Replace All action works
- [x] Cancel action closes modal
- [x] Mixed upload (new + duplicates) shows correct counts
- [ ] Unsupported file type error feedback (follow-up issue needed)
- [x] Modal dismissibility
- [x] Upload flow works with main button

Closes #80

🤖 Generated with [Claude Code](https://claude.ai/code)