### PR TITLE
fix: Pass TESSDATA_PREFIX to Docling OCR options

### DIFF
--- a/ai_ready_rag/services/chunker_docling.py
+++ b/ai_ready_rag/services/chunker_docling.py
@@ -1,6 +1,7 @@
 """Docling chunker for production/Spark deployments."""
 
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -71,9 +72,11 @@ class DoclingChunker:
                 try:
                     from docling.datamodel.pipeline_options import TesseractOcrOptions
 
+                    tessdata_path = os.environ.get("TESSDATA_PREFIX")
                     ocr_options = TesseractOcrOptions(
                         lang=[self.ocr_language],
                         force_full_page_ocr=self.force_full_page_ocr,
+                        path=tessdata_path,
                     )
                     pipeline_options.ocr_options = ocr_options
                 except ImportError:


### PR DESCRIPTION
## Summary
- Pass `TESSDATA_PREFIX` env var to `TesseractOcrOptions(path=...)` so Docling/tesserocr finds language models on Spark
- Without this, tesserocr defaults to looking in `./` (current working directory) and fails with "No language models detected"

## Test plan
- [x] Verified on DGX Spark: `518 CC&R's.pdf` processed successfully (89 chunks, 9,428 words)

🤖 Generated with [Claude Code](https://claude.com/claude-code)