### PR TITLE
feat: Update frontend for warming queue redesign (#192)

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -535,23 +535,52 @@ export interface WarmFileResponse {
 // Cache Warming Queue Types
 // =============================================================================
 
-export type WarmingJobStatus = 'pending' | 'running' | 'paused' | 'completed' | 'failed' | 'cancelled';
+export type WarmingJobStatus = 'pending' | 'running' | 'paused' | 'completed'
+  | 'completed_with_errors' | 'failed' | 'cancelled';
 
 export interface WarmingJob {
   id: string;
-  source_file: string | null;
+  source_type: string;
+  original_filename: string | null;
   status: WarmingJobStatus;
-  total: number;
-  processed: number;
-  success_count: number;
-  failed_count: number;
+  total_queries: number;
+  completed_queries: number;
+  failed_queries: number;
+  pending_queries: number;
+  is_paused: boolean;
+  is_cancel_requested: boolean;
   created_at: string | null;
   started_at: string | null;
   completed_at: string | null;
-  triggered_by: string;
-  // Transitional state flags
-  is_cancel_requested?: boolean;
-  is_paused?: boolean;
+  submitted_by: string | null;
+  error_message: string | null;
+  worker_id: string | null;
+}
+
+export type WarmingQueryStatus = 'pending' | 'processing' | 'completed' | 'failed' | 'skipped';
+
+export interface WarmingQuery {
+  id: string;
+  query_text: string;
+  status: WarmingQueryStatus;
+  error_message: string | null;
+  error_type: string | null;
+  retry_count: number;
+  sort_order: number;
+  processed_at: string | null;
+  created_at: string | null;
+}
+
+export interface BatchQueriesResponse {
+  queries: WarmingQuery[];
+  total_count: number;
+  batch_id: string;
+}
+
+export interface QueryRetryResponse {
+  batch_id: string;
+  retried_count: number;
+  message: string;
 }
 
 export interface WarmingJobListResponse {


### PR DESCRIPTION
## What
Phase 5 of the Warming Queue Redesign: update React frontend to display batch/query-level warming data, handle new status values, add retry capabilities, and update SSE event handling.

Closes #192

## Why
Backend endpoints now return `WarmingBatch`/`WarmingQuery` data with new fields and status values. Frontend types, API calls, store, and component need alignment.

## How
- **Types**: Added `completed_with_errors` to `WarmingJobStatus`, realigned `WarmingJob` fields to match backend, added `WarmingQuery`, `BatchQueriesResponse`, `QueryRetryResponse`
- **API**: Added `getBatchQueries()`, `retryBatch()`, `retryQuery()`. Removed legacy `retryWarmCache()`
- **Store**: Added query expansion state and updated `updateProgress` for new SSE payload shape
- **Component**: Expandable batch rows with lazy-loaded queries, new status badges (`completed_with_errors`, query statuses), batch + single-query retry buttons, updated SSE handlers (`paused` event, new progress shape), UX text changes

## Stack
- [ ] Backend
- [x] Frontend

## Verification
- [x] `npm run lint` — 0 errors on modified files
- [x] `npm run build` — SUCCESS (2161 modules)
- [x] ENUM_VALUE check — all statuses use exact backend strings (snake_case)

## How to Test
1. Navigate to Admin > Cache Warming
2. Submit a warming batch, verify progress SSE updates
3. Click on a batch row to expand and see individual queries
4. Verify `completed_with_errors` badge renders for partial failures
5. Test retry buttons on failed queries and batches

## Risks / Rollback
Low risk — frontend-only, consuming existing backend API.

---
Artifacts: `.agents/outputs/map-192-020926.md`, `plan-192-020926.md`, `patch-192-020926.md`, `prove-192-020926.md`