### PR TITLE
fix: Make Cancel/Pause buttons responsive during stuck LLM calls (#133)

### DIFF
--- a/ai_ready_rag/config.py
+++ b/ai_ready_rag/config.py
@@ -149,6 +149,7 @@ class Settings(BaseSettings):
     # Cache Warming - Retry settings
     warming_max_retries: int = 3
     warming_retry_delays: str = "5,30,120"  # Comma-separated seconds for exponential backoff
+    warming_cancel_timeout_seconds: int = 5  # Max wait after cancel before abandoning query
 
     # Cache Warming - SCTP settings (optional, disabled by default)
     sctp_enabled: bool = False

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -535,7 +535,7 @@ export interface WarmFileResponse {
 // Cache Warming Queue Types
 // =============================================================================
 
-export type WarmingJobStatus = 'pending' | 'running' | 'paused' | 'completed' | 'failed';
+export type WarmingJobStatus = 'pending' | 'running' | 'paused' | 'completed' | 'failed' | 'cancelled';
 
 export interface WarmingJob {
   id: string;
@@ -549,6 +549,9 @@ export interface WarmingJob {
   started_at: string | null;
   completed_at: string | null;
   triggered_by: string;
+  // Transitional state flags
+  is_cancel_requested?: boolean;
+  is_paused?: boolean;
 }
 
 export interface WarmingJobListResponse {


### PR DESCRIPTION
## Summary
- Fix Cancel/Pause buttons that had no effect during stuck LLM calls
- Add cancel timeout wrapper with 5-second abandonment for Cancel
- Add graceful wait-for-completion behavior for Pause
- Add "Cancelling..."/"Pausing..." transitional UI states

## Test plan
- [x] Backend linting passes (ruff check)
- [x] Backend tests pass (111 warming tests, 555 total)
- [x] Frontend build passes
- [x] Manual testing on Spark server with slow LLM queries

## Changes

### Backend
- `config.py`: Add `warming_cancel_timeout_seconds` setting (default: 5)
- `warming_worker.py`: 
  - Add `_warm_query_with_cancel_check()` wrapper that polls every 1s
  - Cancel: Wait up to 5s, then abandon query and mark as failed
  - Pause: Wait for current query to complete (graceful)
  - Add lease validation in `_should_stop()` to prevent cross-worker interference
  - Add `_interruptible_sleep()` for cancel-aware retry delays
  - Add `asyncio.TimeoutError` to retryable exceptions
- `admin.py`: Emit SSE events on cancel/pause for immediate UI updates

### Frontend
- `index.ts`: Add 'cancelled' to WarmingJobStatus, add transitional flags
- `CacheWarmingCard.tsx`: 
  - Show "Cancelling..." when `is_cancel_requested && status === 'running'`
  - Show "Pausing..." when `is_paused && status === 'running'`
  - Add tooltips explaining transitional states

## State Machine
```
running → cancelling → cancelled (abandon after 5s timeout)
running → pausing → paused (wait for query completion)
```

## Artifacts
- MAP-PLAN: `.agents/outputs/map-plan-133-020326.md`
- PATCH: `.agents/outputs/patch-133-020326.md`
- PROVE: `.agents/outputs/prove-133-020326.md`

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)