### PR TITLE
feat: Add RAG Quality view with tab navigation (#155)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { TagsView } from './views/TagsView';
 import { UsersView } from './views/UsersView';
 import { SettingsView } from './views/SettingsView';
 import { HealthView } from './views/HealthView';
+import { RAGQualityView } from './views/RAGQualityView';
 
 // Simple login page for development
 const LoginPage = () => {
@@ -78,6 +79,7 @@ function App() {
                 <Route path="/documents" element={<DocumentsView />} />
                 <Route path="/tags" element={<TagsView />} />
                 <Route path="/users" element={<UsersView />} />
+                <Route path="/rag-quality" element={<RAGQualityView />} />
                 <Route path="/settings" element={<SettingsView />} />
                 <Route path="/health" element={<HealthView />} />
               </Routes>

--- a/frontend/src/components/features/admin/QAManager.tsx
+++ b/frontend/src/components/features/admin/QAManager.tsx
@@ -1,0 +1,17 @@
+import { Card } from '../../ui';
+
+export function QAManager() {
+  return (
+    <Card>
+      <div className="text-center py-12">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+          Curated Q&A Management
+        </h3>
+        <p className="text-gray-500 dark:text-gray-400">
+          Curated Q&A management coming soon. This feature will allow you to create
+          admin-approved answers for specific questions that bypass the RAG pipeline.
+        </p>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/features/admin/SynonymManager.tsx
+++ b/frontend/src/components/features/admin/SynonymManager.tsx
@@ -1,0 +1,17 @@
+import { Card } from '../../ui';
+
+export function SynonymManager() {
+  return (
+    <Card>
+      <div className="text-center py-12">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+          Synonym Management
+        </h3>
+        <p className="text-gray-500 dark:text-gray-400">
+          Synonym management coming soon. This feature will allow you to create
+          term mappings (e.g., vacation → PTO) to improve search quality.
+        </p>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/features/admin/index.ts
+++ b/frontend/src/components/features/admin/index.ts
@@ -14,3 +14,5 @@ export { CacheStatsCard } from './CacheStatsCard';
 export { CacheTopQueriesCard } from './CacheTopQueriesCard';
 export { CacheWarmingCard } from './CacheWarmingCard';
 export { ClearCacheModal } from './ClearCacheModal';
+export { SynonymManager } from './SynonymManager';
+export { QAManager } from './QAManager';

--- a/frontend/src/components/layout/Nav.tsx
+++ b/frontend/src/components/layout/Nav.tsx
@@ -6,6 +6,7 @@ import {
   Users,
   Settings,
   Activity,
+  Sparkles,
 } from 'lucide-react';
 import { useAuthStore } from '../../stores/authStore';
 import type { NavItem, UserRole } from '../../types';
@@ -15,6 +16,7 @@ const navItems: NavItem[] = [
   { href: '/documents', label: 'Documents', icon: FileText, roles: ['admin', 'customer_admin', 'user'] },
   { href: '/tags', label: 'Tags', icon: Tags, roles: ['admin', 'customer_admin'] },
   { href: '/users', label: 'Users', icon: Users, roles: ['admin', 'customer_admin'] },
+  { href: '/rag-quality', label: 'RAG Quality', icon: Sparkles, roles: ['admin'] },
   { href: '/settings', label: 'Settings', icon: Settings, roles: ['admin'] },
   { href: '/health', label: 'Health', icon: Activity, roles: ['admin'] },
 ];

--- a/frontend/src/views/RAGQualityView.tsx
+++ b/frontend/src/views/RAGQualityView.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { SynonymManager, QAManager } from '../components/features/admin';
+
+type TabType = 'synonyms' | 'qa';
+
+interface Tab {
+  id: TabType;
+  label: string;
+}
+
+const tabs: Tab[] = [
+  { id: 'synonyms', label: 'Synonyms' },
+  { id: 'qa', label: 'Curated Q&A' },
+];
+
+export function RAGQualityView() {
+  const [activeTab, setActiveTab] = useState<TabType>('synonyms');
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-heading font-bold text-gray-900 dark:text-white">
+          RAG Quality
+        </h1>
+        <p className="text-gray-500 dark:text-gray-400 mt-1">
+          Improve RAG performance with synonyms and curated Q&A
+        </p>
+      </div>
+
+      {/* Tab Navigation */}
+      <div className="border-b border-gray-200 dark:border-gray-700">
+        <nav className="flex gap-4" aria-label="Tabs">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`
+                py-3 px-1 text-sm font-medium border-b-2 -mb-px transition-colors
+                ${
+                  activeTab === tab.id
+                    ? 'border-primary text-primary'
+                    : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'
+                }
+              `}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {/* Tab Content */}
+      {activeTab === 'synonyms' && <SynonymManager />}
+      {activeTab === 'qa' && <QAManager />}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Create RAGQualityView with Synonyms and Curated Q&A tabs
- Add placeholder components for SynonymManager and QAManager
- Add RAG Quality nav item with Sparkles icon (admin-only)
- Add /rag-quality route

## Test plan
- [x] Build passes without errors
- [ ] Navigate to /rag-quality as admin
- [ ] Verify tab switching works
- [ ] Verify non-admin users don't see nav item

Closes #155

Generated with [Claude Code](https://claude.ai/code)