### PR TITLE
feat: Migrate cache warming and reindexing to ARQ (#174)

### DIFF
--- a/ai_ready_rag/workers/settings.py
+++ b/ai_ready_rag/workers/settings.py
@@ -36,12 +36,12 @@ async def on_shutdown(ctx: dict) -> None:
 
 def get_worker_settings() -> dict:
     """Build WorkerSettings configuration dict."""
-    from ai_ready_rag.workers.tasks import process_document
+    from ai_ready_rag.workers.tasks import process_document, reindex_knowledge_base, warm_cache
 
     settings = get_settings()
 
     return {
-        "functions": [process_document],
+        "functions": [process_document, reindex_knowledge_base, warm_cache],
         "redis_settings": RedisSettings.from_dsn(settings.redis_url),
         "max_jobs": settings.arq_max_jobs,
         "job_timeout": settings.arq_job_timeout,
@@ -54,11 +54,11 @@ def get_worker_settings() -> dict:
 class WorkerSettings:
     """ARQ WorkerSettings for `arq ai_ready_rag.workers.settings.WorkerSettings`."""
 
-    from ai_ready_rag.workers.tasks import process_document
+    from ai_ready_rag.workers.tasks import process_document, reindex_knowledge_base, warm_cache
 
     settings = get_settings()
 
-    functions = [process_document]
+    functions = [process_document, reindex_knowledge_base, warm_cache]
     redis_settings = RedisSettings.from_dsn(settings.redis_url)
     max_jobs = settings.arq_max_jobs
     job_timeout = settings.arq_job_timeout

--- a/ai_ready_rag/workers/tasks/__init__.py
+++ b/ai_ready_rag/workers/tasks/__init__.py
@@ -4,5 +4,7 @@ All ARQ task functions are imported here for WorkerSettings.functions.
 """
 
 from ai_ready_rag.workers.tasks.document import process_document
+from ai_ready_rag.workers.tasks.reindex import reindex_knowledge_base
+from ai_ready_rag.workers.tasks.warming import warm_cache
 
-__all__ = ["process_document"]
+__all__ = ["process_document", "reindex_knowledge_base", "warm_cache"]

--- a/ai_ready_rag/workers/tasks/reindex.py
+++ b/ai_ready_rag/workers/tasks/reindex.py
@@ -1,0 +1,39 @@
+"""Knowledge base reindex ARQ task.
+
+Delegates to the existing run_reindex_job() worker function.
+Falls back to BackgroundTasks if Redis is unavailable.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def reindex_knowledge_base(
+    ctx: dict,
+    job_id: str,
+) -> dict:
+    """ARQ task: reindex all documents in the knowledge base.
+
+    Thin wrapper around the existing run_reindex_job() function which
+    handles all the complexity (pause/abort detection, failure recording,
+    progress tracking via ReindexService).
+
+    Args:
+        ctx: ARQ context dict (unused — run_reindex_job manages its own resources)
+        job_id: The reindex job ID to process
+
+    Returns:
+        Dict with reindex result (success, job_id)
+    """
+    from ai_ready_rag.services.reindex_worker import run_reindex_job
+
+    logger.info(f"[ARQ] Starting reindex job {job_id}")
+
+    try:
+        await run_reindex_job(job_id)
+        logger.info(f"[ARQ] Reindex job {job_id} completed")
+        return {"success": True, "job_id": job_id}
+    except Exception as e:
+        logger.exception(f"[ARQ] Reindex job {job_id} failed: {e}")
+        return {"success": False, "job_id": job_id, "error": str(e)}

--- a/ai_ready_rag/workers/tasks/warming.py
+++ b/ai_ready_rag/workers/tasks/warming.py
@@ -1,0 +1,76 @@
+"""Cache warming ARQ task.
+
+Runs specified queries through the RAG pipeline to pre-populate cache.
+Falls back to BackgroundTasks if Redis is unavailable.
+"""
+
+import asyncio
+import logging
+
+from ai_ready_rag.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+async def warm_cache(
+    ctx: dict,
+    queries: list[str],
+    triggered_by: str,
+) -> dict:
+    """ARQ task: warm cache by running queries through RAG pipeline.
+
+    Args:
+        ctx: ARQ context dict (contains settings, vector_service from on_startup)
+        queries: List of query strings to warm
+        triggered_by: User ID who triggered the warming
+
+    Returns:
+        Dict with warming result (success, warmed, total)
+    """
+    from ai_ready_rag.db.database import SessionLocal
+    from ai_ready_rag.services.factory import get_vector_service
+    from ai_ready_rag.services.rag_service import RAGRequest, RAGService
+
+    logger.info(
+        f"[ARQ] Starting cache warming: {len(queries)} queries (triggered by {triggered_by})"
+    )
+
+    settings = ctx.get("settings") or get_settings()
+    db = SessionLocal()
+
+    try:
+        vector_service = ctx.get("vector_service") or get_vector_service(settings)
+        if not ctx.get("vector_service"):
+            await vector_service.initialize()
+
+        rag_service = RAGService(settings, vector_service=vector_service)
+        warmed = 0
+
+        for i, query in enumerate(queries):
+            try:
+                request = RAGRequest(
+                    query=query,
+                    user_tags=[],  # Admin context - responses cached without tag restriction
+                    tenant_id="default",
+                )
+                await rag_service.generate(request, db)
+                warmed += 1
+                logger.debug(f"Warmed cache for query: {query[:50]}...")
+            except Exception as e:
+                logger.warning(f"Failed to warm cache for query '{query[:50]}...': {e}")
+
+            # Throttle to reduce Ollama contention with live user requests
+            if i < len(queries) - 1 and settings.warming_delay_seconds > 0:
+                await asyncio.sleep(settings.warming_delay_seconds)
+
+        logger.info(
+            f"[ARQ] Cache warming complete: {warmed}/{len(queries)} queries processed "
+            f"(triggered by: {triggered_by})"
+        )
+        return {"success": True, "warmed": warmed, "total": len(queries)}
+
+    except Exception as e:
+        logger.error(f"[ARQ] Cache warming task failed: {e}")
+        return {"success": False, "error": str(e), "warmed": 0, "total": len(queries)}
+    finally:
+        db.close()

--- a/tests/test_arq_warming_reindex.py
+++ b/tests/test_arq_warming_reindex.py
@@ -1,0 +1,227 @@
+"""Tests for ARQ cache warming and reindex task migration."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestWarmCacheTask:
+    """Tests for the warm_cache ARQ task."""
+
+    def test_warm_cache_is_callable(self):
+        """warm_cache task function exists and is callable."""
+        from ai_ready_rag.workers.tasks.warming import warm_cache
+
+        assert callable(warm_cache)
+
+    def test_warm_cache_registered_in_tasks_package(self):
+        """warm_cache is exported from workers.tasks."""
+        from ai_ready_rag.workers.tasks import warm_cache
+
+        assert callable(warm_cache)
+
+    @pytest.mark.asyncio
+    async def test_warm_cache_returns_success_dict(self):
+        """warm_cache returns dict with success, warmed, total keys."""
+        from ai_ready_rag.workers.tasks.warming import warm_cache
+
+        mock_db = MagicMock()
+        mock_vector_service = AsyncMock()
+        mock_rag_service = AsyncMock()
+
+        with (
+            patch("ai_ready_rag.db.database.SessionLocal", return_value=mock_db),
+            patch(
+                "ai_ready_rag.services.factory.get_vector_service", return_value=mock_vector_service
+            ),
+            patch("ai_ready_rag.services.rag_service.RAGService", return_value=mock_rag_service),
+        ):
+            ctx = {
+                "settings": MagicMock(warming_delay_seconds=0),
+                "vector_service": mock_vector_service,
+            }
+            result = await warm_cache(ctx, queries=["test query"], triggered_by="user-123")
+
+            assert result["success"] is True
+            assert result["warmed"] == 1
+            assert result["total"] == 1
+
+    @pytest.mark.asyncio
+    async def test_warm_cache_handles_query_failure(self):
+        """warm_cache handles individual query failures gracefully."""
+        from ai_ready_rag.workers.tasks.warming import warm_cache
+
+        mock_db = MagicMock()
+        mock_vector_service = AsyncMock()
+        mock_rag_service = AsyncMock()
+        mock_rag_service.generate = AsyncMock(side_effect=Exception("Ollama timeout"))
+
+        with (
+            patch("ai_ready_rag.db.database.SessionLocal", return_value=mock_db),
+            patch(
+                "ai_ready_rag.services.factory.get_vector_service", return_value=mock_vector_service
+            ),
+            patch("ai_ready_rag.services.rag_service.RAGService", return_value=mock_rag_service),
+        ):
+            ctx = {
+                "settings": MagicMock(warming_delay_seconds=0),
+                "vector_service": mock_vector_service,
+            }
+            result = await warm_cache(ctx, queries=["fail query"], triggered_by="user-123")
+
+            assert result["success"] is True
+            assert result["warmed"] == 0
+            assert result["total"] == 1
+
+
+class TestReindexKnowledgeBaseTask:
+    """Tests for the reindex_knowledge_base ARQ task."""
+
+    def test_reindex_task_is_callable(self):
+        """reindex_knowledge_base task function exists and is callable."""
+        from ai_ready_rag.workers.tasks.reindex import reindex_knowledge_base
+
+        assert callable(reindex_knowledge_base)
+
+    def test_reindex_task_registered_in_tasks_package(self):
+        """reindex_knowledge_base is exported from workers.tasks."""
+        from ai_ready_rag.workers.tasks import reindex_knowledge_base
+
+        assert callable(reindex_knowledge_base)
+
+    @pytest.mark.asyncio
+    async def test_reindex_returns_success_dict(self):
+        """reindex_knowledge_base returns dict with success and job_id."""
+        from ai_ready_rag.workers.tasks.reindex import reindex_knowledge_base
+
+        with patch(
+            "ai_ready_rag.services.reindex_worker.run_reindex_job",
+            new_callable=AsyncMock,
+        ):
+            ctx = {}
+            result = await reindex_knowledge_base(ctx, job_id="job-123")
+
+            assert result["success"] is True
+            assert result["job_id"] == "job-123"
+
+    @pytest.mark.asyncio
+    async def test_reindex_returns_failure_on_exception(self):
+        """reindex_knowledge_base returns failure dict on exception."""
+        from ai_ready_rag.workers.tasks.reindex import reindex_knowledge_base
+
+        with patch(
+            "ai_ready_rag.services.reindex_worker.run_reindex_job",
+            new_callable=AsyncMock,
+            side_effect=Exception("DB connection lost"),
+        ):
+            ctx = {}
+            result = await reindex_knowledge_base(ctx, job_id="job-456")
+
+            assert result["success"] is False
+            assert result["job_id"] == "job-456"
+            assert "DB connection lost" in result["error"]
+
+
+class TestWorkerSettingsRegistration:
+    """Test new tasks are registered in WorkerSettings."""
+
+    def test_worker_settings_includes_warm_cache(self):
+        """WorkerSettings.functions includes warm_cache."""
+        from ai_ready_rag.workers.settings import WorkerSettings
+        from ai_ready_rag.workers.tasks.warming import warm_cache
+
+        assert warm_cache in WorkerSettings.functions
+
+    def test_worker_settings_includes_reindex(self):
+        """WorkerSettings.functions includes reindex_knowledge_base."""
+        from ai_ready_rag.workers.settings import WorkerSettings
+        from ai_ready_rag.workers.tasks.reindex import reindex_knowledge_base
+
+        assert reindex_knowledge_base in WorkerSettings.functions
+
+    def test_worker_settings_has_three_tasks(self):
+        """WorkerSettings.functions has all 3 registered tasks."""
+        from ai_ready_rag.workers.settings import WorkerSettings
+
+        assert len(WorkerSettings.functions) == 3
+
+    def test_get_worker_settings_includes_new_tasks(self):
+        """get_worker_settings() returns all 3 tasks."""
+        from ai_ready_rag.workers.settings import get_worker_settings
+
+        config = get_worker_settings()
+        assert len(config["functions"]) == 3
+
+
+class TestAdminReindexARQEnqueue:
+    """Test reindex start endpoint uses ARQ with fallback."""
+
+    def test_reindex_start_with_arq(self, client, admin_headers, db):
+        """Reindex start uses ARQ when Redis available."""
+        mock_redis = AsyncMock()
+        mock_redis.enqueue_job = AsyncMock(return_value=AsyncMock(job_id="arq-reindex-1"))
+
+        with patch("ai_ready_rag.api.admin.get_redis_pool", return_value=mock_redis):
+            response = client.post(
+                "/api/admin/reindex/start",
+                json={"confirm": True},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 202
+        mock_redis.enqueue_job.assert_called_once()
+        call_args = mock_redis.enqueue_job.call_args
+        assert call_args[0][0] == "reindex_knowledge_base"
+
+    def test_reindex_start_fallback_no_redis(self, client, admin_headers, db):
+        """Reindex start falls back to BackgroundTasks when no Redis."""
+        with patch("ai_ready_rag.api.admin.get_redis_pool", return_value=None):
+            response = client.post(
+                "/api/admin/reindex/start",
+                json={"confirm": True},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 202
+
+
+class TestAdminWarmCacheARQEnqueue:
+    """Test cache warm endpoint uses ARQ with fallback."""
+
+    def test_warm_cache_with_arq(self, client, admin_headers, db):
+        """Cache warm uses ARQ when Redis available."""
+        mock_redis = AsyncMock()
+        mock_redis.enqueue_job = AsyncMock(return_value=AsyncMock(job_id="arq-warm-1"))
+
+        with patch("ai_ready_rag.api.admin.get_redis_pool", return_value=mock_redis):
+            response = client.post(
+                "/api/admin/cache/warm",
+                json={"queries": ["What is RAG?", "How to use vectors?"]},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 202
+        mock_redis.enqueue_job.assert_called_once()
+        call_args = mock_redis.enqueue_job.call_args
+        assert call_args[0][0] == "warm_cache"
+        assert call_args[0][1] == ["What is RAG?", "How to use vectors?"]
+
+    def test_warm_cache_fallback_no_redis(self, client, admin_headers, db):
+        """Cache warm falls back to BackgroundTasks when no Redis."""
+        with patch("ai_ready_rag.api.admin.get_redis_pool", return_value=None):
+            response = client.post(
+                "/api/admin/cache/warm",
+                json={"queries": ["test query"]},
+                headers=admin_headers,
+            )
+
+        assert response.status_code == 202
+
+    def test_warm_cache_empty_queries_rejected(self, client, admin_headers, db):
+        """Empty queries list returns 400."""
+        response = client.post(
+            "/api/admin/cache/warm",
+            json={"queries": []},
+            headers=admin_headers,
+        )
+        assert response.status_code == 400


### PR DESCRIPTION
## Summary
- Add `warm_cache` and `reindex_knowledge_base` ARQ tasks with BackgroundTasks fallback
- Replace 2 `background_tasks.add_task()` calls in admin.py with ARQ enqueue + degraded mode
- Register both tasks in WorkerSettings (now 3 total: document, warming, reindex)

## Changes
| File | Change |
|------|--------|
| `workers/tasks/warming.py` | NEW — `warm_cache` ARQ task |
| `workers/tasks/reindex.py` | NEW — `reindex_knowledge_base` ARQ task |
| `workers/tasks/__init__.py` | Register new tasks |
| `workers/settings.py` | Add to WorkerSettings functions list |
| `api/admin.py` | ARQ enqueue with BackgroundTasks fallback for reindex + warming |
| `tests/test_arq_warming_reindex.py` | 17 tests covering both paths |

## Test plan
- [x] 17 new tests pass (task functions, registration, ARQ enqueue, fallback, validation)
- [x] 664/670 total tests pass (6 pre-existing test_cache_integration failures from test pollution)
- [x] ruff check + format clean

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)