### PR TITLE
fix: Run chunk_document in thread pool to unblock event loop

### DIFF
--- a/ai_ready_rag/services/processing_service.py
+++ b/ai_ready_rag/services/processing_service.py
@@ -1,5 +1,6 @@
 """Document processing service with profile-aware chunking."""
 
+import asyncio
 import logging
 import time
 from dataclasses import dataclass
@@ -128,9 +129,11 @@ class ProcessingService:
             else:
                 chunker = self.chunker
 
-            # Chunk document using profile-appropriate chunker
+            # Chunk document using profile-appropriate chunker.
+            # Run in a thread so the async event loop stays responsive
+            # during long-running OCR/Docling processing.
             metadata = {"title": document.title} if document.title else None
-            chunk_dicts = chunker.chunk_document(str(file_path), metadata)
+            chunk_dicts = await asyncio.to_thread(chunker.chunk_document, str(file_path), metadata)
 
             if not chunk_dicts:
                 raise ValueError("No chunks extracted from document")


### PR DESCRIPTION
## Summary
- Wrap `chunker.chunk_document()` in `asyncio.to_thread()` so OCR processing runs in a thread pool instead of blocking the event loop
- Prevents server from becoming unresponsive during Docling/tesseract OCR (20-60s per PDF)
- Safe now that OCR uses CLI tesseract (subprocess-isolated, no shared C state)

## Root Cause
On Spark, folder uploads stalled because the first PDF's synchronous OCR processing blocked the event loop, preventing all subsequent upload requests, health checks, and API calls from being served.

## Test plan
- [x] 757 tests pass (6 pre-existing failures unrelated)
- [ ] Deploy to Spark, upload folder of PDFs, verify server stays responsive
- [ ] Verify health endpoint responds during OCR processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)