### PR TITLE
fix: Query normalization, aggregates, all_failed flag, retry scope, 410 stubs (#216)

### DIFF
--- a/ai_ready_rag/schemas/admin.py
+++ b/ai_ready_rag/schemas/admin.py
@@ -557,6 +557,7 @@ class WarmingQueueJobResponse(BaseModel):
     submitted_by: str | None = None
     error_message: str | None = None
     worker_id: str | None = None
+    all_failed: bool = False
 
 
 class WarmingQueueListResponse(BaseModel):
@@ -599,6 +600,9 @@ class BatchQueriesResponse(BaseModel):
     queries: list[WarmingQueryResponse]
     total_count: int
     batch_id: str
+    completed: int = 0
+    failed: int = 0
+    pending: int = 0
 
 
 class QueryRetryResponse(BaseModel):

--- a/frontend/src/components/features/admin/CacheWarmingCard.tsx
+++ b/frontend/src/components/features/admin/CacheWarmingCard.tsx
@@ -936,17 +936,17 @@ export function CacheWarmingCard({
                               {estimatedTimeRemaining && ` - ${formatTimeRemaining(estimatedTimeRemaining)}`}
                             </span>
                           )}
-                          {job.status === 'completed_with_errors' && (
-                            <span className="text-xs text-amber-600 mt-0.5 block">
-                              {job.failed_queries} of {job.total_queries} queries failed
-                            </span>
-                          )}
-                          {job.status === 'failed' && (
+                          {job.status === 'completed_with_errors' && job.all_failed && (
                             <span className="text-xs text-red-500 mt-0.5 block">
                               All queries failed
                             </span>
                           )}
-                          {job.status !== 'completed_with_errors' && job.status !== 'failed' && job.failed_queries > 0 && (
+                          {job.status === 'completed_with_errors' && !job.all_failed && (
+                            <span className="text-xs text-amber-600 mt-0.5 block">
+                              {job.failed_queries} of {job.total_queries} queries failed
+                            </span>
+                          )}
+                          {job.status !== 'completed_with_errors' && job.failed_queries > 0 && (
                             <span className="text-xs text-red-500 mt-0.5 block">
                               {job.failed_queries} failed
                             </span>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -555,6 +555,7 @@ export interface WarmingJob {
   submitted_by: string | null;
   error_message: string | null;
   worker_id: string | null;
+  all_failed: boolean;
 }
 
 export type WarmingQueryStatus = 'pending' | 'processing' | 'cancelling' | 'completed' | 'failed' | 'skipped';
@@ -576,6 +577,9 @@ export interface BatchQueriesResponse {
   queries: WarmingQuery[];
   total_count: number;
   batch_id: string;
+  completed: number;
+  failed: number;
+  pending: number;
 }
 
 export interface QueryRetryResponse {

--- a/tests/test_admin_cache_warming.py
+++ b/tests/test_admin_cache_warming.py
@@ -91,14 +91,15 @@ class TestGetTopQueries:
 
 
 class TestWarmCache:
-    """Tests for POST /api/admin/cache/warm endpoint (fully removed in #193)."""
+    """Tests for POST /api/admin/cache/warm endpoint (returns 410 Gone)."""
 
-    def test_endpoint_removed(self, client, admin_headers):
-        """Legacy endpoint fully removed -- no longer returns 410, returns 404/405."""
+    def test_endpoint_returns_410(self, client, admin_headers):
+        """Legacy endpoint returns 410 Gone with redirect guidance."""
         response = client.post(
             "/api/admin/cache/warm",
             json={"queries": ["What is the vacation policy?"]},
             headers=admin_headers,
         )
 
-        assert response.status_code in [404, 405]
+        assert response.status_code == 410
+        assert "warming/queue/manual" in response.json()["detail"]

--- a/tests/test_cache_integration.py
+++ b/tests/test_cache_integration.py
@@ -379,23 +379,25 @@ class TestCacheWarming:
     process_warming_batch ARQ task.
     """
 
-    def test_legacy_warm_endpoint_removed(self, client, admin_headers):
-        """Legacy POST /cache/warm endpoint fully removed (#193)."""
+    def test_legacy_warm_endpoint_gone(self, client, admin_headers):
+        """Legacy POST /cache/warm returns 410 Gone with redirect guidance."""
         response = client.post(
             "/api/admin/cache/warm",
             json={"queries": ["Query 1"]},
             headers=admin_headers,
         )
-        assert response.status_code in [404, 405]
+        assert response.status_code == 410
+        assert "warming/queue/manual" in response.json()["detail"]
 
-    def test_legacy_warm_retry_removed(self, client, admin_headers):
-        """Legacy POST /cache/warm-retry endpoint fully removed (#193)."""
+    def test_legacy_warm_retry_gone(self, client, admin_headers):
+        """Legacy POST /cache/warm-retry returns 410 Gone with redirect guidance."""
         response = client.post(
             "/api/admin/cache/warm-retry",
             json={"queries": ["Query 1"]},
             headers=admin_headers,
         )
-        assert response.status_code in [404, 405]
+        assert response.status_code == 410
+        assert "warming/batch" in response.json()["detail"]
 
 
 class TestCacheEntryToResponse:

--- a/tests/test_warming_integration.py
+++ b/tests/test_warming_integration.py
@@ -334,16 +334,14 @@ class TestWarmingJobLifecycle:
 
 
 class TestDeprecatedEndpoints:
-    """Verify legacy warming endpoints have been fully removed (#193)."""
+    """Verify legacy warming endpoints return 410 Gone."""
 
-    def test_old_warm_endpoint_removed(self, client, admin_headers):
-        """Old /api/admin/cache/warm fully removed in Phase 6 cleanup."""
+    def test_old_warm_endpoint_gone(self, client, admin_headers):
+        """Old /api/admin/cache/warm returns 410 Gone with redirect guidance."""
         response = client.post(
             "/api/admin/cache/warm",
             headers=admin_headers,
             json={"queries": ["test"]},
         )
-        # Endpoint fully removed -- should be 404 or 405 (no route matches)
-        assert response.status_code in [404, 405], (
-            f"Old endpoint should be removed, not {response.status_code}"
-        )
+        assert response.status_code == 410
+        assert "warming/queue/manual" in response.json()["detail"]


### PR DESCRIPTION
## What
Five P2 spec/code alignment fixes for the warming queue system:
1. **P2-8**: Whitespace normalization — collapse internal spaces in queries
2. **P2-9**: Batch query aggregates — add `completed`/`failed`/`pending` counts
3. **P2-10**: `all_failed` derived flag — expose on batch response + frontend display
4. **P2-11**: Retry scope — only reset `failed` queries (not `skipped`)
5. **P2-12**: Legacy 410 stubs — 4 deprecated endpoints return 410 Gone with redirect

## Why
Code drifted from the warming queue redesign spec (v1.2). These P2 fixes bring the implementation into alignment after P0/P1 fixes in #213, #214, #215.

Closes #216

## How
- Added `re.sub(r"\s+", " ", ...)` for whitespace normalization in both upload and manual query paths
- Added aggregate count fields to `BatchQueriesResponse` schema, computed via SQL `COUNT(CASE(...))` 
- Added `all_failed: bool` to `WarmingQueueJobResponse`, computed in `_batch_to_response()`
- Narrowed retry filter from `status.in_(["failed", "skipped"])` to `status == "failed"`
- Added 4 legacy route stubs returning 410 Gone with redirect messages
- Updated frontend `WarmingJob` type and `CacheWarmingCard` display logic for `all_failed`

## Stack
- [x] Backend
- [x] Frontend

## Contract Changes
- `WarmingQueueJobResponse` adds `all_failed: bool` (default `False`, additive)
- `BatchQueriesResponse` adds `completed: int`, `failed: int`, `pending: int` (additive)
- Frontend `CacheWarmingCard` now uses `job.all_failed` instead of `job.status === 'failed'` for display
- 4 legacy `/cache/warm*` endpoints now return 410 instead of 404/405

## Verification
- [x] `ruff check .` passes
- [x] `pytest -q` passes (736 passed, 6 pre-existing failures, 0 regressions)
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes

## How to Test
1. Start backend: `python -m uvicorn ai_ready_rag.main:app --port 8502`
2. Create warming batch with queries containing extra spaces — verify normalization
3. View batch queries — verify `completed`/`failed`/`pending` counts in response
4. Create batch where all queries fail — verify `all_failed: true` and distinct UI messaging
5. Retry a batch — verify only `failed` queries are reset (not `skipped`)
6. Hit `POST /api/admin/cache/warm` — verify 410 Gone response

## Risks / Rollback
Low risk — all backend changes are additive with defaults. Retry scope narrowing is intentional per spec. 410 stubs replace implicit 404s. Frontend display change is cosmetic.

---
Artifacts: `.agents/outputs/*-216-*.md`