### PR TITLE
fix: Config naming drift and single-query retry response shape (#215)

### DIFF
--- a/ai_ready_rag/config.py
+++ b/ai_ready_rag/config.py
@@ -140,7 +140,7 @@ class Settings(BaseSettings):
     # Cache Warming - Core settings
     warming_delay_seconds: float = 2.0  # Delay between warming queries to reduce Ollama contention
     warming_scan_interval_seconds: int = 5  # DB polling interval for pending batches
-    warming_max_file_size_mb: float = 10.0  # Max uploaded file size for batch submissions
+    warming_max_upload_size_mb: float = 10.0  # Max uploaded file size for batch submissions
     warming_max_queries_per_batch: int = 10000  # Max queries per batch submission
 
     # Cache Warming - Worker settings

--- a/ai_ready_rag/schemas/admin.py
+++ b/ai_ready_rag/schemas/admin.py
@@ -609,6 +609,16 @@ class QueryRetryResponse(BaseModel):
     message: str
 
 
+class SingleQueryRetryResponse(BaseModel):
+    """Response model for single query retry operation."""
+
+    query_id: str
+    batch_id: str
+    status: str
+    retry_count: int
+    batch_requeued: bool
+
+
 # =============================================================================
 # Cache Settings & Stats
 # =============================================================================

--- a/frontend/src/api/cache.ts
+++ b/frontend/src/api/cache.ts
@@ -10,6 +10,7 @@ import type {
   WarmingJob,
   WarmingJobListResponse,
   BatchQueriesResponse,
+  SingleQueryRetryResponse,
   QueryRetryResponse,
   WarmingQueryStatus,
 } from '../types';
@@ -141,8 +142,8 @@ export async function retryBatch(batchId: string): Promise<QueryRetryResponse> {
 export async function retryQuery(
   batchId: string,
   queryId: string,
-): Promise<QueryRetryResponse> {
-  return apiClient.post<QueryRetryResponse>(
+): Promise<SingleQueryRetryResponse> {
+  return apiClient.post<SingleQueryRetryResponse>(
     `/api/admin/warming/batch/${batchId}/queries/${queryId}/retry`
   );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -584,6 +584,14 @@ export interface QueryRetryResponse {
   message: string;
 }
 
+export interface SingleQueryRetryResponse {
+  query_id: string;
+  batch_id: string;
+  status: string;
+  retry_count: number;
+  batch_requeued: boolean;
+}
+
 export interface WarmingJobListResponse {
   jobs: WarmingJob[];
   total_count: number;

--- a/tests/test_warming_api.py
+++ b/tests/test_warming_api.py
@@ -712,7 +712,11 @@ class TestRetryEndpoints:
             )
         assert response.status_code == 200
         data = response.json()
-        assert data["retried_count"] == 1
+        assert data["query_id"] == failed_query.id
+        assert data["batch_id"] == completed_batch.id
+        assert data["status"] == "pending"
+        assert "retry_count" in data
+        assert "batch_requeued" in data
 
     def test_retry_non_failed_query(self, client, system_admin_headers, completed_batch, db):
         completed_query = (
@@ -727,7 +731,7 @@ class TestRetryEndpoints:
             f"/api/admin/warming/batch/{completed_batch.id}/queries/{completed_query.id}/retry",
             headers=system_admin_headers,
         )
-        assert response.status_code == 400
+        assert response.status_code == 409
         assert "failed" in response.json()["detail"].lower()
 
 


### PR DESCRIPTION
## What
Two P1 spec/code alignment fixes for the warming queue system:
1. Renamed config field `warming_max_file_size_mb` → `warming_max_upload_size_mb` to match spec
2. Updated single-query retry endpoint response shape and error code to match spec

## Why
Config naming and API response shape drifted from the warming queue redesign spec (v1.2). This causes inconsistency between documentation and implementation.

Closes #215

## How
- **P1-4 (Config drift)**: Renamed field in `config.py` and updated 2 references in `admin.py`
- **P1-6 (Retry response)**: Created new `SingleQueryRetryResponse` schema with spec-required fields (`query_id`, `batch_id`, `status`, `retry_count`, `batch_requeued`), changed error code from 400 → 409 Conflict for non-failed query retry, updated frontend types and test assertions

## Stack
- [x] Backend
- [x] Frontend (type definitions only)

## Contract Changes
- `POST /warming/batch/{id}/queries/{query_id}/retry` now returns `SingleQueryRetryResponse` instead of `QueryRetryResponse`
- Non-failed query retry now returns 409 Conflict instead of 400 Bad Request

## Verification
- [x] `ruff check .` passes
- [x] `pytest -q` passes (733 passed, 6 pre-existing failures, 0 regressions)

## How to Test
1. Start the backend: `python -m uvicorn ai_ready_rag.main:app --port 8502`
2. Create a warming batch with a query that fails
3. Retry the failed query — verify response contains `{query_id, batch_id, status, retry_count, batch_requeued}`
4. Retry a non-failed query — verify 409 Conflict response

## Risks / Rollback
Low risk — config rename is mechanical, new response schema is additive (frontend discards return value). Frontend type update is backward-compatible.

---
Artifacts: `.agents/outputs/*-215-*.md`