### PR TITLE
feat: Implement Synonym Management UI (#156)

### DIFF
--- a/frontend/src/api/synonyms.ts
+++ b/frontend/src/api/synonyms.ts
@@ -1,0 +1,53 @@
+import { apiClient } from './client';
+import type {
+  Synonym,
+  SynonymListResponse,
+  SynonymListParams,
+  SynonymCreate,
+  SynonymUpdate,
+} from '../types';
+
+/**
+ * List synonyms with pagination and filtering.
+ */
+export async function listSynonyms(params?: SynonymListParams): Promise<SynonymListResponse> {
+  const searchParams = new URLSearchParams();
+  if (params?.page) searchParams.set('page', params.page.toString());
+  if (params?.page_size) searchParams.set('page_size', params.page_size.toString());
+  if (params?.enabled !== undefined && params?.enabled !== null) {
+    searchParams.set('enabled', params.enabled.toString());
+  }
+  if (params?.search) searchParams.set('search', params.search);
+
+  const queryString = searchParams.toString();
+  const url = queryString ? `/api/admin/synonyms?${queryString}` : '/api/admin/synonyms';
+  return apiClient.get<SynonymListResponse>(url);
+}
+
+/**
+ * Create a new synonym mapping.
+ */
+export async function createSynonym(data: SynonymCreate): Promise<Synonym> {
+  return apiClient.post<Synonym>('/api/admin/synonyms', data);
+}
+
+/**
+ * Update an existing synonym mapping.
+ */
+export async function updateSynonym(id: string, data: SynonymUpdate): Promise<Synonym> {
+  return apiClient.put<Synonym>(`/api/admin/synonyms/${id}`, data);
+}
+
+/**
+ * Delete a synonym mapping.
+ */
+export async function deleteSynonym(id: string): Promise<{ success: boolean; message: string }> {
+  return apiClient.delete<{ success: boolean; message: string }>(`/api/admin/synonyms/${id}`);
+}
+
+/**
+ * Toggle synonym enabled status.
+ */
+export async function toggleSynonymStatus(id: string, enabled: boolean): Promise<Synonym> {
+  return apiClient.put<Synonym>(`/api/admin/synonyms/${id}`, { enabled });
+}

--- a/frontend/src/components/features/admin/SynonymForm.tsx
+++ b/frontend/src/components/features/admin/SynonymForm.tsx
@@ -1,0 +1,124 @@
+import { useState, useEffect } from 'react';
+import { Modal, Button, Input, TagInput } from '../../ui';
+import type { Synonym, SynonymCreate, SynonymUpdate } from '../../../types';
+
+interface SynonymFormProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (data: SynonymCreate | SynonymUpdate) => Promise<void>;
+  synonym?: Synonym | null;
+  isLoading?: boolean;
+}
+
+export function SynonymForm({
+  isOpen,
+  onClose,
+  onSave,
+  synonym,
+  isLoading = false,
+}: SynonymFormProps) {
+  const [term, setTerm] = useState('');
+  const [synonyms, setSynonyms] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const isEditing = Boolean(synonym);
+
+  useEffect(() => {
+    if (isOpen) {
+      if (synonym) {
+        setTerm(synonym.term);
+        setSynonyms(synonym.synonyms);
+      } else {
+        setTerm('');
+        setSynonyms([]);
+      }
+      setError(null);
+    }
+  }, [isOpen, synonym]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const trimmedTerm = term.trim().toLowerCase();
+
+    if (!trimmedTerm) {
+      setError('Term is required');
+      return;
+    }
+
+    if (synonyms.length === 0) {
+      setError('At least one synonym is required');
+      return;
+    }
+
+    const termRegex = /^[a-z0-9\s\-]+$/;
+    if (!termRegex.test(trimmedTerm)) {
+      setError('Term must contain only lowercase letters, numbers, spaces, or hyphens');
+      return;
+    }
+
+    try {
+      if (isEditing) {
+        await onSave({
+          term: trimmedTerm,
+          synonyms,
+        } as SynonymUpdate);
+      } else {
+        await onSave({
+          term: trimmedTerm,
+          synonyms,
+        } as SynonymCreate);
+      }
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save synonym');
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={isEditing ? 'Edit Synonym' : 'Create Synonym'}
+      size="md"
+    >
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && (
+          <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-300 text-sm">
+            {error}
+          </div>
+        )}
+
+        <Input
+          label="Term"
+          value={term}
+          onChange={(e) => setTerm(e.target.value)}
+          placeholder="e.g., pto"
+        />
+        <p className="text-xs text-gray-500 -mt-2">
+          The source term that will be expanded during search
+        </p>
+
+        <TagInput
+          label="Synonyms"
+          value={synonyms}
+          onChange={setSynonyms}
+          placeholder="Type synonym and press Enter"
+        />
+        <p className="text-xs text-gray-500 -mt-2">
+          Related terms that will be included in search queries
+        </p>
+
+        <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+          <Button variant="secondary" onClick={onClose} disabled={isLoading}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? 'Saving...' : isEditing ? 'Save Changes' : 'Create Synonym'}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/frontend/src/components/features/admin/SynonymManager.tsx
+++ b/frontend/src/components/features/admin/SynonymManager.tsx
@@ -1,17 +1,290 @@
-import { Card } from '../../ui';
+import { useState, useEffect, useCallback } from 'react';
+import { Plus, Pencil, Trash2, Search, ToggleLeft, ToggleRight } from 'lucide-react';
+import { Button, Alert, Card, Input, Pagination } from '../../ui';
+import { SynonymForm } from './SynonymForm';
+import { ConfirmModal } from './ConfirmModal';
+import {
+  listSynonyms,
+  createSynonym,
+  updateSynonym,
+  deleteSynonym,
+  toggleSynonymStatus,
+} from '../../../api/synonyms';
+import type { Synonym, SynonymCreate, SynonymUpdate } from '../../../types';
+
+const PAGE_SIZE = 10;
 
 export function SynonymManager() {
+  const [synonyms, setSynonyms] = useState<Synonym[]>([]);
+  const [total, setTotal] = useState(0);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [showForm, setShowForm] = useState(false);
+  const [editingSynonym, setEditingSynonym] = useState<Synonym | null>(null);
+  const [deletingSynonym, setDeletingSynonym] = useState<Synonym | null>(null);
+  const [actionLoading, setActionLoading] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(searchTerm);
+      setCurrentPage(1);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchTerm]);
+
+  const fetchSynonyms = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await listSynonyms({
+        page: currentPage,
+        page_size: PAGE_SIZE,
+        search: debouncedSearch || undefined,
+      });
+      setSynonyms(response.synonyms);
+      setTotal(response.total);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load synonyms');
+    } finally {
+      setLoading(false);
+    }
+  }, [currentPage, debouncedSearch]);
+
+  useEffect(() => {
+    fetchSynonyms();
+  }, [fetchSynonyms]);
+
+  const handleCreate = () => {
+    setEditingSynonym(null);
+    setShowForm(true);
+  };
+
+  const handleEdit = (synonym: Synonym) => {
+    setEditingSynonym(synonym);
+    setShowForm(true);
+  };
+
+  const handleSave = async (data: SynonymCreate | SynonymUpdate) => {
+    setActionLoading(true);
+    try {
+      if (editingSynonym) {
+        await updateSynonym(editingSynonym.id, data as SynonymUpdate);
+      } else {
+        await createSynonym(data as SynonymCreate);
+      }
+      await fetchSynonyms();
+      setShowForm(false);
+    } catch (err) {
+      throw err;
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleDelete = (synonym: Synonym) => {
+    setDeletingSynonym(synonym);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!deletingSynonym) return;
+    setActionLoading(true);
+    try {
+      await deleteSynonym(deletingSynonym.id);
+      await fetchSynonyms();
+      setDeletingSynonym(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete synonym');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleToggleStatus = async (synonym: Synonym) => {
+    try {
+      await toggleSynonymStatus(synonym.id, !synonym.enabled);
+      await fetchSynonyms();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to toggle status');
+    }
+  };
+
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+
   return (
-    <Card>
-      <div className="text-center py-12">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-          Synonym Management
-        </h3>
-        <p className="text-gray-500 dark:text-gray-400">
-          Synonym management coming soon. This feature will allow you to create
-          term mappings (e.g., vacation → PTO) to improve search quality.
-        </p>
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-heading font-semibold text-gray-900 dark:text-white">
+            Query Synonyms
+          </h2>
+          <p className="text-gray-500 dark:text-gray-400 text-sm mt-1">
+            Define synonym mappings for query expansion in RAG searches
+          </p>
+        </div>
+        <Button icon={Plus} onClick={handleCreate}>
+          Add Synonym
+        </Button>
       </div>
-    </Card>
+
+      <div className="max-w-md">
+        <Input
+          icon={Search}
+          placeholder="Search terms or synonyms..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+        />
+      </div>
+
+      {error && (
+        <Alert variant="danger" onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      <Card>
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-gray-200 dark:border-gray-700">
+                <th className="text-left py-3 px-4 text-sm font-semibold text-gray-600 dark:text-gray-300">
+                  Term
+                </th>
+                <th className="text-left py-3 px-4 text-sm font-semibold text-gray-600 dark:text-gray-300">
+                  Synonyms
+                </th>
+                <th className="text-center py-3 px-4 text-sm font-semibold text-gray-600 dark:text-gray-300">
+                  Status
+                </th>
+                <th className="text-right py-3 px-4 text-sm font-semibold text-gray-600 dark:text-gray-300">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr>
+                  <td colSpan={4} className="py-8 text-center text-gray-500">
+                    Loading synonyms...
+                  </td>
+                </tr>
+              ) : synonyms.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="py-8 text-center text-gray-500">
+                    {debouncedSearch
+                      ? 'No synonyms match your search.'
+                      : 'No synonyms found. Create your first synonym mapping.'}
+                  </td>
+                </tr>
+              ) : (
+                synonyms.map((synonym) => (
+                  <tr
+                    key={synonym.id}
+                    className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                  >
+                    <td className="py-3 px-4">
+                      <code className="text-sm text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded">
+                        {synonym.term}
+                      </code>
+                    </td>
+                    <td className="py-3 px-4">
+                      <div className="flex flex-wrap gap-1">
+                        {synonym.synonyms.map((s, idx) => (
+                          <span
+                            key={idx}
+                            className="inline-block px-2 py-0.5 text-xs rounded-full bg-primary/10 text-primary dark:bg-primary/20"
+                          >
+                            {s}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                    <td className="py-3 px-4 text-center">
+                      <button
+                        onClick={() => handleToggleStatus(synonym)}
+                        className={`
+                          inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium transition-colors
+                          ${synonym.enabled
+                            ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 hover:bg-green-200 dark:hover:bg-green-900/50'
+                            : 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700'
+                          }
+                        `}
+                      >
+                        {synonym.enabled ? (
+                          <>
+                            <ToggleRight size={14} />
+                            Enabled
+                          </>
+                        ) : (
+                          <>
+                            <ToggleLeft size={14} />
+                            Disabled
+                          </>
+                        )}
+                      </button>
+                    </td>
+                    <td className="py-3 px-4">
+                      <div className="flex items-center justify-end gap-2">
+                        <button
+                          onClick={() => handleEdit(synonym)}
+                          className="p-1.5 text-gray-400 hover:text-primary hover:bg-primary/10 rounded transition-colors"
+                          title="Edit synonym"
+                        >
+                          <Pencil size={16} />
+                        </button>
+                        <button
+                          onClick={() => handleDelete(synonym)}
+                          className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
+                          title="Delete synonym"
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {totalPages > 1 && (
+          <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700">
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              totalItems={total}
+              itemsPerPage={PAGE_SIZE}
+              onPageChange={setCurrentPage}
+            />
+          </div>
+        )}
+      </Card>
+
+      <SynonymForm
+        isOpen={showForm}
+        onClose={() => {
+          setShowForm(false);
+          setEditingSynonym(null);
+        }}
+        onSave={handleSave}
+        synonym={editingSynonym}
+        isLoading={actionLoading}
+      />
+
+      <ConfirmModal
+        isOpen={Boolean(deletingSynonym)}
+        onClose={() => setDeletingSynonym(null)}
+        onConfirm={handleConfirmDelete}
+        title="Delete Synonym"
+        message={`Are you sure you want to delete the synonym mapping for "${deletingSynonym?.term}"? This will affect query expansion in RAG searches.`}
+        confirmLabel="Delete"
+        isLoading={actionLoading}
+        variant="danger"
+      />
+    </div>
   );
 }

--- a/frontend/src/components/features/admin/index.ts
+++ b/frontend/src/components/features/admin/index.ts
@@ -15,4 +15,5 @@ export { CacheTopQueriesCard } from './CacheTopQueriesCard';
 export { CacheWarmingCard } from './CacheWarmingCard';
 export { ClearCacheModal } from './ClearCacheModal';
 export { SynonymManager } from './SynonymManager';
+export { SynonymForm } from './SynonymForm';
 export { QAManager } from './QAManager';

--- a/frontend/src/components/ui/TagInput.tsx
+++ b/frontend/src/components/ui/TagInput.tsx
@@ -1,0 +1,110 @@
+import { useState, useRef, type KeyboardEvent } from 'react';
+import { X } from 'lucide-react';
+
+interface TagInputProps {
+  label?: string;
+  value: string[];
+  onChange: (tags: string[]) => void;
+  placeholder?: string;
+  error?: string;
+  disabled?: boolean;
+}
+
+export function TagInput({
+  label,
+  value,
+  onChange,
+  placeholder = 'Type and press Enter to add',
+  error,
+  disabled = false,
+}: TagInputProps) {
+  const [inputValue, setInputValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const trimmed = inputValue.trim().toLowerCase();
+      if (trimmed && !value.includes(trimmed)) {
+        onChange([...value, trimmed]);
+        setInputValue('');
+      }
+    } else if (e.key === 'Backspace' && !inputValue && value.length > 0) {
+      // Remove last tag when backspace on empty input
+      onChange(value.slice(0, -1));
+    }
+  };
+
+  const removeTag = (tagToRemove: string) => {
+    if (!disabled) {
+      onChange(value.filter((tag) => tag !== tagToRemove));
+    }
+  };
+
+  const handleContainerClick = () => {
+    inputRef.current?.focus();
+  };
+
+  return (
+    <div>
+      {label && (
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+          {label}
+        </label>
+      )}
+      <div
+        onClick={handleContainerClick}
+        className={`
+          min-h-[42px] w-full px-3 py-2 rounded-lg border transition-colors cursor-text
+          flex flex-wrap gap-2 items-center
+          ${error
+            ? 'border-red-500 focus-within:ring-red-500/50'
+            : 'border-gray-300 dark:border-gray-600 focus-within:border-primary focus-within:ring-primary/50'
+          }
+          ${disabled ? 'bg-gray-100 dark:bg-gray-900 cursor-not-allowed' : 'bg-white dark:bg-gray-800'}
+          focus-within:outline-none focus-within:ring-2
+        `}
+      >
+        {value.map((tag) => (
+          <span
+            key={tag}
+            className={`
+              inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-sm
+              bg-primary/10 text-primary dark:bg-primary/20 dark:text-primary-light
+              ${disabled ? 'opacity-60' : ''}
+            `}
+          >
+            {tag}
+            {!disabled && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  removeTag(tag);
+                }}
+                className="hover:bg-primary/20 rounded-full p-0.5 transition-colors"
+              >
+                <X size={12} />
+              </button>
+            )}
+          </span>
+        ))}
+        <input
+          ref={inputRef}
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={value.length === 0 ? placeholder : ''}
+          disabled={disabled}
+          className={`
+            flex-1 min-w-[120px] outline-none bg-transparent
+            text-gray-900 dark:text-white placeholder-gray-400
+            ${disabled ? 'cursor-not-allowed' : ''}
+          `}
+        />
+      </div>
+      {error && <p className="mt-1 text-sm text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -9,3 +9,4 @@ export { Checkbox } from './Checkbox';
 export { Pagination } from './Pagination';
 export { KeyboardShortcutsModal } from './KeyboardShortcutsModal';
 export { Slider } from './Slider';
+export { TagInput } from './TagInput';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -575,3 +575,42 @@ export interface BulkDeleteSessionsResponse {
   failed_ids: string[];
   total_messages_deleted: number;
 }
+
+// =============================================================================
+// Synonym Management Types
+// =============================================================================
+
+export interface Synonym {
+  id: string;
+  term: string;
+  synonyms: string[];
+  enabled: boolean;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SynonymListResponse {
+  synonyms: Synonym[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+export interface SynonymListParams {
+  page?: number;
+  page_size?: number;
+  enabled?: boolean | null;
+  search?: string | null;
+}
+
+export interface SynonymCreate {
+  term: string;
+  synonyms: string[];
+}
+
+export interface SynonymUpdate {
+  term?: string;
+  synonyms?: string[];
+  enabled?: boolean;
+}


### PR DESCRIPTION
## Summary
- Add TagInput reusable component for chip-based input (Enter to add, X to remove)
- Add SynonymForm modal for create/edit operations  
- Add synonyms API client module
- Implement full SynonymManager with CRUD, search, pagination
- Add Synonym types to types/index.ts

## Test plan
- [x] Build passes without errors
- [ ] Navigate to RAG Quality > Synonyms tab
- [ ] Create a new synonym mapping
- [ ] Edit an existing synonym
- [ ] Toggle enabled/disabled status
- [ ] Delete a synonym with confirmation
- [ ] Search filters synonyms correctly
- [ ] Pagination works

Closes #156

Generated with [Claude Code](https://claude.ai/code)