### PR TITLE
fix: Harden folder upload with error resilience

### DIFF
--- a/frontend/src/components/features/documents/UploadDropZone.tsx
+++ b/frontend/src/components/features/documents/UploadDropZone.tsx
@@ -1,9 +1,10 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { Upload, FileText } from 'lucide-react';
+import { Upload, FileText, Loader2 } from 'lucide-react';
 
 interface UploadDropZoneProps {
   onFilesSelected: (files: File[], skippedFiles?: File[]) => void;
   disabled?: boolean;
+  maxFiles?: number;
 }
 
 const ALLOWED_TYPES = [
@@ -19,7 +20,20 @@ const ALLOWED_TYPES = [
 
 const ALLOWED_EXTENSIONS = ['.pdf', '.docx', '.xlsx', '.pptx', '.txt', '.md', '.html', '.csv'];
 
+// Hidden/system files to always skip
+const IGNORED_NAMES = new Set(['.DS_Store', 'Thumbs.db', 'desktop.ini', '.gitkeep']);
+const IGNORED_PREFIXES = ['~$', '._'];
+
+function isHiddenOrSystemFile(name: string): boolean {
+  if (IGNORED_NAMES.has(name)) return true;
+  if (IGNORED_PREFIXES.some((p) => name.startsWith(p))) return true;
+  // Files inside __MACOSX directory
+  if (name.includes('__MACOSX')) return true;
+  return false;
+}
+
 function isValidFile(file: File): boolean {
+  if (isHiddenOrSystemFile(file.name)) return false;
   // Check MIME type
   if (ALLOWED_TYPES.includes(file.type)) {
     return true;
@@ -35,12 +49,16 @@ async function readAllDirectoryEntries(
   const reader = directory.createReader();
   const entries: FileSystemEntry[] = [];
 
-  while (true) {
-    const batch = await new Promise<FileSystemEntry[]>((resolve, reject) => {
-      reader.readEntries(resolve, reject);
-    });
-    if (batch.length === 0) break;
-    entries.push(...batch);
+  try {
+    while (true) {
+      const batch = await new Promise<FileSystemEntry[]>((resolve, reject) => {
+        reader.readEntries(resolve, reject);
+      });
+      if (batch.length === 0) break;
+      entries.push(...batch);
+    }
+  } catch (err) {
+    console.warn(`Failed to read directory "${directory.name}":`, err);
   }
 
   return entries;
@@ -49,17 +67,24 @@ async function readAllDirectoryEntries(
 async function entryToFiles(entry: FileSystemEntry): Promise<File[]> {
   if (entry.isFile) {
     const fileEntry = entry as FileSystemFileEntry;
-    const file = await new Promise<File>((resolve, reject) => {
-      fileEntry.file(resolve, reject);
-    });
-    return [file];
+    try {
+      const file = await new Promise<File>((resolve, reject) => {
+        fileEntry.file(resolve, reject);
+      });
+      return [file];
+    } catch (err) {
+      console.warn(`Failed to read file "${entry.name}":`, err);
+      return [];
+    }
   }
 
   if (entry.isDirectory) {
     const directoryEntry = entry as FileSystemDirectoryEntry;
     const childEntries = await readAllDirectoryEntries(directoryEntry);
-    const nestedFiles = await Promise.all(childEntries.map((child) => entryToFiles(child)));
-    return nestedFiles.flat();
+    const results = await Promise.allSettled(childEntries.map((child) => entryToFiles(child)));
+    return results
+      .filter((r): r is PromiseFulfilledResult<File[]> => r.status === 'fulfilled')
+      .flatMap((r) => r.value);
   }
 
   return [];
@@ -75,12 +100,22 @@ async function extractDroppedFiles(dataTransfer: DataTransfer): Promise<File[]> 
     return Array.from(dataTransfer.files);
   }
 
-  const fileGroups = await Promise.all(entries.map((entry) => entryToFiles(entry)));
-  return fileGroups.flat();
+  const results = await Promise.allSettled(entries.map((entry) => entryToFiles(entry)));
+  return results
+    .filter((r): r is PromiseFulfilledResult<File[]> => r.status === 'fulfilled')
+    .flatMap((r) => r.value);
 }
 
-export function UploadDropZone({ onFilesSelected, disabled = false }: UploadDropZoneProps) {
+const DEFAULT_MAX_FILES = 100;
+
+export function UploadDropZone({
+  onFilesSelected,
+  disabled = false,
+  maxFiles = DEFAULT_MAX_FILES,
+}: UploadDropZoneProps) {
   const [isDragging, setIsDragging] = useState(false);
+  const [isEnumerating, setIsEnumerating] = useState(false);
+  const [enumerationError, setEnumerationError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const folderInputRef = useRef<HTMLInputElement>(null);
   const lastPickerOpenAtRef = useRef(0);
@@ -97,6 +132,29 @@ export function UploadDropZone({ onFilesSelected, disabled = false }: UploadDrop
   useEffect(() => {
     configureFolderInput();
   }, [configureFolderInput]);
+
+  const processFiles = useCallback(
+    (files: File[]) => {
+      setEnumerationError(null);
+
+      const validFiles = files.filter(isValidFile);
+      const skippedFiles = files.filter((f) => !isHiddenOrSystemFile(f.name) && !isValidFile(f));
+
+      if (validFiles.length > maxFiles) {
+        setEnumerationError(
+          `Too many files (${validFiles.length}). Maximum is ${maxFiles}. Select a smaller folder.`
+        );
+        return;
+      }
+
+      if (validFiles.length > 0) {
+        onFilesSelected(validFiles, skippedFiles);
+      } else if (skippedFiles.length > 0) {
+        onFilesSelected([], skippedFiles);
+      }
+    },
+    [maxFiles, onFilesSelected]
+  );
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -120,31 +178,32 @@ export function UploadDropZone({ onFilesSelected, disabled = false }: UploadDrop
 
       if (disabled) return;
 
-      const files = await extractDroppedFiles(e.dataTransfer);
-      const validFiles = files.filter(isValidFile);
-      const skippedFiles = files.filter((file) => !isValidFile(file));
-
-      if (validFiles.length > 0) {
-        onFilesSelected(validFiles, skippedFiles);
-        return;
-      }
-
-      if (skippedFiles.length > 0) {
-        onFilesSelected([], skippedFiles);
+      setIsEnumerating(true);
+      setEnumerationError(null);
+      try {
+        const files = await extractDroppedFiles(e.dataTransfer);
+        processFiles(files);
+      } catch (err) {
+        console.error('Failed to read dropped files:', err);
+        setEnumerationError('Failed to read some files. Try using "Select folder" instead.');
+      } finally {
+        setIsEnumerating(false);
       }
     },
-    [disabled, onFilesSelected]
+    [disabled, processFiles]
   );
 
   const openPicker = useCallback(
     (picker: 'file' | 'folder') => {
-      if (disabled) return;
+      if (disabled || isEnumerating) return;
 
       const now = Date.now();
       if (now - lastPickerOpenAtRef.current < 500) {
         return;
       }
       lastPickerOpenAtRef.current = now;
+
+      setEnumerationError(null);
 
       if (picker === 'folder') {
         configureFolderInput();
@@ -154,19 +213,12 @@ export function UploadDropZone({ onFilesSelected, disabled = false }: UploadDrop
 
       fileInputRef.current?.click();
     },
-    [configureFolderInput, disabled]
+    [configureFolderInput, disabled, isEnumerating]
   );
 
   const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
-    const validFiles = files.filter(isValidFile);
-    const skippedFiles = files.filter((file) => !isValidFile(file));
-
-    if (validFiles.length > 0) {
-      onFilesSelected(validFiles, skippedFiles);
-    } else if (skippedFiles.length > 0) {
-      onFilesSelected([], skippedFiles);
-    }
+    processFiles(files);
 
     // Reset input
     if (fileInputRef.current) {
@@ -176,19 +228,19 @@ export function UploadDropZone({ onFilesSelected, disabled = false }: UploadDrop
 
   const handleFolderInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
-    const validFiles = files.filter(isValidFile);
-    const skippedFiles = files.filter((file) => !isValidFile(file));
-
-    if (validFiles.length > 0) {
-      onFilesSelected(validFiles, skippedFiles);
-    } else if (skippedFiles.length > 0) {
-      onFilesSelected([], skippedFiles);
+    setIsEnumerating(true);
+    try {
+      processFiles(files);
+    } finally {
+      setIsEnumerating(false);
     }
 
     if (folderInputRef.current) {
       folderInputRef.current.value = '';
     }
   };
+
+  const isDisabled = disabled || isEnumerating;
 
   return (
     <div
@@ -199,7 +251,7 @@ export function UploadDropZone({ onFilesSelected, disabled = false }: UploadDrop
         relative border-2 border-dashed rounded-xl p-8
         flex flex-col items-center justify-center
         transition-all
-        ${disabled
+        ${isDisabled
           ? 'border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50'
           : isDragging
             ? 'border-primary bg-primary/5 scale-[1.02]'
@@ -214,41 +266,59 @@ export function UploadDropZone({ onFilesSelected, disabled = false }: UploadDrop
         accept={ALLOWED_EXTENSIONS.join(',')}
         onChange={handleFileInputChange}
         className="hidden"
-        disabled={disabled}
+        disabled={isDisabled}
       />
       <input
         ref={folderInputRef}
         type="file"
         onChange={handleFolderInputChange}
         className="hidden"
-        disabled={disabled}
+        disabled={isDisabled}
       />
 
       <div
         className={`
           w-16 h-16 rounded-full flex items-center justify-center mb-4
-          ${isDragging
+          ${isEnumerating
             ? 'bg-primary/20 text-primary'
-            : 'bg-gray-100 dark:bg-gray-700 text-gray-400'
+            : isDragging
+              ? 'bg-primary/20 text-primary'
+              : 'bg-gray-100 dark:bg-gray-700 text-gray-400'
           }
         `}
       >
-        {isDragging ? <FileText size={32} /> : <Upload size={32} />}
+        {isEnumerating ? (
+          <Loader2 size={32} className="animate-spin" />
+        ) : isDragging ? (
+          <FileText size={32} />
+        ) : (
+          <Upload size={32} />
+        )}
       </div>
 
       <p className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-1">
-        {isDragging ? 'Drop files here' : 'Drag and drop files or folders here'}
+        {isEnumerating
+          ? 'Reading folder contents...'
+          : isDragging
+            ? 'Drop files here'
+            : 'Drag and drop files or folders here'}
       </p>
 
-      <p className="text-sm text-gray-500 dark:text-gray-400">
-        PDF, DOCX, XLSX, PPTX, TXT, MD, HTML, CSV
-      </p>
+      {enumerationError ? (
+        <p className="text-sm text-red-500 dark:text-red-400 mt-1 text-center max-w-md">
+          {enumerationError}
+        </p>
+      ) : (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          PDF, DOCX, XLSX, PPTX, TXT, MD, HTML, CSV
+        </p>
+      )}
       <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
         <button
           type="button"
           className="px-3 py-1.5 text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
           onClick={() => openPicker('file')}
-          disabled={disabled}
+          disabled={isDisabled}
         >
           Select files
         </button>
@@ -256,7 +326,7 @@ export function UploadDropZone({ onFilesSelected, disabled = false }: UploadDrop
           type="button"
           className="px-3 py-1.5 text-sm rounded-md border border-primary text-primary hover:bg-primary/5 disabled:opacity-50 disabled:cursor-not-allowed"
           onClick={() => openPicker('folder')}
-          disabled={disabled}
+          disabled={isDisabled}
         >
           Select folder
         </button>


### PR DESCRIPTION
## Summary
- `Promise.all` → `Promise.allSettled` so one bad file/directory entry doesn't silently kill the entire folder upload
- try/catch around `fileEntry.file()` and `readEntries()` for permission errors and unreadable entries
- Loading spinner + "Reading folder contents..." text during folder enumeration
- Max file count guard (default 100) with visible error message
- Filter hidden/system files (`.DS_Store`, `~$*`, `Thumbs.db`, `__MACOSX`)
- Shared `processFiles()` helper eliminates duplicated validation logic

## Test plan
- [ ] Select folder via "Select folder" button — files appear in queue
- [ ] Drag-and-drop a folder — files appear in queue
- [ ] Folder with >100 valid files shows "Too many files" error
- [ ] Folder with unreadable files gracefully skips them
- [ ] Loading spinner visible during folder enumeration
- [ ] Hidden files (.DS_Store, ~$temp.docx) not queued

🤖 Generated with [Claude Code](https://claude.com/claude-code)