### PR TITLE
feat: Generate document summary chunks for improved retrieval (#235)

### DIFF
--- a/ai_ready_rag/config.py
+++ b/ai_ready_rag/config.py
@@ -23,6 +23,8 @@ PROFILE_DEFAULTS: dict[str, dict[str, Any]] = {
         "db_pool_timeout": 30,
         # Concurrent processing - limited for laptop
         "max_concurrent_processing": 3,
+        # Summary generation
+        "generate_summaries": True,
     },
     "spark": {
         "vector_backend": "qdrant",
@@ -40,6 +42,8 @@ PROFILE_DEFAULTS: dict[str, dict[str, Any]] = {
         "db_pool_timeout": 60,
         # Concurrent processing - conservative to avoid tesseract/OCR race conditions
         "max_concurrent_processing": 2,
+        # Summary generation
+        "generate_summaries": True,
     },
 }
 
@@ -86,6 +90,7 @@ class Settings(BaseSettings):
 
     # Feature Flags
     enable_rag: bool = True  # Enabled for RAG functionality
+    generate_summaries: bool | None = None  # None = use profile default
     # Setup Wizard
     skip_setup_wizard: bool = False  # Set to True to bypass setup check for automated deployments
 
@@ -118,6 +123,7 @@ class Settings(BaseSettings):
 
     # RAG Service
     chat_model: str | None = None  # None = use profile default
+    summary_model: str | None = None  # Override model for summaries (default: use chat_model)
     rag_temperature: float = 0.1
     rag_timeout_seconds: int = 30
     rag_confidence_threshold: int = 40

--- a/ai_ready_rag/services/summary_generator.py
+++ b/ai_ready_rag/services/summary_generator.py
@@ -1,0 +1,193 @@
+"""Generate document summaries via Ollama for RAG indexing.
+
+Produces a structured summary chunk for each document, enabling the retriever
+to identify the correct document before pulling granular chunks.
+"""
+
+import logging
+import re
+
+import httpx
+
+from ai_ready_rag.services.processing_service import ChunkInfo
+
+logger = logging.getLogger(__name__)
+
+# Timeout for Ollama summary generation (generous for large context)
+SUMMARY_TIMEOUT_SECONDS = 120
+
+
+class SummaryGenerator:
+    """Generate document summaries via Ollama for RAG indexing."""
+
+    def __init__(self, ollama_url: str, model: str = "qwen3:8b"):
+        self.ollama_url = ollama_url
+        self.model = model
+
+    async def generate(
+        self,
+        chunks: list[ChunkInfo],
+        filename: str,
+        document_id: str,
+    ) -> tuple[ChunkInfo, dict] | None:
+        """Generate a summary chunk from sampled document chunks.
+
+        Args:
+            chunks: List of ChunkInfo objects from the document.
+            filename: Original filename for context.
+            document_id: Document identifier (for logging).
+
+        Returns:
+            Tuple of (ChunkInfo for summary, extra metadata dict) or None on failure.
+        """
+        if not chunks:
+            logger.warning(f"No chunks to summarize for document {document_id}")
+            return None
+
+        sampled = self._sample_chunks(chunks)
+        word_count = sum(len(c.text.split()) for c in chunks)
+        prompt = self._build_prompt(filename, sampled, len(chunks), word_count)
+
+        try:
+            async with httpx.AsyncClient(timeout=SUMMARY_TIMEOUT_SECONDS) as client:
+                response = await client.post(
+                    f"{self.ollama_url}/api/generate",
+                    json={
+                        "model": self.model,
+                        "prompt": prompt,
+                        "stream": False,
+                    },
+                )
+                response.raise_for_status()
+                response_text = response.json().get("response", "").strip()
+
+            if not response_text:
+                logger.warning(f"Empty summary response for document {document_id}")
+                return None
+
+            parsed = self._parse_response(response_text)
+
+            summary_text = f"DOCUMENT SUMMARY: {parsed['text']}"
+            summary_chunk = ChunkInfo(
+                text=summary_text,
+                chunk_index=-1,
+                page_number=None,
+                section="Document Summary",
+                token_count=len(summary_text) // 4,
+            )
+            summary_metadata = {
+                "is_summary": True,
+                "document_type": parsed["document_type"],
+                "carrier": parsed["carrier"],
+                "policy_period": parsed["policy_period"],
+            }
+
+            logger.info(
+                f"Generated summary for {document_id}: "
+                f"type={parsed['document_type']}, carrier={parsed['carrier']}"
+            )
+            return summary_chunk, summary_metadata
+
+        except httpx.TimeoutException:
+            logger.warning(f"Ollama timed out generating summary for {document_id}")
+            return None
+        except Exception as e:
+            logger.warning(f"Summary generation failed for {document_id}: {e}")
+            return None
+
+    def _sample_chunks(self, chunks: list[ChunkInfo]) -> list[ChunkInfo]:
+        """Sample up to 9 chunks: first 3, middle 3, last 3.
+
+        For documents with <= 9 chunks, returns all chunks.
+        """
+        if len(chunks) <= 9:
+            return list(chunks)
+
+        first = chunks[:3]
+        mid_start = len(chunks) // 2 - 1
+        middle = chunks[mid_start : mid_start + 3]
+        last = chunks[-3:]
+
+        return first + middle + last
+
+    def _build_prompt(
+        self,
+        filename: str,
+        sampled_chunks: list[ChunkInfo],
+        chunk_count: int,
+        word_count: int,
+    ) -> str:
+        """Build the LLM prompt for summary generation."""
+        chunk_texts = "\n\n".join(
+            f"[Chunk {c.chunk_index}]: {c.text[:500]}" for c in sampled_chunks
+        )
+
+        return f"""You are summarizing a document for a retrieval-augmented generation (RAG) system.
+Your summary will be embedded and used to match user questions to the right document.
+
+Document: {filename}
+Total chunks: {chunk_count}
+Total words: {word_count:,}
+
+Here are representative samples from the document:
+
+{chunk_texts}
+
+Produce the following (be precise, use exact numbers/names from the document):
+
+DOCUMENT_TYPE: (one of: policy, quote, submission, loss_run, financial, sov, certificate, application, other)
+CARRIER: (carrier or market name, or "unknown")
+POLICY_PERIOD: (e.g., "12/01/2024-12/01/2025", or "unknown")
+SUMMARY: (one paragraph, 100-200 words) Describe what this document contains, its key coverages/limits/deductibles if applicable, and what types of questions it could answer. Include specific numbers, names, and dates from the content."""
+
+    def _parse_response(self, response_text: str) -> dict:
+        """Parse structured fields from the LLM response.
+
+        Returns:
+            Dict with keys: text, document_type, carrier, policy_period.
+            Falls back to full response as summary text if parsing fails.
+        """
+        result = {
+            "text": "",
+            "document_type": "other",
+            "carrier": "unknown",
+            "policy_period": "unknown",
+        }
+
+        # Extract DOCUMENT_TYPE
+        dt_match = re.search(r"DOCUMENT_TYPE:\s*(.+)", response_text, re.IGNORECASE)
+        if dt_match:
+            dt_value = dt_match.group(1).strip().lower().rstrip(".")
+            valid_types = {
+                "policy",
+                "quote",
+                "submission",
+                "loss_run",
+                "financial",
+                "sov",
+                "certificate",
+                "application",
+                "other",
+            }
+            result["document_type"] = dt_value if dt_value in valid_types else "other"
+
+        # Extract CARRIER
+        carrier_match = re.search(r"CARRIER:\s*(.+)", response_text, re.IGNORECASE)
+        if carrier_match:
+            result["carrier"] = carrier_match.group(1).strip().rstrip(".")
+
+        # Extract POLICY_PERIOD
+        period_match = re.search(r"POLICY_PERIOD:\s*(.+)", response_text, re.IGNORECASE)
+        if period_match:
+            result["policy_period"] = period_match.group(1).strip().rstrip(".")
+
+        # Extract SUMMARY
+        summary_match = re.search(r"SUMMARY:\s*(.+)", response_text, re.IGNORECASE | re.DOTALL)
+        if summary_match:
+            result["text"] = summary_match.group(1).strip()
+        else:
+            # Fallback: use entire response as summary text
+            result["text"] = response_text
+            result["document_type"] = "other"
+
+        return result

--- a/ai_ready_rag/services/vector_service.py
+++ b/ai_ready_rag/services/vector_service.py
@@ -434,6 +434,11 @@ class VectorService:
                 "section": meta.get("section"),
             }
 
+            # Pass through extra metadata keys (e.g., is_summary, document_type)
+            for key, value in meta.items():
+                if key not in payload and value is not None:
+                    payload[key] = value
+
             points.append(
                 models.PointStruct(
                     id=chunk_id,

--- a/scripts/export_chunks_remote.py
+++ b/scripts/export_chunks_remote.py
@@ -103,6 +103,7 @@ def get_chunks_via_api(client: httpx.Client, headers: dict, document_id: str) ->
                         "chars": len(text),
                         "page": result.get("page_number"),
                         "section": result.get("section"),
+                        "is_summary": result.get("is_summary", False),
                     }
                 )
             return sorted(chunks, key=lambda c: c["index"])
@@ -141,6 +142,7 @@ def get_chunks_via_qdrant(qdrant_url: str, document_id: str) -> list[dict]:
                     "chars": len(text),
                     "page": payload.get("page_number"),
                     "section": payload.get("section"),
+                    "is_summary": payload.get("is_summary", False),
                 }
             )
         return sorted(chunks, key=lambda c: c["index"])
@@ -264,7 +266,10 @@ def write_markdown(
     for c in chunks:
         page_str = f"Page {c['page']}" if c["page"] else "—"
         section_str = c.get("section") or "—"
-        lines.append(f"### Chunk {c['index']}  ({c['words']} words, {page_str})")
+        if c.get("is_summary"):
+            lines.append(f"### [SUMMARY] Chunk {c['index']}  ({c['words']} words)")
+        else:
+            lines.append(f"### Chunk {c['index']}  ({c['words']} words, {page_str})")
         if section_str != "—":
             lines.append(f"**Section:** {section_str}")
         lines.append("")

--- a/tests/test_summary_generator.py
+++ b/tests/test_summary_generator.py
@@ -1,0 +1,258 @@
+"""Tests for SummaryGenerator.
+
+Unit tests mock Ollama for CI compatibility.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from ai_ready_rag.services.processing_service import ChunkInfo
+from ai_ready_rag.services.summary_generator import SummaryGenerator
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def generator():
+    """SummaryGenerator instance with test defaults."""
+    return SummaryGenerator(
+        ollama_url="http://localhost:11434",
+        model="test-model",
+    )
+
+
+@pytest.fixture
+def sample_chunks():
+    """Build a list of ChunkInfo objects for testing."""
+
+    def _make(count: int) -> list[ChunkInfo]:
+        return [
+            ChunkInfo(
+                text=f"Chunk {i} text content about insurance policy details.",
+                chunk_index=i,
+                page_number=i + 1,
+                section=f"Section {i}",
+                token_count=10,
+            )
+            for i in range(count)
+        ]
+
+    return _make
+
+
+VALID_RESPONSE = """DOCUMENT_TYPE: policy
+CARRIER: CNA
+POLICY_PERIOD: 12/01/2024-12/01/2025
+SUMMARY: This is a Directors & Officers liability policy issued by CNA for Cervantes Villas HOA. Coverage includes D&O liability with a $2M aggregate limit."""
+
+
+# =============================================================================
+# Chunk Sampling Tests
+# =============================================================================
+
+
+class TestSampleChunks:
+    def test_sample_chunks_small_doc(self, generator, sample_chunks):
+        """Documents with <= 9 chunks return all chunks."""
+        chunks = sample_chunks(5)
+        sampled = generator._sample_chunks(chunks)
+        assert len(sampled) == 5
+        assert sampled == chunks
+
+    def test_sample_chunks_exact_nine(self, generator, sample_chunks):
+        """Document with exactly 9 chunks returns all."""
+        chunks = sample_chunks(9)
+        sampled = generator._sample_chunks(chunks)
+        assert len(sampled) == 9
+
+    def test_sample_chunks_large_doc(self, generator, sample_chunks):
+        """Documents with > 9 chunks return exactly 9 (first 3 + middle 3 + last 3)."""
+        chunks = sample_chunks(30)
+        sampled = generator._sample_chunks(chunks)
+        assert len(sampled) == 9
+
+        # First 3
+        assert sampled[0].chunk_index == 0
+        assert sampled[1].chunk_index == 1
+        assert sampled[2].chunk_index == 2
+
+        # Last 3
+        assert sampled[6].chunk_index == 27
+        assert sampled[7].chunk_index == 28
+        assert sampled[8].chunk_index == 29
+
+
+# =============================================================================
+# Prompt Building Tests
+# =============================================================================
+
+
+class TestBuildPrompt:
+    def test_build_prompt_contains_filename(self, generator, sample_chunks):
+        """Prompt includes the filename."""
+        chunks = sample_chunks(3)
+        prompt = generator._build_prompt("test_policy.pdf", chunks, 10, 5000)
+        assert "test_policy.pdf" in prompt
+
+    def test_build_prompt_contains_chunk_text(self, generator, sample_chunks):
+        """Prompt includes sampled chunk text."""
+        chunks = sample_chunks(3)
+        prompt = generator._build_prompt("test.pdf", chunks, 3, 1000)
+        assert "[Chunk 0]:" in prompt
+        assert "insurance policy details" in prompt
+
+    def test_build_prompt_contains_stats(self, generator, sample_chunks):
+        """Prompt includes chunk count and word count."""
+        chunks = sample_chunks(3)
+        prompt = generator._build_prompt("test.pdf", chunks, 50, 12345)
+        assert "Total chunks: 50" in prompt
+        assert "12,345" in prompt
+
+
+# =============================================================================
+# Response Parsing Tests
+# =============================================================================
+
+
+class TestParseResponse:
+    def test_parse_response_valid(self, generator):
+        """Full structured response parses all fields correctly."""
+        parsed = generator._parse_response(VALID_RESPONSE)
+        assert parsed["document_type"] == "policy"
+        assert parsed["carrier"] == "CNA"
+        assert parsed["policy_period"] == "12/01/2024-12/01/2025"
+        assert "Directors & Officers" in parsed["text"]
+
+    def test_parse_response_missing_carrier(self, generator):
+        """Missing CARRIER falls back to 'unknown'."""
+        response = """DOCUMENT_TYPE: quote
+POLICY_PERIOD: 2024-2025
+SUMMARY: A basic quote document."""
+        parsed = generator._parse_response(response)
+        assert parsed["document_type"] == "quote"
+        assert parsed["carrier"] == "unknown"
+        assert parsed["policy_period"] == "2024-2025"
+
+    def test_parse_response_malformed(self, generator):
+        """Completely malformed response uses full text as summary."""
+        response = "This document is about insurance coverage and limits."
+        parsed = generator._parse_response(response)
+        assert parsed["text"] == response
+        assert parsed["document_type"] == "other"
+
+    def test_parse_response_invalid_document_type(self, generator):
+        """Invalid document type falls back to 'other'."""
+        response = """DOCUMENT_TYPE: banana
+CARRIER: Test Corp
+SUMMARY: A test document."""
+        parsed = generator._parse_response(response)
+        assert parsed["document_type"] == "other"
+
+    def test_parse_response_case_insensitive(self, generator):
+        """Field labels are matched case-insensitively."""
+        response = """document_type: policy
+carrier: Acme Insurance
+summary: A policy document."""
+        parsed = generator._parse_response(response)
+        assert parsed["document_type"] == "policy"
+        assert parsed["carrier"] == "Acme Insurance"
+
+
+# =============================================================================
+# Generate Tests (with mocked Ollama)
+# =============================================================================
+
+
+class TestGenerate:
+    @pytest.mark.asyncio
+    async def test_generate_success(self, generator, sample_chunks):
+        """Successful generation returns ChunkInfo + metadata tuple."""
+        chunks = sample_chunks(5)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"response": VALID_RESPONSE}
+
+        with patch("ai_ready_rag.services.summary_generator.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await generator.generate(chunks, "test.pdf", "doc-123")
+
+        assert result is not None
+        summary_chunk, metadata = result
+        assert isinstance(summary_chunk, ChunkInfo)
+        assert summary_chunk.text.startswith("DOCUMENT SUMMARY:")
+        assert summary_chunk.chunk_index == -1
+        assert summary_chunk.section == "Document Summary"
+        assert summary_chunk.page_number is None
+        assert metadata["is_summary"] is True
+        assert metadata["document_type"] == "policy"
+        assert metadata["carrier"] == "CNA"
+
+    @pytest.mark.asyncio
+    async def test_generate_ollama_failure(self, generator, sample_chunks):
+        """Ollama failure returns None (graceful fallback)."""
+        chunks = sample_chunks(5)
+
+        with patch("ai_ready_rag.services.summary_generator.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = httpx.ConnectError("Connection refused")
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await generator.generate(chunks, "test.pdf", "doc-123")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_generate_empty_chunks(self, generator):
+        """Empty chunk list returns None."""
+        result = await generator.generate([], "test.pdf", "doc-123")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_generate_timeout(self, generator, sample_chunks):
+        """Ollama timeout returns None (graceful fallback)."""
+        chunks = sample_chunks(5)
+
+        with patch("ai_ready_rag.services.summary_generator.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = httpx.TimeoutException("Request timed out")
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await generator.generate(chunks, "test.pdf", "doc-123")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_generate_empty_response(self, generator, sample_chunks):
+        """Empty Ollama response returns None."""
+        chunks = sample_chunks(5)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"response": ""}
+
+        with patch("ai_ready_rag.services.summary_generator.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await generator.generate(chunks, "test.pdf", "doc-123")
+
+        assert result is None


### PR DESCRIPTION
## Summary
- Add LLM-powered document summary generation to the processing pipeline
- Summary chunks stored in Qdrant with structured metadata (document_type, carrier, policy_period)
- Enables retriever to identify the correct document for broad queries like "What's the earthquake deductible?"

Closes #235

## Changes
- **New:** `ai_ready_rag/services/summary_generator.py` — SummaryGenerator class with Ollama integration, chunk sampling (first/middle/last 3), structured response parsing
- **New:** `tests/test_summary_generator.py` — 16 unit tests covering all code paths
- **Modified:** `ai_ready_rag/services/vector_service.py` — Qdrant payload builder passes through extra metadata keys (parity with Chroma)
- **Modified:** `ai_ready_rag/services/processing_service.py` — Integrates summary generation after chunking with graceful fallback
- **Modified:** `ai_ready_rag/config.py` — `generate_summaries` and `summary_model` settings in both laptop/spark profiles
- **Modified:** `scripts/export_chunks_remote.py` — Labels summary chunks with [SUMMARY] in markdown output

## Test plan
- [x] 16 new unit tests pass (chunk sampling, prompt building, response parsing, success/failure/timeout paths)
- [x] 773 total tests pass, 0 regressions
- [x] `ruff check` and `ruff format` pass
- [ ] Manual: Deploy to Spark, reprocess a document, verify summary chunk in Qdrant
- [ ] Manual: Run export script, verify summary appears in markdown output

🤖 Generated with [Claude Code](https://claude.com/claude-code)