### PR TITLE
feat: Migrate security settings and feature flags to SQLite (#172)

### DIFF
--- a/ai_ready_rag/api/auth.py
+++ b/ai_ready_rag/api/auth.py
@@ -17,6 +17,7 @@ from ai_ready_rag.schemas.auth import (
     SetupRequest,
     UserBasicResponse,
 )
+from ai_ready_rag.services.settings_service import get_security_setting
 
 router = APIRouter()
 settings = get_settings()
@@ -41,7 +42,8 @@ async def login(
 
     # Create token
     token = create_access_token(data={"sub": user.id, "email": user.email, "role": user.role})
-    expires_in = settings.jwt_expiration_hours * 3600
+    jwt_hours = get_security_setting("jwt_expiration_hours", settings.jwt_expiration_hours)
+    expires_in = jwt_hours * 3600
 
     # Update last login
     user.last_login = datetime.utcnow()

--- a/ai_ready_rag/core/security.py
+++ b/ai_ready_rag/core/security.py
@@ -8,13 +8,15 @@ import bcrypt
 import jwt
 
 from ai_ready_rag.config import get_settings
+from ai_ready_rag.services.settings_service import get_security_setting
 
 settings = get_settings()
 
 
 def hash_password(password: str) -> str:
     """Hash password using bcrypt."""
-    salt = bcrypt.gensalt(rounds=settings.bcrypt_rounds)
+    rounds = get_security_setting("bcrypt_rounds", settings.bcrypt_rounds)
+    salt = bcrypt.gensalt(rounds=rounds)
     return bcrypt.hashpw(password.encode(), salt).decode()
 
 
@@ -26,7 +28,8 @@ def verify_password(password: str, hashed: str) -> bool:
 def create_access_token(data: dict[str, Any], expires_delta: timedelta | None = None) -> str:
     """Create JWT access token."""
     to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(hours=settings.jwt_expiration_hours))
+    jwt_hours = get_security_setting("jwt_expiration_hours", settings.jwt_expiration_hours)
+    expire = datetime.utcnow() + (expires_delta or timedelta(hours=jwt_hours))
     to_encode.update({"exp": expire})
     return jwt.encode(to_encode, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
 

--- a/ai_ready_rag/schemas/admin.py
+++ b/ai_ready_rag/schemas/admin.py
@@ -363,6 +363,46 @@ class SettingsAuditResponse(BaseModel):
 
 
 # =============================================================================
+# Security Settings
+# =============================================================================
+
+
+class SecuritySettingsResponse(BaseModel):
+    """Response containing security settings."""
+
+    jwt_expiration_hours: int
+    password_min_length: int
+    bcrypt_rounds: int
+
+
+class SecuritySettingsRequest(BaseModel):
+    """Request to update security settings."""
+
+    jwt_expiration_hours: int | None = None
+    password_min_length: int | None = None
+    bcrypt_rounds: int | None = None
+
+
+# =============================================================================
+# Feature Flags
+# =============================================================================
+
+
+class FeatureFlagsResponse(BaseModel):
+    """Response containing feature flag settings."""
+
+    enable_rag: bool
+    skip_setup_wizard: bool
+
+
+class FeatureFlagsRequest(BaseModel):
+    """Request to update feature flags."""
+
+    enable_rag: bool | None = None
+    skip_setup_wizard: bool | None = None
+
+
+# =============================================================================
 # Advanced Settings & Reindex
 # =============================================================================
 

--- a/ai_ready_rag/schemas/setup.py
+++ b/ai_ready_rag/schemas/setup.py
@@ -2,6 +2,8 @@
 
 from pydantic import BaseModel, field_validator
 
+from ai_ready_rag.services.settings_service import get_security_setting
+
 
 class SetupStatusResponse(BaseModel):
     """Response for setup status check."""
@@ -20,8 +22,9 @@ class CompleteSetupRequest(BaseModel):
     @field_validator("new_password")
     @classmethod
     def password_min_length(cls, v: str) -> str:
-        if len(v) < 12:
-            raise ValueError("Password must be at least 12 characters long")
+        min_length = get_security_setting("password_min_length", 12)
+        if len(v) < min_length:
+            raise ValueError(f"Password must be at least {min_length} characters long")
         return v
 
     @field_validator("confirm_password")

--- a/tests/test_admin_security_settings.py
+++ b/tests/test_admin_security_settings.py
@@ -1,0 +1,210 @@
+"""Tests for security settings and feature flag endpoints."""
+
+
+class TestGetSecuritySettings:
+    """Tests for GET /api/admin/settings/security."""
+
+    def test_returns_default_settings(self, client, admin_headers):
+        """GET returns default security settings."""
+        response = client.get("/api/admin/settings/security", headers=admin_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "jwt_expiration_hours" in data
+        assert "password_min_length" in data
+        assert "bcrypt_rounds" in data
+        assert data["jwt_expiration_hours"] == 24
+        assert data["password_min_length"] == 12
+
+    def test_requires_admin(self, client, user_headers):
+        """GET requires admin role."""
+        response = client.get("/api/admin/settings/security", headers=user_headers)
+        assert response.status_code == 403
+
+    def test_requires_auth(self, client):
+        """GET requires authentication."""
+        response = client.get("/api/admin/settings/security")
+        assert response.status_code == 401
+
+
+class TestUpdateSecuritySettings:
+    """Tests for PUT /api/admin/settings/security."""
+
+    def test_updates_jwt_expiration(self, client, admin_headers):
+        """PUT updates jwt_expiration_hours."""
+        response = client.put(
+            "/api/admin/settings/security",
+            headers=admin_headers,
+            json={"jwt_expiration_hours": 48},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["jwt_expiration_hours"] == 48
+
+    def test_updates_password_min_length(self, client, admin_headers):
+        """PUT updates password_min_length."""
+        response = client.put(
+            "/api/admin/settings/security",
+            headers=admin_headers,
+            json={"password_min_length": 16},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["password_min_length"] == 16
+
+    def test_updates_bcrypt_rounds(self, client, admin_headers):
+        """PUT updates bcrypt_rounds."""
+        response = client.put(
+            "/api/admin/settings/security",
+            headers=admin_headers,
+            json={"bcrypt_rounds": 14},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["bcrypt_rounds"] == 14
+
+    def test_rejects_jwt_too_low(self, client, admin_headers):
+        """PUT rejects jwt_expiration_hours < 1."""
+        response = client.put(
+            "/api/admin/settings/security",
+            headers=admin_headers,
+            json={"jwt_expiration_hours": 0},
+        )
+        assert response.status_code == 400
+
+    def test_rejects_jwt_too_high(self, client, admin_headers):
+        """PUT rejects jwt_expiration_hours > 720."""
+        response = client.put(
+            "/api/admin/settings/security",
+            headers=admin_headers,
+            json={"jwt_expiration_hours": 721},
+        )
+        assert response.status_code == 400
+
+    def test_rejects_password_length_too_low(self, client, admin_headers):
+        """PUT rejects password_min_length < 8."""
+        response = client.put(
+            "/api/admin/settings/security",
+            headers=admin_headers,
+            json={"password_min_length": 5},
+        )
+        assert response.status_code == 400
+
+    def test_rejects_bcrypt_rounds_too_low(self, client, admin_headers):
+        """PUT rejects bcrypt_rounds < 4."""
+        response = client.put(
+            "/api/admin/settings/security",
+            headers=admin_headers,
+            json={"bcrypt_rounds": 2},
+        )
+        assert response.status_code == 400
+
+    def test_rejects_bcrypt_rounds_too_high(self, client, admin_headers):
+        """PUT rejects bcrypt_rounds > 31."""
+        response = client.put(
+            "/api/admin/settings/security",
+            headers=admin_headers,
+            json={"bcrypt_rounds": 32},
+        )
+        assert response.status_code == 400
+
+    def test_partial_update(self, client, admin_headers):
+        """PUT updates only provided fields."""
+        # Update just one field
+        response = client.put(
+            "/api/admin/settings/security",
+            headers=admin_headers,
+            json={"jwt_expiration_hours": 12},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["jwt_expiration_hours"] == 12
+        # Other fields should still be at defaults
+        assert data["password_min_length"] == 12
+
+    def test_requires_admin(self, client, user_headers):
+        """PUT requires admin role."""
+        response = client.put(
+            "/api/admin/settings/security",
+            headers=user_headers,
+            json={"jwt_expiration_hours": 48},
+        )
+        assert response.status_code == 403
+
+
+class TestGetFeatureFlags:
+    """Tests for GET /api/admin/settings/feature-flags."""
+
+    def test_returns_default_flags(self, client, admin_headers):
+        """GET returns default feature flags."""
+        response = client.get("/api/admin/settings/feature-flags", headers=admin_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "enable_rag" in data
+        assert "skip_setup_wizard" in data
+        assert data["enable_rag"] is True
+        assert data["skip_setup_wizard"] is False
+
+    def test_requires_admin(self, client, user_headers):
+        """GET requires admin role."""
+        response = client.get("/api/admin/settings/feature-flags", headers=user_headers)
+        assert response.status_code == 403
+
+    def test_requires_auth(self, client):
+        """GET requires authentication."""
+        response = client.get("/api/admin/settings/feature-flags")
+        assert response.status_code == 401
+
+
+class TestUpdateFeatureFlags:
+    """Tests for PUT /api/admin/settings/feature-flags."""
+
+    def test_updates_enable_rag(self, client, admin_headers):
+        """PUT updates enable_rag."""
+        response = client.put(
+            "/api/admin/settings/feature-flags",
+            headers=admin_headers,
+            json={"enable_rag": False},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enable_rag"] is False
+
+    def test_updates_skip_setup_wizard(self, client, admin_headers):
+        """PUT updates skip_setup_wizard."""
+        response = client.put(
+            "/api/admin/settings/feature-flags",
+            headers=admin_headers,
+            json={"skip_setup_wizard": True},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["skip_setup_wizard"] is True
+
+    def test_partial_update(self, client, admin_headers):
+        """PUT updates only provided fields."""
+        response = client.put(
+            "/api/admin/settings/feature-flags",
+            headers=admin_headers,
+            json={"enable_rag": False},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enable_rag"] is False
+
+    def test_requires_admin(self, client, user_headers):
+        """PUT requires admin role."""
+        response = client.put(
+            "/api/admin/settings/feature-flags",
+            headers=user_headers,
+            json={"enable_rag": False},
+        )
+        assert response.status_code == 403


### PR DESCRIPTION
## Summary
- Add `get_security_setting()` standalone function + `SECURITY_DEFAULTS` to settings_service.py
- Add admin API endpoints: `GET/PUT /settings/security` and `GET/PUT /settings/feature-flags`
- Update `security.py`, `auth.py`, `setup.py` consumers to read from DB with config.py fallback
- Fix hardcoded `password_min_length=12` in setup schema — now reads from DB
- 20 new tests covering all endpoints, validation bounds, and auth checks

## Test plan
- [x] 639 tests pass, 0 failures
- [x] 20 new tests for security settings + feature flags endpoints
- [x] ruff check clean
- [x] Validation: jwt 1-720h, password 8-128, bcrypt 4-31

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)