### PR TITLE
feat: Add evaluation DB models, dataset CRUD API, and config (#237)

### DIFF
--- a/ai_ready_rag/config.py
+++ b/ai_ready_rag/config.py
@@ -181,6 +181,22 @@ class Settings(BaseSettings):
     sse_event_buffer_size: int = 1000  # Ring buffer size for replay
     sse_heartbeat_seconds: int = 30  # Heartbeat interval
 
+    # Evaluation Framework
+    eval_enabled: bool = True
+    eval_scan_interval_seconds: int = 30
+    eval_timeout_seconds: int = 120
+    eval_sample_deadline_seconds: int = 300
+    eval_delay_between_samples_seconds: float = 1.0
+    eval_lease_duration_minutes: int = 15
+    eval_lease_renewal_seconds: int = 60
+    eval_max_retries_per_sample: int = 1
+    eval_retry_backoff_seconds: int = 10
+    eval_max_samples_per_run: int = 500
+    eval_max_run_duration_hours: float = 8.0
+    eval_live_max_concurrent: int = 2
+    eval_live_queue_size: int = 10
+    eval_live_retention_days: int = 30
+
     # Document Management
     upload_dir: str = "./data/uploads"
     max_upload_size_mb: int = 100

--- a/ai_ready_rag/db/models/__init__.py
+++ b/ai_ready_rag/db/models/__init__.py
@@ -20,6 +20,12 @@ from ai_ready_rag.db.models.cache import (
 )
 from ai_ready_rag.db.models.chat import ChatMessage, ChatSession
 from ai_ready_rag.db.models.document import Document
+from ai_ready_rag.db.models.evaluation import (
+    DatasetSample,
+    EvaluationDataset,
+    EvaluationRun,
+    EvaluationSample,
+)
 from ai_ready_rag.db.models.rag import CuratedQA, CuratedQAKeyword, QuerySynonym
 from ai_ready_rag.db.models.user import Tag, User
 from ai_ready_rag.db.models.warming import WarmingBatch, WarmingQuery
@@ -48,4 +54,8 @@ __all__ = [
     "CuratedQAKeyword",
     "WarmingBatch",
     "WarmingQuery",
+    "EvaluationDataset",
+    "DatasetSample",
+    "EvaluationRun",
+    "EvaluationSample",
 ]

--- a/ai_ready_rag/db/models/evaluation.py
+++ b/ai_ready_rag/db/models/evaluation.py
@@ -1,0 +1,157 @@
+"""Evaluation framework models for RAG quality assessment."""
+
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+
+from ai_ready_rag.db.database import Base
+from ai_ready_rag.db.models.base import generate_uuid
+
+
+class EvaluationDataset(Base):
+    """Named collection of Q&A pairs for repeatable evaluation."""
+
+    __tablename__ = "evaluation_datasets"
+    __table_args__ = (Index("idx_evaluation_datasets_source", "source_type"),)
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    name = Column(String, nullable=False, unique=True)
+    description = Column(Text, nullable=True)
+    source_type = Column(String, nullable=False)  # manual | ragbench | synthetic | live_sample
+    source_config = Column(Text, nullable=True)  # JSON
+    sample_count = Column(Integer, nullable=False, default=0)
+    created_by = Column(String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class DatasetSample(Base):
+    """Individual Q&A pair within a dataset."""
+
+    __tablename__ = "dataset_samples"
+    __table_args__ = (
+        UniqueConstraint("dataset_id", "sort_order", name="uq_dataset_samples_dataset_sort"),
+        Index("idx_dataset_samples_dataset", "dataset_id"),
+    )
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    dataset_id = Column(
+        String,
+        ForeignKey("evaluation_datasets.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    question = Column(Text, nullable=False)
+    ground_truth = Column(Text, nullable=True)
+    reference_contexts = Column(Text, nullable=True)  # JSON list
+    metadata_ = Column("metadata", Text, nullable=True)  # JSON — "metadata" is reserved in SA
+    sort_order = Column(Integer, nullable=False, default=0)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
+class EvaluationRun(Base):
+    """Tracks batch evaluation executions."""
+
+    __tablename__ = "evaluation_runs"
+    __table_args__ = (
+        Index("idx_evaluation_runs_status", "status", "created_at"),
+        Index("idx_evaluation_runs_dataset", "dataset_id"),
+        Index("idx_evaluation_runs_lease", "worker_lease_expires_at"),
+    )
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    name = Column(String, nullable=False)
+    description = Column(Text, nullable=True)
+    dataset_id = Column(
+        String,
+        ForeignKey("evaluation_datasets.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    status = Column(String, nullable=False, default="pending")
+    total_samples = Column(Integer, nullable=False, default=0)
+    completed_samples = Column(Integer, nullable=False, default=0)
+    failed_samples = Column(Integer, nullable=False, default=0)
+
+    # Access control scope
+    tag_scope = Column(Text, nullable=True)  # JSON list of tags
+    admin_bypass_tags = Column(Boolean, nullable=False, default=False)
+
+    # Aggregate scores
+    avg_faithfulness = Column(Float, nullable=True)
+    avg_answer_relevancy = Column(Float, nullable=True)
+    avg_llm_context_precision = Column(Float, nullable=True)
+    avg_llm_context_recall = Column(Float, nullable=True)
+    invalid_score_count = Column(Integer, nullable=False, default=0)
+
+    # Reproducibility snapshot
+    model_used = Column(String, nullable=False)
+    embedding_model_used = Column(String, nullable=False)
+    config_snapshot = Column(Text, nullable=False)  # JSON
+
+    # Worker lease fields
+    worker_id = Column(String, nullable=True)
+    worker_lease_expires_at = Column(DateTime, nullable=True)
+    is_cancel_requested = Column(Boolean, nullable=False, default=False)
+
+    # Capacity controls
+    max_duration_hours = Column(Float, nullable=True)
+
+    error_message = Column(Text, nullable=True)
+    triggered_by = Column(String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    started_at = Column(DateTime, nullable=True)
+    completed_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class EvaluationSample(Base):
+    """Per-question results within an evaluation run."""
+
+    __tablename__ = "evaluation_samples"
+    __table_args__ = (
+        UniqueConstraint("run_id", "sort_order", name="uq_evaluation_samples_run_sort"),
+        Index("idx_evaluation_samples_run", "run_id"),
+        Index("idx_evaluation_samples_status", "run_id", "status"),
+    )
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    run_id = Column(
+        String,
+        ForeignKey("evaluation_runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    sort_order = Column(Integer, nullable=False, default=0)
+    status = Column(String, nullable=False, default="pending")
+
+    # Input (from dataset)
+    question = Column(Text, nullable=False)
+    ground_truth = Column(Text, nullable=True)
+    reference_contexts = Column(Text, nullable=True)  # JSON list
+
+    # RAG output
+    generated_answer = Column(Text, nullable=True)
+    retrieved_contexts = Column(Text, nullable=True)  # JSON list
+
+    # RAGAS metric scores
+    faithfulness = Column(Float, nullable=True)
+    answer_relevancy = Column(Float, nullable=True)
+    llm_context_precision = Column(Float, nullable=True)
+    llm_context_recall = Column(Float, nullable=True)
+
+    generation_time_ms = Column(Float, nullable=True)
+    retry_count = Column(Integer, nullable=False, default=0)
+    error_message = Column(Text, nullable=True)
+    error_type = Column(String, nullable=True)
+    processed_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/ai_ready_rag/db/repositories/__init__.py
+++ b/ai_ready_rag/db/repositories/__init__.py
@@ -5,6 +5,12 @@ from ai_ready_rag.db.repositories.base import BaseRepository
 from ai_ready_rag.db.repositories.cache import EmbeddingCacheRepository, ResponseCacheRepository
 from ai_ready_rag.db.repositories.chat import ChatMessageRepository, ChatSessionRepository
 from ai_ready_rag.db.repositories.document import DocumentRepository
+from ai_ready_rag.db.repositories.evaluation import (
+    DatasetSampleRepository,
+    EvaluationDatasetRepository,
+    EvaluationRunRepository,
+    EvaluationSampleRepository,
+)
 from ai_ready_rag.db.repositories.tag import TagRepository
 from ai_ready_rag.db.repositories.user import UserRepository
 
@@ -18,4 +24,8 @@ __all__ = [
     "AuditLogRepository",
     "ResponseCacheRepository",
     "EmbeddingCacheRepository",
+    "EvaluationDatasetRepository",
+    "DatasetSampleRepository",
+    "EvaluationRunRepository",
+    "EvaluationSampleRepository",
 ]

--- a/ai_ready_rag/db/repositories/evaluation.py
+++ b/ai_ready_rag/db/repositories/evaluation.py
@@ -1,0 +1,179 @@
+"""Evaluation repository for datasets, samples, and runs."""
+
+import json
+import logging
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from ai_ready_rag.db.models.evaluation import (
+    DatasetSample,
+    EvaluationDataset,
+    EvaluationRun,
+    EvaluationSample,
+)
+from ai_ready_rag.db.repositories.base import BaseRepository
+
+logger = logging.getLogger(__name__)
+
+
+class EvaluationDatasetRepository(BaseRepository[EvaluationDataset]):
+    model = EvaluationDataset
+
+    def get_by_name(self, name: str) -> EvaluationDataset | None:
+        """Get dataset by unique name."""
+        results = self.list_by(name=name)
+        return results[0] if results else None
+
+    def list_paginated(
+        self,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[EvaluationDataset], int]:
+        """List datasets with pagination."""
+        total = self.count()
+        stmt = (
+            select(EvaluationDataset)
+            .order_by(EvaluationDataset.created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        datasets = list(self.db.scalars(stmt).all())
+        return datasets, total
+
+    def has_active_runs(self, dataset_id: str) -> bool:
+        """Check if any evaluation runs reference this dataset."""
+        return (
+            self.db.scalar(
+                select(func.count())
+                .select_from(EvaluationRun)
+                .where(EvaluationRun.dataset_id == dataset_id)
+            )
+            or 0
+        ) > 0
+
+
+class DatasetSampleRepository(BaseRepository[DatasetSample]):
+    model = DatasetSample
+
+    def list_by_dataset(
+        self,
+        dataset_id: str,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[DatasetSample], int]:
+        """List samples for a dataset with pagination."""
+        total = self.count(dataset_id=dataset_id)
+        stmt = (
+            select(DatasetSample)
+            .where(DatasetSample.dataset_id == dataset_id)
+            .order_by(DatasetSample.sort_order)
+            .limit(limit)
+            .offset(offset)
+        )
+        samples = list(self.db.scalars(stmt).all())
+        return samples, total
+
+    def bulk_create(
+        self,
+        dataset_id: str,
+        samples_data: list[dict],
+    ) -> list[DatasetSample]:
+        """Create multiple samples with sort_order assignment.
+
+        Returns the created sample objects. Does NOT flush/commit --
+        caller is responsible for transaction boundaries.
+        """
+        samples = []
+        for i, data in enumerate(samples_data):
+            # Ground-truth normalization: strip whitespace, empty -> None
+            ground_truth = data.get("ground_truth")
+            if ground_truth is not None:
+                ground_truth = ground_truth.strip()
+                if not ground_truth:
+                    ground_truth = None
+
+            reference_contexts = data.get("reference_contexts")
+            metadata = data.get("metadata")
+
+            sample = DatasetSample(
+                dataset_id=dataset_id,
+                question=data["question"],
+                ground_truth=ground_truth,
+                reference_contexts=json.dumps(reference_contexts) if reference_contexts else None,
+                metadata_=json.dumps(metadata) if metadata else None,
+                sort_order=i,
+            )
+            samples.append(sample)
+
+        self.add_all(samples)
+        return samples
+
+
+class EvaluationRunRepository(BaseRepository[EvaluationRun]):
+    model = EvaluationRun
+
+    def list_paginated(
+        self,
+        status: str | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[EvaluationRun], int]:
+        """List runs with optional status filter and pagination."""
+        total = self.count() if status is None else self.count(status=status)
+        stmt = select(EvaluationRun)
+        if status:
+            stmt = stmt.where(EvaluationRun.status == status)
+        stmt = stmt.order_by(EvaluationRun.created_at.desc()).limit(limit).offset(offset)
+        runs = list(self.db.scalars(stmt).all())
+        return runs, total
+
+
+class EvaluationSampleRepository(BaseRepository[EvaluationSample]):
+    model = EvaluationSample
+
+    def list_by_run(
+        self,
+        run_id: str,
+        status: str | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[EvaluationSample], int]:
+        """List samples for a run with optional status filter."""
+        count_stmt = (
+            select(func.count())
+            .select_from(EvaluationSample)
+            .where(EvaluationSample.run_id == run_id)
+        )
+        if status:
+            count_stmt = count_stmt.where(EvaluationSample.status == status)
+        total = self.db.scalar(count_stmt) or 0
+
+        stmt = select(EvaluationSample).where(EvaluationSample.run_id == run_id)
+        if status:
+            stmt = stmt.where(EvaluationSample.status == status)
+        stmt = stmt.order_by(EvaluationSample.sort_order).limit(limit).offset(offset)
+        samples = list(self.db.scalars(stmt).all())
+        return samples, total
+
+
+def recompute_dataset_sample_counts(db: Session) -> int:
+    """Recompute all dataset sample_count values from actual row counts.
+
+    Returns number of datasets updated.
+    """
+    datasets = db.scalars(select(EvaluationDataset)).all()
+    updated = 0
+    for dataset in datasets:
+        actual = (
+            db.scalar(
+                select(func.count())
+                .select_from(DatasetSample)
+                .where(DatasetSample.dataset_id == dataset.id)
+            )
+            or 0
+        )
+        if dataset.sample_count != actual:
+            dataset.sample_count = actual
+            updated += 1
+    return updated

--- a/ai_ready_rag/schemas/__init__.py
+++ b/ai_ready_rag/schemas/__init__.py
@@ -105,6 +105,21 @@ from ai_ready_rag.schemas.document import (
     TagInfo,
     TagUpdateRequest,
 )
+from ai_ready_rag.schemas.evaluation import (
+    CancelRunResponse,
+    DatasetCreate,
+    DatasetListResponse,
+    DatasetResponse,
+    DatasetSampleCreate,
+    DatasetSampleListResponse,
+    DatasetSampleResponse,
+    EvaluationSampleListResponse,
+    EvaluationSampleResponse,
+    EvaluationSummaryResponse,
+    RunCreate,
+    RunListResponse,
+    RunResponse,
+)
 from ai_ready_rag.schemas.experimental import (
     GeneratePresentationRequest,
     PresentationResponse,
@@ -242,6 +257,20 @@ __all__ = [
     "WarmFileResponse",
     "WarmingQueueJobResponse",
     "WarmingQueueListResponse",
+    # evaluation
+    "CancelRunResponse",
+    "DatasetCreate",
+    "DatasetListResponse",
+    "DatasetResponse",
+    "DatasetSampleCreate",
+    "DatasetSampleListResponse",
+    "DatasetSampleResponse",
+    "EvaluationSampleListResponse",
+    "EvaluationSampleResponse",
+    "EvaluationSummaryResponse",
+    "RunCreate",
+    "RunListResponse",
+    "RunResponse",
     # experimental
     "GeneratePresentationRequest",
     "PresentationResponse",

--- a/ai_ready_rag/schemas/evaluation.py
+++ b/ai_ready_rag/schemas/evaluation.py
@@ -1,0 +1,218 @@
+"""Pydantic schemas for evaluation framework."""
+
+import json
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+# ---------- Dataset Schemas ----------
+
+
+class DatasetSampleCreate(BaseModel):
+    """Single Q&A pair for dataset creation."""
+
+    question: str
+    ground_truth: str | None = None
+    reference_contexts: list[str] | None = None
+    metadata: dict | None = None
+
+
+class DatasetCreate(BaseModel):
+    """Request to create a manual dataset."""
+
+    name: str
+    description: str | None = None
+    samples: list[DatasetSampleCreate]
+
+    @field_validator("samples")
+    @classmethod
+    def at_least_one_sample(cls, v: list) -> list:
+        if not v:
+            raise ValueError("At least one sample is required")
+        return v
+
+
+class DatasetSampleResponse(BaseModel):
+    """Single dataset sample response."""
+
+    id: str
+    dataset_id: str
+    question: str
+    ground_truth: str | None
+    reference_contexts: list[str] | None = None
+    metadata: dict | None = Field(default=None, validation_alias="metadata_")
+    sort_order: int
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+        populate_by_name = True
+
+    @field_validator("reference_contexts", mode="before")
+    @classmethod
+    def parse_reference_contexts(cls, v):
+        if isinstance(v, str):
+            return json.loads(v)
+        return v
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def parse_metadata(cls, v):
+        if isinstance(v, str):
+            return json.loads(v)
+        return v
+
+
+class DatasetResponse(BaseModel):
+    """Dataset response."""
+
+    id: str
+    name: str
+    description: str | None
+    source_type: str
+    sample_count: int
+    created_by: str | None
+    created_at: datetime
+    updated_at: datetime
+    warning: str | None = None
+
+    class Config:
+        from_attributes = True
+
+
+class DatasetListResponse(BaseModel):
+    """Paginated dataset list."""
+
+    datasets: list[DatasetResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+class DatasetSampleListResponse(BaseModel):
+    """Paginated sample list."""
+
+    samples: list[DatasetSampleResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+# ---------- Run Schemas (Stubs for Phase 1) ----------
+
+
+class RunCreate(BaseModel):
+    """Request to trigger an evaluation run."""
+
+    dataset_id: str
+    name: str
+    description: str | None = None
+    tag_scope: list[str] | None = None
+    admin_bypass_tags: bool = False
+
+
+class RunResponse(BaseModel):
+    """Evaluation run response."""
+
+    id: str
+    name: str
+    description: str | None
+    dataset_id: str
+    status: str
+    total_samples: int
+    completed_samples: int
+    failed_samples: int
+    tag_scope: list[str] | None = None
+    admin_bypass_tags: bool
+    avg_faithfulness: float | None
+    avg_answer_relevancy: float | None
+    avg_llm_context_precision: float | None
+    avg_llm_context_recall: float | None
+    invalid_score_count: int
+    model_used: str
+    embedding_model_used: str
+    config_snapshot: dict
+    is_cancel_requested: bool
+    error_message: str | None
+    triggered_by: str | None
+    started_at: datetime | None
+    completed_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+    eta_seconds: float | None = None
+
+    class Config:
+        from_attributes = True
+
+    @field_validator("tag_scope", mode="before")
+    @classmethod
+    def parse_tag_scope(cls, v):
+        if isinstance(v, str):
+            return json.loads(v)
+        return v
+
+    @field_validator("config_snapshot", mode="before")
+    @classmethod
+    def parse_config_snapshot(cls, v):
+        if isinstance(v, str):
+            return json.loads(v)
+        return v
+
+
+class RunListResponse(BaseModel):
+    """Paginated run list."""
+
+    runs: list[RunResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+class EvaluationSampleResponse(BaseModel):
+    """Per-sample evaluation result."""
+
+    id: str
+    sort_order: int
+    status: str
+    question: str
+    ground_truth: str | None
+    generated_answer: str | None
+    faithfulness: float | None
+    answer_relevancy: float | None
+    llm_context_precision: float | None
+    llm_context_recall: float | None
+    generation_time_ms: float | None
+    retry_count: int
+    error_message: str | None
+    error_type: str | None
+    processed_at: datetime | None
+
+    class Config:
+        from_attributes = True
+
+
+class EvaluationSampleListResponse(BaseModel):
+    """Paginated evaluation sample list."""
+
+    samples: list[EvaluationSampleResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+class CancelRunResponse(BaseModel):
+    """Response from cancel request."""
+
+    id: str
+    status: str
+    is_cancel_requested: bool
+
+
+class EvaluationSummaryResponse(BaseModel):
+    """Dashboard summary."""
+
+    latest_run: RunResponse | None
+    total_runs: int
+    total_datasets: int
+    avg_scores: dict
+    score_trend: list[dict]

--- a/requirements-spark.txt
+++ b/requirements-spark.txt
@@ -24,6 +24,10 @@ passlib[bcrypt]>=1.7.4
 # Qdrant for Spark deployment (NOT chromadb - incompatible with DGX onnxruntime)
 qdrant-client>=1.13.0
 
+# ============== Evaluation Framework ==============
+ragas>=0.4.0,<0.5.0
+openai>=1.0.0,<2.0.0
+
 # ============== Document Processing (Full Docling) ==============
 # Required for spark profile chunker_backend=docling
 docling>=2.0.0

--- a/requirements-wsl.txt
+++ b/requirements-wsl.txt
@@ -21,6 +21,10 @@ langchain>=0.3.0
 langchain-community>=0.3.0
 langchain-ollama>=0.2.0
 
+# ============== Evaluation Framework ==============
+ragas>=0.4.0,<0.5.0
+openai>=1.0.0,<2.0.0
+
 # ============== Document Processing (Lightweight) ==============
 python-magic>=0.4.27
 pypdf>=3.0.0

--- a/tests/test_evaluations_api.py
+++ b/tests/test_evaluations_api.py
@@ -1,0 +1,250 @@
+"""Tests for evaluation framework API endpoints."""
+
+import pytest
+from fastapi import status
+
+from ai_ready_rag.db.models.evaluation import DatasetSample, EvaluationDataset
+
+
+@pytest.fixture
+def sample_dataset(db, admin_user):
+    """Create a sample evaluation dataset."""
+    dataset = EvaluationDataset(
+        name="Test Dataset",
+        description="Test description",
+        source_type="manual",
+        sample_count=2,
+        created_by=admin_user.id,
+    )
+    db.add(dataset)
+    db.flush()
+
+    # Add samples
+    for i in range(2):
+        sample = DatasetSample(
+            dataset_id=dataset.id,
+            question=f"Question {i}?",
+            ground_truth=f"Answer {i}",
+            sort_order=i,
+        )
+        db.add(sample)
+    db.flush()
+    db.refresh(dataset)
+    return dataset
+
+
+class TestDatasetCRUD:
+    """Test dataset CRUD operations."""
+
+    def test_create_dataset_requires_admin(self, client, user_headers):
+        """Non-admin users cannot create datasets."""
+        response = client.post(
+            "/api/evaluations/datasets",
+            json={
+                "name": "Test",
+                "samples": [{"question": "Q?", "ground_truth": "A"}],
+            },
+            headers=user_headers,
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_create_dataset_success(self, client, admin_headers):
+        """Admin can create a manual dataset."""
+        response = client.post(
+            "/api/evaluations/datasets",
+            json={
+                "name": "HR Policy QA",
+                "description": "Test dataset",
+                "samples": [
+                    {"question": "What is PTO?", "ground_truth": "15 days"},
+                    {"question": "What is sick leave?", "ground_truth": "10 days"},
+                ],
+            },
+            headers=admin_headers,
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["name"] == "HR Policy QA"
+        assert data["source_type"] == "manual"
+        assert data["sample_count"] == 2
+        assert data.get("warning") is None
+
+    def test_create_dataset_ground_truth_warning(self, client, admin_headers):
+        """Warning returned when samples lack ground truth."""
+        response = client.post(
+            "/api/evaluations/datasets",
+            json={
+                "name": "Mixed Dataset",
+                "samples": [
+                    {"question": "Q1?", "ground_truth": "A1"},
+                    {"question": "Q2?"},  # No ground truth
+                    {"question": "Q3?", "ground_truth": "  "},  # Whitespace only
+                ],
+            },
+            headers=admin_headers,
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["sample_count"] == 3
+        assert data["warning"] is not None
+        assert "2 samples" in data["warning"]
+
+    def test_create_dataset_duplicate_name(self, client, admin_headers, sample_dataset):
+        """Duplicate dataset name returns 409."""
+        response = client.post(
+            "/api/evaluations/datasets",
+            json={
+                "name": sample_dataset.name,
+                "samples": [{"question": "Q?"}],
+            },
+            headers=admin_headers,
+        )
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+    def test_create_dataset_empty_samples(self, client, admin_headers):
+        """Empty samples list returns 422."""
+        response = client.post(
+            "/api/evaluations/datasets",
+            json={"name": "Empty", "samples": []},
+            headers=admin_headers,
+        )
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_list_datasets(self, client, admin_headers, sample_dataset):
+        """Admin can list datasets."""
+        response = client.get("/api/evaluations/datasets", headers=admin_headers)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["total"] >= 1
+        assert len(data["datasets"]) >= 1
+
+    def test_list_datasets_pagination(self, client, admin_headers, sample_dataset):
+        """Pagination parameters work."""
+        response = client.get(
+            "/api/evaluations/datasets?limit=1&offset=0",
+            headers=admin_headers,
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["limit"] == 1
+        assert data["offset"] == 0
+
+    def test_get_dataset(self, client, admin_headers, sample_dataset):
+        """Admin can get a single dataset."""
+        response = client.get(
+            f"/api/evaluations/datasets/{sample_dataset.id}",
+            headers=admin_headers,
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["name"] == sample_dataset.name
+        assert data["sample_count"] == 2
+
+    def test_get_dataset_not_found(self, client, admin_headers):
+        """404 for non-existent dataset."""
+        response = client.get(
+            "/api/evaluations/datasets/nonexistent-id",
+            headers=admin_headers,
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_list_dataset_samples(self, client, admin_headers, sample_dataset):
+        """Admin can list samples in a dataset."""
+        response = client.get(
+            f"/api/evaluations/datasets/{sample_dataset.id}/samples",
+            headers=admin_headers,
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["total"] == 2
+        assert len(data["samples"]) == 2
+        assert data["samples"][0]["sort_order"] == 0
+
+    def test_list_dataset_samples_not_found(self, client, admin_headers):
+        """404 for non-existent dataset."""
+        response = client.get(
+            "/api/evaluations/datasets/nonexistent-id/samples",
+            headers=admin_headers,
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_delete_dataset(self, client, admin_headers, sample_dataset):
+        """Admin can delete a dataset."""
+        response = client.delete(
+            f"/api/evaluations/datasets/{sample_dataset.id}",
+            headers=admin_headers,
+        )
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    def test_delete_dataset_not_found(self, client, admin_headers):
+        """404 for non-existent dataset."""
+        response = client.delete(
+            "/api/evaluations/datasets/nonexistent-id",
+            headers=admin_headers,
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_recompute_counts(self, client, admin_headers):
+        """Recompute counts endpoint works."""
+        response = client.post(
+            "/api/evaluations/datasets/recompute-counts",
+            headers=admin_headers,
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert "updated" in response.json()
+
+
+class TestRunStubs:
+    """Test that run stubs return 501."""
+
+    def test_create_run_stub(self, client, admin_headers):
+        response = client.post("/api/evaluations/runs", headers=admin_headers)
+        assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED
+
+    def test_get_run_stub(self, client, admin_headers):
+        response = client.get("/api/evaluations/runs/some-id", headers=admin_headers)
+        assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED
+
+    def test_delete_run_stub(self, client, admin_headers):
+        response = client.delete("/api/evaluations/runs/some-id", headers=admin_headers)
+        assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED
+
+    def test_cancel_run_stub(self, client, admin_headers):
+        response = client.post("/api/evaluations/runs/some-id/cancel", headers=admin_headers)
+        assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED
+
+    def test_summary_stub(self, client, admin_headers):
+        response = client.get("/api/evaluations/summary", headers=admin_headers)
+        assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED
+
+    def test_run_samples_stub(self, client, admin_headers):
+        response = client.get("/api/evaluations/runs/some-id/samples", headers=admin_headers)
+        assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED
+
+
+class TestRunList:
+    """Test that GET /runs works (returns empty list)."""
+
+    def test_list_runs_empty(self, client, admin_headers):
+        """List runs returns empty when no runs exist."""
+        response = client.get("/api/evaluations/runs", headers=admin_headers)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["total"] == 0
+        assert data["runs"] == []
+
+
+class TestAccessControl:
+    """Test that all endpoints require admin."""
+
+    def test_list_datasets_requires_admin(self, client, user_headers):
+        response = client.get("/api/evaluations/datasets", headers=user_headers)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_list_runs_requires_admin(self, client, user_headers):
+        response = client.get("/api/evaluations/runs", headers=user_headers)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_unauthenticated_rejected(self, client):
+        response = client.get("/api/evaluations/datasets")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
## Summary
- Add 4 SQLAlchemy models (`EvaluationDataset`, `DatasetSample`, `EvaluationRun`, `EvaluationSample`) with proper indexes, constraints, and FK relationships
- Add 4 repository classes extending `BaseRepository[T]` with domain-specific queries and transactional `sample_count` management
- Add 13 Pydantic schemas for dataset CRUD request/response with JSON field validators and `metadata_` alias handling
- Add evaluation API router with router-level admin auth (`dependencies=[Depends(require_admin)]`)
- Implement dataset CRUD endpoints: list, create, get, delete, list samples, recompute counts
- Add run API stubs (501) for Phase 3 implementation
- Add 14 `eval_*` configuration settings to `Settings` class
- Add startup schema verification (fail-fast when `eval_enabled=True` but tables missing)
- Pin `ragas>=0.4.0,<0.5.0` and `openai>=1.0.0,<2.0.0` in both requirements files
- No runtime imports of ragas/openai (air-gap compatible)

Closes #237

## Stack
- [x] Backend
- [ ] Frontend

## Verification
- [x] `ruff check ai_ready_rag tests` passes
- [x] `ruff format --check ai_ready_rag tests` passes (127 files clean)
- [x] `pytest tests/ -v` — 797 passed, 6 failed (pre-existing), 0 regressions
- [x] 24 new evaluation tests all pass

## How to Test
1. Start server: `python -m uvicorn ai_ready_rag.main:app --host 0.0.0.0 --port 8502`
2. Log in as admin and get token
3. `POST /api/evaluations/datasets` with `{"name": "test", "samples": [{"question": "What is RAG?"}]}`
4. `GET /api/evaluations/datasets` — should list the created dataset
5. `GET /api/evaluations/datasets/{id}/samples` — should return samples
6. `DELETE /api/evaluations/datasets/{id}` — should delete
7. Verify non-admin gets 403 on all endpoints

## Risks / Rollback
Low risk — isolated new module with no changes to existing behavior. Rollback: revert single commit.

---
Artifacts: `.agents/outputs/*-237-*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)