### PR TITLE
feat: Create warming_queue SQLite table and model (#115)

### DIFF
--- a/ai_ready_rag/db/models.py
+++ b/ai_ready_rag/db/models.py
@@ -3,7 +3,18 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, String, Table, Text
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Table,
+    Text,
+)
 from sqlalchemy.orm import relationship
 
 from ai_ready_rag.db.database import Base
@@ -261,3 +272,35 @@ class CacheAccessLog(Base):
     query_text = Column(Text, nullable=False)
     was_hit = Column(Boolean, nullable=False)
     accessed_at = Column(DateTime, default=datetime.utcnow, index=True)
+
+
+class WarmingQueue(Base):
+    """Persistent queue for cache warming jobs."""
+
+    __tablename__ = "warming_queue"
+    __table_args__ = (
+        Index("idx_warming_queue_fifo", "status", "created_at"),
+        Index("idx_warming_queue_status", "status"),
+        Index("idx_warming_queue_completed", "completed_at"),
+        Index("idx_warming_queue_lease", "worker_lease_expires_at"),
+    )
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    file_path = Column(String, nullable=False)
+    file_checksum = Column(String, nullable=False)
+    source_type = Column(String, nullable=False)  # 'manual' | 'upload' | 'sctp'
+    original_filename = Column(String, nullable=True)
+    total_queries = Column(Integer, nullable=False)
+    processed_queries = Column(Integer, default=0)
+    failed_queries = Column(Integer, default=0)
+    byte_offset = Column(Integer, default=0)
+    status = Column(String, default="pending")  # pending|running|paused|completed|failed|cancelled
+    is_paused = Column(Boolean, default=False)
+    is_cancel_requested = Column(Boolean, default=False)
+    worker_id = Column(String, nullable=True)
+    worker_lease_expires_at = Column(DateTime, nullable=True)
+    error_message = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    started_at = Column(DateTime, nullable=True)
+    completed_at = Column(DateTime, nullable=True)
+    created_by = Column(String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)


### PR DESCRIPTION
## Summary
- Add `WarmingQueue` SQLAlchemy model for persistent job queue
- 19 fields for complete job tracking
- 4 indexes for efficient queries (FIFO, status, cleanup, lease)
- Supports byte offset resume and worker leasing

## Test plan
- [x] Model imports successfully
- [x] Linting passes
- [x] 507 tests pass

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)