### PR TITLE
feat: FK indexes, constructor injection, lifespan, Depends() chain (#170)

### DIFF
--- a/ai_ready_rag/db/models/chat.py
+++ b/ai_ready_rag/db/models/chat.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, String, Text
 from sqlalchemy.orm import relationship
 
 from ai_ready_rag.db.database import Base
@@ -11,6 +11,7 @@ from ai_ready_rag.db.models.base import TimestampMixin, generate_uuid
 
 class ChatSession(TimestampMixin, Base):
     __tablename__ = "chat_sessions"
+    __table_args__ = (Index("idx_chat_sessions_user_id", "user_id"),)
 
     id = Column(String, primary_key=True, default=generate_uuid)
     user_id = Column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
@@ -23,6 +24,7 @@ class ChatSession(TimestampMixin, Base):
 
 class ChatMessage(TimestampMixin, Base):
     __tablename__ = "chat_messages"
+    __table_args__ = (Index("idx_chat_messages_session_id", "session_id"),)
 
     id = Column(String, primary_key=True, default=generate_uuid)
     session_id = Column(String, ForeignKey("chat_sessions.id", ondelete="CASCADE"), nullable=False)

--- a/tests/test_cache_integration.py
+++ b/tests/test_cache_integration.py
@@ -383,6 +383,7 @@ class TestCacheWarming:
         with (
             patch("ai_ready_rag.config.get_settings") as mock_get_settings,
             patch("ai_ready_rag.db.database.SessionLocal") as mock_session,
+            patch("ai_ready_rag.services.factory.get_vector_service") as mock_get_vs,
             patch("ai_ready_rag.services.rag_service.RAGService") as mock_rag_class,
         ):
             mock_settings = MagicMock()
@@ -391,6 +392,10 @@ class TestCacheWarming:
 
             mock_db = MagicMock()
             mock_session.return_value = mock_db
+
+            mock_vector_service = MagicMock()
+            mock_vector_service.initialize = AsyncMock()
+            mock_get_vs.return_value = mock_vector_service
 
             mock_rag_service = MagicMock()
             mock_rag_service.generate = AsyncMock()
@@ -415,6 +420,7 @@ class TestCacheWarming:
         with (
             patch("ai_ready_rag.config.get_settings") as mock_get_settings,
             patch("ai_ready_rag.db.database.SessionLocal") as mock_session,
+            patch("ai_ready_rag.services.factory.get_vector_service") as mock_get_vs,
             patch("ai_ready_rag.services.rag_service.RAGService") as mock_rag_class,
         ):
             mock_settings = MagicMock()
@@ -423,6 +429,10 @@ class TestCacheWarming:
 
             mock_db = MagicMock()
             mock_session.return_value = mock_db
+
+            mock_vector_service = MagicMock()
+            mock_vector_service.initialize = AsyncMock()
+            mock_get_vs.return_value = mock_vector_service
 
             mock_rag_service = MagicMock()
             # First query fails, second succeeds

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -308,15 +308,8 @@ class TestSendMessage:
 
     def test_send_message_success(self, client, user_headers, test_session, mock_rag_response):
         """Send message and receive response."""
-        # Mock VectorService and RAGService
-        with (
-            patch("ai_ready_rag.api.chat.VectorService") as mock_vector_class,
-            patch("ai_ready_rag.api.chat.RAGService") as mock_rag_class,
-        ):
-            mock_vector_instance = MagicMock()
-            mock_vector_instance.initialize = AsyncMock()
-            mock_vector_class.return_value = mock_vector_instance
-
+        # Mock RAGService (VectorService is singleton from app.state)
+        with patch("ai_ready_rag.api.chat.RAGService") as mock_rag_class:
             mock_rag_instance = MagicMock()
             mock_rag_instance.generate = AsyncMock(return_value=mock_rag_response)
             mock_rag_class.return_value = mock_rag_instance
@@ -347,15 +340,8 @@ class TestSendMessage:
         self, client, user_headers, test_session, mock_rag_response_routed
     ):
         """Message routed when confidence low."""
-        # Mock VectorService and RAGService
-        with (
-            patch("ai_ready_rag.api.chat.VectorService") as mock_vector_class,
-            patch("ai_ready_rag.api.chat.RAGService") as mock_rag_class,
-        ):
-            mock_vector_instance = MagicMock()
-            mock_vector_instance.initialize = AsyncMock()
-            mock_vector_class.return_value = mock_vector_instance
-
+        # Mock RAGService (VectorService is singleton from app.state)
+        with patch("ai_ready_rag.api.chat.RAGService") as mock_rag_class:
             mock_rag_instance = MagicMock()
             mock_rag_instance.generate = AsyncMock(return_value=mock_rag_response_routed)
             mock_rag_class.return_value = mock_rag_instance
@@ -405,15 +391,8 @@ class TestSendMessage:
 
     def test_send_message_ollama_unavailable(self, client, user_headers, test_session):
         """503 when Ollama unavailable."""
-        # Mock VectorService and RAGService
-        with (
-            patch("ai_ready_rag.api.chat.VectorService") as mock_vector_class,
-            patch("ai_ready_rag.api.chat.RAGService") as mock_rag_class,
-        ):
-            mock_vector_instance = MagicMock()
-            mock_vector_instance.initialize = AsyncMock()
-            mock_vector_class.return_value = mock_vector_instance
-
+        # Mock RAGService (VectorService is singleton from app.state)
+        with patch("ai_ready_rag.api.chat.RAGService") as mock_rag_class:
             mock_rag_instance = MagicMock()
             mock_rag_instance.generate = AsyncMock(
                 side_effect=LLMConnectionError("Cannot connect to Ollama")

--- a/tests/test_warming_integration.py
+++ b/tests/test_warming_integration.py
@@ -18,29 +18,17 @@ import pytest
 class TestWarmingWorkerStartup:
     """Verify WarmingWorker starts correctly with the application."""
 
-    def test_warming_worker_global_exists(self):
-        """Verify warming_worker global is defined in main module."""
+    def test_lifespan_defined(self):
+        """Verify lifespan context manager is defined in main module."""
         from ai_ready_rag import main
 
-        assert hasattr(main, "warming_worker"), "warming_worker global not defined"
+        assert hasattr(main, "lifespan"), "lifespan function not defined"
 
-    def test_warming_cleanup_global_exists(self):
-        """Verify warming_cleanup global is defined in main module."""
-        from ai_ready_rag import main
-
-        assert hasattr(main, "warming_cleanup"), "warming_cleanup global not defined"
-
-    def test_startup_event_defined(self):
-        """Verify startup event handler is registered."""
+    def test_app_has_lifespan(self):
+        """Verify app uses lifespan context manager."""
         from ai_ready_rag.main import app
 
-        # Check that on_event handlers are registered
-        startup_handlers = [
-            route for route in app.router.on_startup if "startup_event" in str(route)
-        ]
-        assert len(startup_handlers) > 0 or hasattr(app, "router"), (
-            "Startup event should be registered"
-        )
+        assert app.router.lifespan_context is not None, "App should have lifespan configured"
 
     @pytest.mark.asyncio
     async def test_warming_worker_can_be_instantiated(self):


### PR DESCRIPTION
## Summary
- Add FK indexes on `ChatSession.user_id` and `ChatMessage.session_id` for query performance
- Refactor `RAGService` constructor with explicit `vector_service` and `cache_service` params (constructor injection)
- Replace deprecated `@app.on_event("startup"/"shutdown")` with `@asynccontextmanager` lifespan pattern
- Initialize `VectorService` as singleton in `app.state` during lifespan (was per-request)
- Add 4 service factory functions to `dependencies.py` for `Depends()` chain
- Update route files (`chat.py`, `experimental.py`, `admin.py`) to use singleton vector service

## Test plan
- [x] All 619 tests pass (0 failures)
- [x] Ruff check + format clean
- [x] FK indexes compile correctly in SQLAlchemy models
- [x] Lifespan manages startup/shutdown lifecycle
- [x] Service factories resolve from `app.state`

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)