### PR TITLE
feat: Fixed-height chat window with scroll behavior + responsive container (#108)

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -20,7 +20,7 @@ export function Layout({ children }: LayoutProps) {
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
       <Header />
       <Nav />
-      <main className="w-1/2 mx-auto py-6">
+      <main className="max-w-7xl mx-auto px-4 py-6">
         {children}
       </main>
 


### PR DESCRIPTION
## Summary
- Chat window now has fixed height (500px / 60vh max) with scroll
- Auto-scroll only triggers when user is at bottom (preserves reading history)
- Floating "scroll to bottom" button appears when scrolled up
- Container width changed from `w-1/2` to `max-w-7xl` for responsive design

## Changes
- **Layout.tsx**: Changed `w-1/2 mx-auto py-6` → `max-w-7xl mx-auto px-4 py-6`
- **MessageList.tsx**: Added scroll tracking, conditional auto-scroll, floating button

## Features
- Fixed 500px height (capped at 60vh on smaller screens)
- Smart auto-scroll: only scrolls to bottom if user was already there
- Floating ArrowDown button when user scrolls up to read history
- Responsive container matches Header/Nav pattern

## Test plan
- [x] ESLint passes
- [x] Build succeeds
- [ ] Manual test: Chat scroll behavior
- [ ] Manual test: Responsive container on different screen sizes

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)