### PR TITLE
feat: Add live monitoring with sampling queue and eval worker (#241)

### DIFF
--- a/ai_ready_rag/api/health.py
+++ b/ai_ready_rag/api/health.py
@@ -23,6 +23,18 @@ async def health_check(request: Request):
         eval_status["worker_running"] = False
         eval_status["current_run_id"] = None
 
+    live_queue = getattr(request.app.state, "live_eval_queue", None)
+    if live_queue:
+        eval_status["live_queue_depth"] = live_queue.depth
+        eval_status["live_queue_capacity"] = live_queue.capacity
+        eval_status["live_queue_drops"] = live_queue.drops_since_startup
+        eval_status["live_queue_processed"] = live_queue.processed_since_startup
+    else:
+        eval_status["live_queue_depth"] = 0
+        eval_status["live_queue_capacity"] = 0
+        eval_status["live_queue_drops"] = 0
+        eval_status["live_queue_processed"] = 0
+
     return {
         "status": "healthy",
         "version": settings.app_version,

--- a/ai_ready_rag/db/models/__init__.py
+++ b/ai_ready_rag/db/models/__init__.py
@@ -25,6 +25,7 @@ from ai_ready_rag.db.models.evaluation import (
     EvaluationDataset,
     EvaluationRun,
     EvaluationSample,
+    LiveEvaluationScore,
 )
 from ai_ready_rag.db.models.rag import CuratedQA, CuratedQAKeyword, QuerySynonym
 from ai_ready_rag.db.models.user import Tag, User
@@ -58,4 +59,5 @@ __all__ = [
     "DatasetSample",
     "EvaluationRun",
     "EvaluationSample",
+    "LiveEvaluationScore",
 ]

--- a/ai_ready_rag/db/models/evaluation.py
+++ b/ai_ready_rag/db/models/evaluation.py
@@ -155,3 +155,25 @@ class EvaluationSample(Base):
     processed_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class LiveEvaluationScore(Base):
+    """Scores from live production query sampling."""
+
+    __tablename__ = "live_evaluation_scores"
+    __table_args__ = (
+        Index("idx_live_eval_scores_created", "created_at"),
+        Index("idx_live_eval_scores_model", "model_used"),
+    )
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    query = Column(Text, nullable=False)
+    answer = Column(Text, nullable=False)
+    retrieved_contexts = Column(Text, nullable=True)  # JSON list
+    model_used = Column(String, nullable=False)
+    faithfulness = Column(Float, nullable=True)
+    answer_relevancy = Column(Float, nullable=True)
+    generation_time_ms = Column(Float, nullable=True)
+    evaluation_time_ms = Column(Float, nullable=True)
+    error_message = Column(Text, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)

--- a/ai_ready_rag/schemas/evaluation.py
+++ b/ai_ready_rag/schemas/evaluation.py
@@ -241,3 +241,55 @@ class EvaluationSummaryResponse(BaseModel):
     total_datasets: int
     avg_scores: dict
     score_trend: list[dict]
+
+
+# ---------- Live Monitoring Schemas ----------
+
+
+class LiveScoreResponse(BaseModel):
+    """Single live evaluation score."""
+
+    id: str
+    query: str
+    answer: str
+    model_used: str
+    faithfulness: float | None
+    answer_relevancy: float | None
+    generation_time_ms: float | None
+    evaluation_time_ms: float | None
+    error_message: str | None
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class LiveScoreListResponse(BaseModel):
+    """Paginated live scores."""
+
+    scores: list[LiveScoreResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+class LiveStatsHourly(BaseModel):
+    """Per-hour aggregate for live monitoring."""
+
+    hour: str
+    count: int
+    avg_faithfulness: float | None
+    avg_answer_relevancy: float | None
+
+
+class LiveStatsResponse(BaseModel):
+    """Live monitoring dashboard stats."""
+
+    total_scores: int
+    scores_last_24h: int
+    avg_faithfulness: float | None
+    avg_answer_relevancy: float | None
+    hourly_breakdown: list[LiveStatsHourly]
+    queue_depth: int
+    queue_capacity: int
+    drops_since_startup: int

--- a/ai_ready_rag/workers/live_eval_queue.py
+++ b/ai_ready_rag/workers/live_eval_queue.py
@@ -1,0 +1,113 @@
+"""Bounded asyncio.Queue with consumer tasks for live RAG query evaluation."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ai_ready_rag.config import Settings
+    from ai_ready_rag.services.evaluation_service import EvaluationService
+
+logger = logging.getLogger(__name__)
+
+
+class LiveEvaluationQueue:
+    """Bounded asyncio.Queue with N consumer tasks scoring live queries via RAGAS."""
+
+    def __init__(self, eval_service: EvaluationService, settings: Settings) -> None:
+        self._eval_service = eval_service
+        self._settings = settings
+        self._queue: asyncio.Queue = asyncio.Queue(maxsize=settings.eval_live_queue_size)
+        self._consumers: list[asyncio.Task] = []
+        self._shutdown = asyncio.Event()
+        self._drops_since_startup = 0
+        self._processed_since_startup = 0
+
+    def enqueue(
+        self,
+        query: str,
+        answer: str,
+        contexts: list[str],
+        model_used: str,
+        generation_time_ms: float | None = None,
+    ) -> bool:
+        """Non-blocking enqueue. Returns False if queue is full (item dropped)."""
+        try:
+            self._queue.put_nowait(
+                {
+                    "query": query,
+                    "answer": answer,
+                    "contexts": contexts,
+                    "model_used": model_used,
+                    "generation_time_ms": generation_time_ms,
+                }
+            )
+            return True
+        except asyncio.QueueFull:
+            self._drops_since_startup += 1
+            logger.warning(
+                "Live eval queue full (capacity=%d), dropping query",
+                self._settings.eval_live_queue_size,
+            )
+            return False
+
+    async def start(self) -> None:
+        """Start consumer tasks."""
+        self._shutdown.clear()
+        for i in range(self._settings.eval_live_max_concurrent):
+            task = asyncio.create_task(self._consumer(i))
+            self._consumers.append(task)
+        logger.info(
+            "LiveEvaluationQueue started: %d consumers, capacity %d",
+            self._settings.eval_live_max_concurrent,
+            self._settings.eval_live_queue_size,
+        )
+
+    async def stop(self) -> None:
+        """Stop all consumer tasks gracefully."""
+        self._shutdown.set()
+        for task in self._consumers:
+            task.cancel()
+        await asyncio.gather(*self._consumers, return_exceptions=True)
+        self._consumers.clear()
+        logger.info("LiveEvaluationQueue stopped")
+
+    async def _consumer(self, consumer_id: int) -> None:
+        """Consumer loop: dequeue items and score them."""
+        while not self._shutdown.is_set():
+            try:
+                item = await asyncio.wait_for(self._queue.get(), timeout=5.0)
+            except TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+
+            try:
+                await self._eval_service.score_live_query(**item)
+                self._processed_since_startup += 1
+            except Exception:
+                logger.exception("Live eval consumer %d failed to score query", consumer_id)
+            finally:
+                self._queue.task_done()
+
+    @property
+    def depth(self) -> int:
+        """Current queue depth."""
+        return self._queue.qsize()
+
+    @property
+    def capacity(self) -> int:
+        """Queue max capacity."""
+        return self._settings.eval_live_queue_size
+
+    @property
+    def drops_since_startup(self) -> int:
+        """Number of items dropped since startup."""
+        return self._drops_since_startup
+
+    @property
+    def processed_since_startup(self) -> int:
+        """Number of items processed since startup."""
+        return self._processed_since_startup

--- a/tests/test_live_eval_queue.py
+++ b/tests/test_live_eval_queue.py
@@ -1,0 +1,111 @@
+"""Tests for LiveEvaluationQueue — bounded asyncio.Queue with consumer tasks."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ai_ready_rag.workers.live_eval_queue import LiveEvaluationQueue
+
+
+@pytest.fixture
+def mock_settings():
+    settings = MagicMock()
+    settings.eval_live_max_concurrent = 2
+    settings.eval_live_queue_size = 3
+    return settings
+
+
+@pytest.fixture
+def mock_eval_service():
+    service = MagicMock()
+    service.score_live_query = AsyncMock()
+    return service
+
+
+@pytest.fixture
+def queue(mock_eval_service, mock_settings):
+    return LiveEvaluationQueue(mock_eval_service, mock_settings)
+
+
+def test_enqueue_accepts_when_not_full(queue):
+    """Enqueue returns True and depth increments when queue is not full."""
+    result = queue.enqueue(
+        query="What is RAG?",
+        answer="Retrieval-Augmented Generation",
+        contexts=["context1"],
+        model_used="llama3.2",
+        generation_time_ms=150.0,
+    )
+    assert result is True
+    assert queue.depth == 1
+
+
+def test_enqueue_drops_when_full(queue):
+    """Enqueue returns False when queue is at capacity, drops counter increments."""
+    # Fill queue to capacity (3)
+    for i in range(3):
+        assert queue.enqueue(
+            query=f"q{i}", answer=f"a{i}", contexts=[], model_used="m", generation_time_ms=None
+        )
+
+    assert queue.depth == 3
+    assert queue.drops_since_startup == 0
+
+    # Try one more — should be dropped
+    result = queue.enqueue(
+        query="overflow", answer="answer", contexts=[], model_used="m", generation_time_ms=None
+    )
+    assert result is False
+    assert queue.drops_since_startup == 1
+    assert queue.depth == 3
+
+
+@pytest.mark.asyncio
+async def test_consumer_processes_items(mock_eval_service, mock_settings):
+    """Consumer dequeues items and calls score_live_query with correct args."""
+    queue = LiveEvaluationQueue(mock_eval_service, mock_settings)
+    await queue.start()
+
+    queue.enqueue(
+        query="test query",
+        answer="test answer",
+        contexts=["ctx1", "ctx2"],
+        model_used="qwen3:8b",
+        generation_time_ms=200.0,
+    )
+
+    # Wait for consumer to process
+    await asyncio.sleep(0.5)
+    await queue.stop()
+
+    mock_eval_service.score_live_query.assert_called_once_with(
+        query="test query",
+        answer="test answer",
+        contexts=["ctx1", "ctx2"],
+        model_used="qwen3:8b",
+        generation_time_ms=200.0,
+    )
+    assert queue.processed_since_startup == 1
+
+
+@pytest.mark.asyncio
+async def test_start_stop_lifecycle(mock_eval_service, mock_settings):
+    """Start creates N consumer tasks, stop clears them."""
+    queue = LiveEvaluationQueue(mock_eval_service, mock_settings)
+
+    assert len(queue._consumers) == 0
+
+    await queue.start()
+    assert len(queue._consumers) == 2  # eval_live_max_concurrent = 2
+
+    await queue.stop()
+    assert len(queue._consumers) == 0
+
+
+def test_stats_properties(queue):
+    """Initial stats are all zero/default."""
+    assert queue.depth == 0
+    assert queue.capacity == 3  # eval_live_queue_size = 3
+    assert queue.drops_since_startup == 0
+    assert queue.processed_since_startup == 0


### PR DESCRIPTION
## Summary
- Adds `LiveEvaluationScore` DB model with indexes for live quality tracking
- Implements `LiveEvaluationQueue` with bounded asyncio.Queue, N consumers, and drop counting
- Hooks into `rag_service.generate()` to probabilistically sample live queries for evaluation
- Adds `GET /api/evaluations/live/stats` (hourly breakdown) and `GET /api/evaluations/live/scores` endpoints
- Adds retention purge for old live scores in warming_cleanup worker
- Exposes queue metrics in health endpoint

## Test plan
- [x] 5 new unit tests for LiveEvaluationQueue (enqueue, drops, consumer processing, lifecycle, stats)
- [x] All 881 existing tests pass (6 pre-existing failures unchanged)
- [x] `ruff check` and `ruff format` pass
- [x] No new lint errors

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)