### PR TITLE
feat: System admin bypasses tag filtering during cache warming (#107)

### DIFF
--- a/ai_ready_rag/services/rag_service.py
+++ b/ai_ready_rag/services/rag_service.py
@@ -101,7 +101,7 @@ class RAGRequest:
     """Input for RAG generation."""
 
     query: str
-    user_tags: list[str]
+    user_tags: list[str] | None  # None = no tag filtering (system admin bypass)
     tenant_id: str = "default"
     chat_history: list[ChatMessage] | None = None
     model: str | None = None
@@ -615,7 +615,7 @@ class RAGService:
     async def get_quality_context(
         self,
         query: str,
-        user_tags: list[str],
+        user_tags: list[str] | None,
         tenant_id: str,
         max_chunks: int = 8,
     ) -> list[SearchResult]:
@@ -632,7 +632,8 @@ class RAGService:
 
         Args:
             query: User's question
-            user_tags: User's access tags
+            user_tags: User's access tags. None = no tag filtering
+                (system admin bypass), empty list = public only.
             tenant_id: Tenant identifier
             max_chunks: Maximum chunks to return
 


### PR DESCRIPTION
## Summary
- System admin now bypasses tag filtering during cache warming operations
- Introduces sentinel value pattern: `user_tags=None` means "no tag filtering"
- Preserves security: `user_tags=[]` still means "public docs only"

## Changes
- **vector_service.py**: `search()` accepts `user_tags: list[str] | None`
- **rag_service.py**: `get_quality_context()` passes through `None`
- **admin.py**: `_warm_file_task()` detects system_admin and sets `admin_tags=None`

## Security Boundary

| `user_tags` value | Behavior |
|-------------------|----------|
| `None` | No tag filtering (system admin) |
| `[]` | Only public docs (preserved) |
| `["hr"]` | Public + hr docs (normal user) |

## Test plan
- [x] Linting passes
- [x] Unit tests pass (55 tests)
- [ ] Manual test: Admin with no tags can warm cache

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)