### PR TITLE
feat: Add ARQ + Redis infrastructure with document processing migration (#173)

### DIFF
--- a/ai_ready_rag/api/health.py
+++ b/ai_ready_rag/api/health.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter
 
 from ai_ready_rag.config import get_settings
+from ai_ready_rag.core.redis import is_redis_available
 
 router = APIRouter()
 settings = get_settings()
@@ -11,10 +12,12 @@ settings = get_settings()
 @router.get("/health")
 async def health_check():
     """Health check endpoint."""
+    redis_ok = await is_redis_available()
     return {
         "status": "healthy",
         "version": settings.app_version,
         "database": "sqlite",
+        "redis": "connected" if redis_ok else "unavailable",
         "rag_enabled": settings.enable_rag,
         "profile": settings.env_profile,
         "backends": {

--- a/ai_ready_rag/config.py
+++ b/ai_ready_rag/config.py
@@ -97,6 +97,12 @@ class Settings(BaseSettings):
     # API
     api_base_url: str = "http://localhost:8000"
 
+    # Redis / ARQ Task Queue
+    redis_url: str = "redis://localhost:6379"
+    arq_job_timeout: int = 600  # 10 min max for document processing
+    arq_max_jobs: int = 10  # Max concurrent ARQ jobs
+    arq_health_check_interval: int = 60  # Seconds between worker health checks
+
     # Vector Service
     qdrant_url: str = "http://localhost:6333"
     qdrant_collection: str = "documents"

--- a/ai_ready_rag/core/redis.py
+++ b/ai_ready_rag/core/redis.py
@@ -1,0 +1,81 @@
+"""Redis connection pool with degraded mode fallback.
+
+The application works without Redis (degraded mode):
+- Background tasks fall back to FastAPI BackgroundTasks (in-process)
+- Chat and all other functionality continues normally
+- Health endpoint reports Redis as unavailable
+"""
+
+import logging
+
+from arq.connections import ArqRedis, RedisSettings, create_pool
+
+from ai_ready_rag.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+_redis_pool: ArqRedis | None = None
+_redis_checked: bool = False  # True after first connection attempt
+
+
+def _parse_redis_settings() -> RedisSettings:
+    """Parse redis_url into ARQ RedisSettings with fast failure."""
+    settings = get_settings()
+    base = RedisSettings.from_dsn(settings.redis_url)
+    # Override retry settings for fast degraded-mode detection
+    return RedisSettings(
+        host=base.host,
+        port=base.port,
+        unix_socket_path=base.unix_socket_path,
+        database=base.database,
+        password=base.password,
+        ssl=base.ssl,
+        conn_timeout=2,
+        conn_retries=0,
+        conn_retry_delay=0,
+    )
+
+
+async def get_redis_pool() -> ArqRedis | None:
+    """Get or create the Redis connection pool.
+
+    Returns None if Redis is unavailable (degraded mode).
+    Safe to call repeatedly — creates pool once and caches it.
+    Only attempts connection once; after failure, returns None without retrying.
+    """
+    global _redis_pool, _redis_checked
+    if _redis_pool is not None:
+        return _redis_pool
+    if _redis_checked:
+        return None  # Already tried and failed
+
+    _redis_checked = True
+    try:
+        _redis_pool = await create_pool(_parse_redis_settings())
+        logger.info("Redis connection pool created")
+        return _redis_pool
+    except (ConnectionError, OSError, Exception) as e:
+        logger.warning(f"Redis unavailable — running in degraded mode: {e}")
+        return None
+
+
+async def close_redis_pool() -> None:
+    """Close the Redis connection pool on shutdown."""
+    global _redis_pool, _redis_checked
+    if _redis_pool is not None:
+        await _redis_pool.aclose()
+        _redis_pool = None
+        logger.info("Redis connection pool closed")
+    _redis_checked = False
+
+
+async def is_redis_available() -> bool:
+    """Check if Redis is connected and responding."""
+    pool = await get_redis_pool()
+    if pool is None:
+        return False
+    try:
+        await pool.ping()
+        return True
+    except Exception:
+        return False

--- a/ai_ready_rag/workers/settings.py
+++ b/ai_ready_rag/workers/settings.py
@@ -1,0 +1,67 @@
+"""ARQ worker settings.
+
+Start the worker with:
+    arq ai_ready_rag.workers.settings.WorkerSettings
+"""
+
+import logging
+
+from arq.connections import RedisSettings
+
+from ai_ready_rag.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+async def on_startup(ctx: dict) -> None:
+    """ARQ worker startup: initialize shared resources."""
+    from ai_ready_rag.db.database import init_db
+    from ai_ready_rag.services.factory import get_vector_service
+
+    settings = get_settings()
+    init_db()
+
+    vector_service = get_vector_service(settings)
+    await vector_service.initialize()
+
+    ctx["settings"] = settings
+    ctx["vector_service"] = vector_service
+    logger.info("ARQ worker started — vector service initialized")
+
+
+async def on_shutdown(ctx: dict) -> None:
+    """ARQ worker shutdown: clean up resources."""
+    logger.info("ARQ worker shutting down")
+
+
+def get_worker_settings() -> dict:
+    """Build WorkerSettings configuration dict."""
+    from ai_ready_rag.workers.tasks import process_document
+
+    settings = get_settings()
+
+    return {
+        "functions": [process_document],
+        "redis_settings": RedisSettings.from_dsn(settings.redis_url),
+        "max_jobs": settings.arq_max_jobs,
+        "job_timeout": settings.arq_job_timeout,
+        "health_check_interval": settings.arq_health_check_interval,
+        "on_startup": on_startup,
+        "on_shutdown": on_shutdown,
+    }
+
+
+class WorkerSettings:
+    """ARQ WorkerSettings for `arq ai_ready_rag.workers.settings.WorkerSettings`."""
+
+    from ai_ready_rag.workers.tasks import process_document
+
+    settings = get_settings()
+
+    functions = [process_document]
+    redis_settings = RedisSettings.from_dsn(settings.redis_url)
+    max_jobs = settings.arq_max_jobs
+    job_timeout = settings.arq_job_timeout
+    health_check_interval = settings.arq_health_check_interval
+    on_startup = on_startup
+    on_shutdown = on_shutdown

--- a/ai_ready_rag/workers/tasks/__init__.py
+++ b/ai_ready_rag/workers/tasks/__init__.py
@@ -1,0 +1,8 @@
+"""ARQ task registration.
+
+All ARQ task functions are imported here for WorkerSettings.functions.
+"""
+
+from ai_ready_rag.workers.tasks.document import process_document
+
+__all__ = ["process_document"]

--- a/ai_ready_rag/workers/tasks/document.py
+++ b/ai_ready_rag/workers/tasks/document.py
@@ -1,0 +1,115 @@
+"""Document processing ARQ task.
+
+Handles document parsing, chunking, and vector indexing as a
+persistent background job via ARQ + Redis.
+"""
+
+import asyncio
+import logging
+
+from ai_ready_rag.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+# Module-level semaphore for concurrency control
+_processing_semaphore: asyncio.Semaphore | None = None
+
+
+def _get_semaphore() -> asyncio.Semaphore:
+    """Get or create the processing semaphore."""
+    global _processing_semaphore
+    if _processing_semaphore is None:
+        settings = get_settings()
+        _processing_semaphore = asyncio.Semaphore(settings.max_concurrent_processing)
+    return _processing_semaphore
+
+
+async def process_document(
+    ctx: dict,
+    document_id: str,
+    processing_options_dict: dict | None = None,
+    delete_existing: bool = False,
+) -> dict:
+    """ARQ task: process a document (parse, chunk, index vectors).
+
+    Args:
+        ctx: ARQ context dict (contains settings, vector_service from on_startup)
+        document_id: Document ID to process
+        processing_options_dict: Optional per-upload processing overrides
+        delete_existing: If True, delete existing vectors first (reprocess)
+
+    Returns:
+        Dict with processing result (success, chunk_count, error)
+    """
+    from ai_ready_rag.db.database import SessionLocal
+    from ai_ready_rag.db.models import Document
+    from ai_ready_rag.services.factory import get_vector_service
+    from ai_ready_rag.services.processing_service import ProcessingOptions, ProcessingService
+
+    logger.info(f"[ARQ] Starting processing for document {document_id}")
+
+    semaphore = _get_semaphore()
+    async with semaphore:
+        settings = ctx.get("settings") or get_settings()
+        db = SessionLocal()
+
+        # Reconstruct ProcessingOptions if provided
+        processing_options = None
+        if processing_options_dict:
+            processing_options = ProcessingOptions(**processing_options_dict)
+
+        try:
+            document = db.query(Document).filter(Document.id == document_id).first()
+            if not document:
+                logger.error(f"Document {document_id} not found for processing")
+                return {"success": False, "error": "Document not found"}
+
+            # Use worker's vector service if available, otherwise create one
+            vector_service = ctx.get("vector_service") or get_vector_service(settings)
+            if not ctx.get("vector_service"):
+                await vector_service.initialize()
+
+            # Delete existing vectors if reprocessing
+            if delete_existing:
+                try:
+                    await vector_service.delete_document(document_id)
+                    logger.info(f"Deleted existing vectors for document {document_id}")
+                except Exception as e:
+                    logger.warning(f"Failed to delete vectors for {document_id}: {e}")
+
+            processing_service = ProcessingService(
+                vector_service=vector_service,
+                settings=settings,
+            )
+
+            result = await processing_service.process_document(
+                document, db, processing_options=processing_options
+            )
+
+            if result.success:
+                logger.info(
+                    f"[ARQ] Document {document_id} processed: "
+                    f"{result.chunk_count} chunks in {result.processing_time_ms}ms"
+                )
+                return {
+                    "success": True,
+                    "chunk_count": result.chunk_count,
+                    "processing_time_ms": result.processing_time_ms,
+                }
+            else:
+                logger.warning(f"[ARQ] Document {document_id} failed: {result.error_message}")
+                return {"success": False, "error": result.error_message}
+
+        except Exception as e:
+            logger.exception(f"[ARQ] Unexpected error processing document {document_id}: {e}")
+            try:
+                document = db.query(Document).filter(Document.id == document_id).first()
+                if document:
+                    document.status = "failed"
+                    document.error_message = f"Unexpected error: {e}"
+                    db.commit()
+            except Exception:
+                logger.exception("Failed to update document status after error")
+            return {"success": False, "error": str(e)}
+        finally:
+            db.close()

--- a/requirements-spark.txt
+++ b/requirements-spark.txt
@@ -46,6 +46,10 @@ beautifulsoup4>=4.12.0
 python-magic>=0.4.27
 markdown>=3.5.0
 
+# ============== Task Queue ==============
+arq>=0.26.0
+redis>=5.0.0
+
 # ============== Async File I/O ==============
 aiofiles>=24.1.0
 

--- a/requirements-wsl.txt
+++ b/requirements-wsl.txt
@@ -28,6 +28,10 @@ python-docx>=1.0.0
 openpyxl>=3.1.0
 markdown>=3.5.0
 
+# ============== Task Queue ==============
+arq>=0.26.0
+redis>=5.0.0
+
 # ============== HTML Sanitization ==============
 bleach>=6.0.0
 

--- a/tests/test_arq_infrastructure.py
+++ b/tests/test_arq_infrastructure.py
@@ -1,0 +1,171 @@
+"""Tests for ARQ infrastructure and Redis degraded mode."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class TestConfigHasRedisSettings:
+    """Test that config includes Redis/ARQ settings."""
+
+    def test_redis_url_default(self):
+        """Config has redis_url with default."""
+        from ai_ready_rag.config import Settings
+
+        settings = Settings()
+        assert settings.redis_url == "redis://localhost:6379"
+
+    def test_arq_job_timeout_default(self):
+        """Config has arq_job_timeout with default."""
+        from ai_ready_rag.config import Settings
+
+        settings = Settings()
+        assert settings.arq_job_timeout == 600
+
+    def test_arq_max_jobs_default(self):
+        """Config has arq_max_jobs with default."""
+        from ai_ready_rag.config import Settings
+
+        settings = Settings()
+        assert settings.arq_max_jobs == 10
+
+
+class TestRedisPool:
+    """Tests for Redis connection pool with degraded mode."""
+
+    @pytest.mark.asyncio
+    async def test_get_redis_pool_returns_none_when_unavailable(self):
+        """get_redis_pool returns None when Redis is not running."""
+        import ai_ready_rag.core.redis as redis_module
+
+        # Reset cached pool and checked flag
+        redis_module._redis_pool = None
+        redis_module._redis_checked = False
+
+        with patch(
+            "ai_ready_rag.core.redis.create_pool",
+            side_effect=ConnectionError("Connection refused"),
+        ):
+            pool = await redis_module.get_redis_pool()
+            assert pool is None
+
+        # Clean up
+        redis_module._redis_pool = None
+        redis_module._redis_checked = False
+
+    @pytest.mark.asyncio
+    async def test_is_redis_available_false_when_no_pool(self):
+        """is_redis_available returns False when pool is None."""
+        import ai_ready_rag.core.redis as redis_module
+
+        redis_module._redis_pool = None
+        redis_module._redis_checked = False
+
+        with patch(
+            "ai_ready_rag.core.redis.create_pool",
+            side_effect=ConnectionError("Connection refused"),
+        ):
+            result = await redis_module.is_redis_available()
+            assert result is False
+
+        redis_module._redis_pool = None
+        redis_module._redis_checked = False
+
+    @pytest.mark.asyncio
+    async def test_close_redis_pool_noop_when_none(self):
+        """close_redis_pool is safe to call when pool is None."""
+        import ai_ready_rag.core.redis as redis_module
+
+        redis_module._redis_pool = None
+        redis_module._redis_checked = False
+        await redis_module.close_redis_pool()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_close_redis_pool_closes_connection(self):
+        """close_redis_pool calls aclose on the pool."""
+        import ai_ready_rag.core.redis as redis_module
+
+        mock_pool = AsyncMock()
+        redis_module._redis_pool = mock_pool
+
+        await redis_module.close_redis_pool()
+
+        mock_pool.aclose.assert_called_once()
+        assert redis_module._redis_pool is None
+
+
+class TestHealthEndpointRedis:
+    """Test health endpoint includes Redis status."""
+
+    def test_health_includes_redis_field(self, client):
+        """Health endpoint includes redis field."""
+        # Redis won't be running in tests, so should be 'unavailable'
+        response = client.get("/api/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert "redis" in data
+        assert data["redis"] in ("connected", "unavailable")
+
+
+class TestDocumentUploadDegradedMode:
+    """Test document upload falls back to BackgroundTasks when no Redis."""
+
+    @pytest.mark.asyncio
+    async def test_enqueue_falls_back_to_background_tasks(self):
+        """enqueue_document_processing falls back when Redis unavailable."""
+        from ai_ready_rag.api.documents import enqueue_document_processing
+
+        mock_bg_tasks = AsyncMock()
+        mock_bg_tasks.add_task = lambda *args, **kwargs: None  # sync method
+
+        with patch("ai_ready_rag.api.documents.get_redis_pool", return_value=None):
+            job_id = await enqueue_document_processing("test-doc-id", mock_bg_tasks, None, False)
+            assert job_id is None  # None means BackgroundTasks was used
+
+    @pytest.mark.asyncio
+    async def test_enqueue_uses_arq_when_available(self):
+        """enqueue_document_processing uses ARQ when Redis is available."""
+        from ai_ready_rag.api.documents import enqueue_document_processing
+
+        mock_bg_tasks = AsyncMock()
+        mock_redis = AsyncMock()
+        mock_job = AsyncMock()
+        mock_job.job_id = "arq-job-123"
+        mock_redis.enqueue_job = AsyncMock(return_value=mock_job)
+
+        with patch("ai_ready_rag.api.documents.get_redis_pool", return_value=mock_redis):
+            job_id = await enqueue_document_processing("test-doc-id", mock_bg_tasks, None, False)
+            assert job_id == "arq-job-123"
+            mock_redis.enqueue_job.assert_called_once_with(
+                "process_document", "test-doc-id", None, False
+            )
+
+
+class TestWorkerSettings:
+    """Test ARQ WorkerSettings configuration."""
+
+    def test_worker_settings_has_functions(self):
+        """WorkerSettings class has functions list."""
+        from ai_ready_rag.workers.settings import WorkerSettings
+
+        assert hasattr(WorkerSettings, "functions")
+        assert len(WorkerSettings.functions) > 0
+
+    def test_worker_settings_has_redis_settings(self):
+        """WorkerSettings class has redis_settings."""
+        from ai_ready_rag.workers.settings import WorkerSettings
+
+        assert hasattr(WorkerSettings, "redis_settings")
+
+    def test_worker_settings_has_timeouts(self):
+        """WorkerSettings class has job_timeout and max_jobs."""
+        from ai_ready_rag.workers.settings import WorkerSettings
+
+        assert WorkerSettings.job_timeout == 600
+        assert WorkerSettings.max_jobs == 10
+
+    def test_process_document_registered(self):
+        """process_document task is registered in tasks package."""
+        from ai_ready_rag.workers.tasks import process_document
+
+        assert callable(process_document)


### PR DESCRIPTION
## Summary
- Add `core/redis.py` — Redis connection pool with degraded mode (app works without Redis)
- Add `workers/settings.py` — ARQ WorkerSettings (`arq ai_ready_rag.workers.settings.WorkerSettings`)
- Add `workers/tasks/document.py` — Document processing as ARQ task
- Migrate upload/reprocess/bulk-reprocess to ARQ enqueue with BackgroundTasks fallback
- Health endpoint reports `"redis": "connected"|"unavailable"`
- Add `arq>=0.26.0` and `redis>=5.0.0` to requirements

## Test plan
- [x] 653 tests pass, 0 failures (14 new)
- [x] All tests pass without Redis running (degraded mode verified)
- [x] Redis pool returns None when unavailable (fast fail, no retries)
- [x] Document upload falls back to BackgroundTasks when no Redis
- [x] ARQ enqueue works when Redis mock is available
- [x] ruff check clean

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)