### PR TITLE
feat: Create warming_failed_queries and warming_sse_events tables (#116)

### DIFF
--- a/ai_ready_rag/config.py
+++ b/ai_ready_rag/config.py
@@ -142,6 +142,10 @@ class Settings(BaseSettings):
     warming_archive_completed: bool = False  # Archive completed jobs for audit
     warming_checkpoint_interval: int = 1  # Save progress every N queries
 
+    # SSE settings
+    sse_event_buffer_size: int = 1000  # Ring buffer size for replay
+    sse_heartbeat_seconds: int = 30  # Heartbeat interval
+
     # Document Management
     upload_dir: str = "./data/uploads"
     max_upload_size_mb: int = 100

--- a/ai_ready_rag/db/models.py
+++ b/ai_ready_rag/db/models.py
@@ -3,7 +3,18 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, String, Table, Text
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Table,
+    Text,
+)
 from sqlalchemy.orm import relationship
 
 from ai_ready_rag.db.database import Base
@@ -261,3 +272,68 @@ class CacheAccessLog(Base):
     query_text = Column(Text, nullable=False)
     was_hit = Column(Boolean, nullable=False)
     accessed_at = Column(DateTime, default=datetime.utcnow, index=True)
+
+
+class WarmingQueue(Base):
+    """Persistent cache warming job queue."""
+
+    __tablename__ = "warming_queue"
+    __table_args__ = (
+        Index("idx_warming_queue_fifo", "status", "created_at"),
+        Index("idx_warming_queue_status", "status"),
+        Index("idx_warming_queue_completed", "completed_at"),
+        Index("idx_warming_queue_lease", "worker_lease_expires_at"),
+    )
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    file_path = Column(Text, nullable=False)  # Path to query file (immutable)
+    file_checksum = Column(String, nullable=False)  # SHA256 for integrity verification
+    source_type = Column(String, nullable=False)  # 'manual' | 'upload' | 'sctp'
+    original_filename = Column(String, nullable=True)  # User-friendly name
+    total_queries = Column(Integer, nullable=False)  # Total queries in file
+    processed_queries = Column(Integer, default=0)
+    failed_queries = Column(Integer, default=0)
+    byte_offset = Column(Integer, default=0)  # File position for resume
+    status = Column(String, default="pending")  # pending|running|paused|completed|failed|cancelled
+    is_paused = Column(Boolean, default=False)  # Persisted pause flag
+    is_cancel_requested = Column(Boolean, default=False)  # Graceful cancel flag
+    worker_id = Column(String, nullable=True)  # Lease: which worker owns this job
+    worker_lease_expires_at = Column(DateTime, nullable=True)  # Lease expiry
+    error_message = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    started_at = Column(DateTime, nullable=True)
+    completed_at = Column(DateTime, nullable=True)
+    created_by = Column(String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+
+
+class WarmingFailedQuery(Base):
+    """Failed queries during cache warming jobs."""
+
+    __tablename__ = "warming_failed_queries"
+    __table_args__ = (Index("idx_warming_failed_job", "job_id"),)
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    job_id = Column(String, ForeignKey("warming_queue.id", ondelete="CASCADE"), nullable=False)
+    query = Column(Text, nullable=False)
+    line_number = Column(Integer, nullable=False)
+    error_message = Column(Text, nullable=True)
+    error_type = Column(String, nullable=True)  # Exception class name
+    retry_count = Column(Integer, default=0)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class WarmingSSEEvent(Base):
+    """SSE events ring buffer for cache warming progress replay."""
+
+    __tablename__ = "warming_sse_events"
+    __table_args__ = (
+        Index("idx_sse_events_job", "job_id"),
+        Index("idx_sse_events_created", "created_at"),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    event_id = Column(String, unique=True, nullable=False)  # UUID for client tracking
+    event_type = Column(String, nullable=False)  # 'progress', 'job_started', etc.
+    job_id = Column(String, nullable=True)  # Nullable for heartbeats
+    payload = Column(Text, nullable=False)  # JSON event data
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/ai_ready_rag/services/sse_buffer_service.py
+++ b/ai_ready_rag/services/sse_buffer_service.py
@@ -1,0 +1,138 @@
+"""SSE event ring buffer service for cache warming progress replay."""
+
+import json
+import logging
+import uuid
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from ai_ready_rag.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+def store_sse_event(
+    db: Session,
+    event_type: str,
+    job_id: str | None,
+    payload: dict,
+) -> str:
+    """Store SSE event in ring buffer.
+
+    Args:
+        db: Database session
+        event_type: Event type (e.g., 'progress', 'job_started')
+        job_id: Associated job ID (nullable for heartbeats)
+        payload: Event data dictionary
+
+    Returns:
+        event_id: UUID string for client tracking
+    """
+    from ai_ready_rag.db.models import WarmingSSEEvent
+
+    event_id = str(uuid.uuid4())
+
+    event = WarmingSSEEvent(
+        event_id=event_id,
+        event_type=event_type,
+        job_id=job_id,
+        payload=json.dumps(payload),
+        created_at=datetime.utcnow(),
+    )
+    db.add(event)
+    db.commit()
+
+    logger.debug(f"Stored SSE event: {event_type} for job {job_id}")
+    return event_id
+
+
+def get_events_since(db: Session, last_event_id: str | None) -> list[dict]:
+    """Get events after a specific event_id for replay.
+
+    Args:
+        db: Database session
+        last_event_id: Last event ID received by client (None for all events)
+
+    Returns:
+        List of event dictionaries with event_id, event_type, job_id, payload, created_at
+    """
+    from ai_ready_rag.db.models import WarmingSSEEvent
+
+    if last_event_id is None:
+        # No last_event_id, return recent events up to buffer size
+        settings = get_settings()
+        events = (
+            db.query(WarmingSSEEvent)
+            .order_by(WarmingSSEEvent.id.desc())
+            .limit(settings.sse_event_buffer_size)
+            .all()
+        )
+        # Reverse to get chronological order
+        events = list(reversed(events))
+    else:
+        # Find the row ID for the last_event_id
+        last_event = (
+            db.query(WarmingSSEEvent).filter(WarmingSSEEvent.event_id == last_event_id).first()
+        )
+        if last_event is None:
+            # Event not found, return empty (client too far behind)
+            return []
+
+        # Get all events after that row ID
+        events = (
+            db.query(WarmingSSEEvent)
+            .filter(WarmingSSEEvent.id > last_event.id)
+            .order_by(WarmingSSEEvent.id.asc())
+            .all()
+        )
+
+    return [
+        {
+            "event_id": e.event_id,
+            "event_type": e.event_type,
+            "job_id": e.job_id,
+            "payload": json.loads(e.payload),
+            "created_at": e.created_at.isoformat() if e.created_at else None,
+        }
+        for e in events
+    ]
+
+
+def prune_old_events(db: Session) -> int:
+    """Prune events beyond buffer size, keeping most recent.
+
+    Args:
+        db: Database session
+
+    Returns:
+        Number of events deleted
+    """
+    from ai_ready_rag.db.models import WarmingSSEEvent
+
+    settings = get_settings()
+    buffer_size = settings.sse_event_buffer_size
+
+    # Count total events
+    total_count = db.query(WarmingSSEEvent).count()
+    if total_count <= buffer_size:
+        return 0
+
+    # Find the cutoff ID (keep events with id > cutoff)
+    cutoff_event = (
+        db.query(WarmingSSEEvent).order_by(WarmingSSEEvent.id.desc()).offset(buffer_size).first()
+    )
+
+    if cutoff_event is None:
+        return 0
+
+    # Delete events with id <= cutoff
+    deleted = (
+        db.query(WarmingSSEEvent)
+        .filter(WarmingSSEEvent.id <= cutoff_event.id)
+        .delete(synchronize_session=False)
+    )
+    db.commit()
+
+    logger.info(f"Pruned {deleted} old SSE events from ring buffer")
+    return deleted


### PR DESCRIPTION
## Summary
- Add `WarmingFailedQuery` model for tracking failed queries during warming
- Add `WarmingSSEEvent` model as ring buffer for SSE event replay
- Add `sse_buffer_service.py` with helper functions for storing, replaying, and pruning events

## Models Added
- **WarmingFailedQuery**: job_id (FK), query, line_number, error_message, error_type, retry_count
- **WarmingSSEEvent**: Integer PK (for ordering), event_id, event_type, job_id, payload

## Service Functions
- `store_sse_event()` - Store event and return event_id
- `get_events_since()` - Get events after last_event_id for replay
- `prune_old_events()` - Keep buffer under configured size

## Test plan
- [x] Models import successfully
- [x] Service functions import successfully
- [x] Linting passes
- [x] 507 tests pass

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)