### PR TITLE
feat: Forms cleanup, template API, and observability (#253, #254, #255)

### DIFF
--- a/ai_ready_rag/api/forms_templates.py
+++ b/ai_ready_rag/api/forms_templates.py
@@ -1,0 +1,313 @@
+"""Form template management endpoints.
+
+Wraps ingestkit_forms.FormTemplateAPI with VE-RAG auth dependencies.
+All FormTemplateAPI methods are synchronous (filesystem I/O) and are
+executed via asyncio.to_thread() to avoid blocking the event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import tempfile
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+
+from ai_ready_rag.config import get_settings
+from ai_ready_rag.core.dependencies import (
+    ROLE_CUSTOMER_ADMIN,
+    ROLE_SYSTEM_ADMIN,
+    get_current_user,
+    normalize_role,
+    require_admin,
+)
+from ai_ready_rag.db.models import User
+from ai_ready_rag.schemas.forms_template import (
+    CreateTemplateRequest,
+    ExtractedFieldResponse,
+    ExtractionPreviewResponse,
+    FieldMappingResponse,
+    FormTemplateListResponse,
+    FormTemplateResponse,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Dependencies
+# ---------------------------------------------------------------------------
+
+
+def get_template_api():
+    """Build FormTemplateAPI from current settings.
+
+    Lazy import to support conditional mounting (ingestkit-forms optional).
+    """
+    from ingestkit_forms import FileSystemTemplateStore
+    from ingestkit_forms.api import FormTemplateAPI
+    from ingestkit_forms.config import FormProcessorConfig
+
+    settings = get_settings()
+    store = FileSystemTemplateStore(settings.forms_template_storage_path)
+    config = FormProcessorConfig(
+        form_template_storage_path=settings.forms_template_storage_path,
+    )
+    return FormTemplateAPI(store=store, config=config)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_admin(user: User) -> bool:
+    """Check if user has admin privileges."""
+    role = normalize_role(user.role)
+    return role in (ROLE_SYSTEM_ADMIN, ROLE_CUSTOMER_ADMIN)
+
+
+def _map_form_error(exc) -> HTTPException:
+    """Map FormIngestException to HTTPException."""
+    from ingestkit_forms.errors import FormErrorCode
+
+    code_map = {
+        FormErrorCode.E_FORM_TEMPLATE_NOT_FOUND: 404,
+        FormErrorCode.E_FORM_TEMPLATE_INVALID: 400,
+        FormErrorCode.E_FORM_TEMPLATE_VERSION_CONFLICT: 409,
+        FormErrorCode.E_FORM_TEMPLATE_STORE_UNAVAILABLE: 503,
+    }
+    status_code = code_map.get(exc.code, 500)
+    return HTTPException(status_code=status_code, detail=exc.message)
+
+
+def _template_to_response(template) -> FormTemplateResponse:
+    """Convert ingestkit FormTemplate to API response model."""
+    return FormTemplateResponse(
+        template_id=template.template_id,
+        name=template.name,
+        description=template.description,
+        version=template.version,
+        source_format=(
+            template.source_format.value
+            if hasattr(template.source_format, "value")
+            else str(template.source_format)
+        ),
+        page_count=template.page_count,
+        fields=[
+            FieldMappingResponse(
+                field_id=f.field_id,
+                field_name=f.field_name,
+                field_label=f.field_label,
+                field_type=(
+                    f.field_type.value if hasattr(f.field_type, "value") else str(f.field_type)
+                ),
+                page_number=f.page_number,
+                required=f.required,
+                sensitive=f.sensitive,
+            )
+            for f in template.fields
+        ],
+        status=template.status.value,
+        created_at=template.created_at,
+        updated_at=template.updated_at,
+        created_by=template.created_by,
+        tenant_id=template.tenant_id,
+        approved_by=template.approved_by,
+        approved_at=template.approved_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/templates", status_code=status.HTTP_201_CREATED, response_model=FormTemplateResponse)
+async def create_template(
+    request: CreateTemplateRequest,
+    current_user: User = Depends(require_admin),
+    api=Depends(get_template_api),
+):
+    """Create a new form template (admin only)."""
+    from ingestkit_forms.errors import FormIngestException
+    from ingestkit_forms.models import FieldMapping, FormTemplateCreateRequest
+
+    settings = get_settings()
+    initial_status = "approved" if not settings.forms_template_require_approval else "draft"
+
+    try:
+        fields = [FieldMapping(**f) for f in request.fields]
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid field mapping: {e}",
+        ) from e
+
+    create_req = FormTemplateCreateRequest(
+        name=request.name,
+        description=request.description,
+        source_format=request.source_format,
+        sample_file_path=request.sample_file_path,
+        page_count=request.page_count,
+        fields=fields,
+        tenant_id=request.tenant_id,
+        created_by=str(current_user.id),
+        initial_status=initial_status,
+    )
+
+    try:
+        template = await asyncio.to_thread(api.create_template, create_req)
+    except FormIngestException as exc:
+        raise _map_form_error(exc) from exc
+
+    return _template_to_response(template)
+
+
+@router.get("/templates", response_model=FormTemplateListResponse)
+async def list_templates(
+    tenant_id: str | None = None,
+    source_format: str | None = None,
+    template_status: str | None = None,
+    current_user: User = Depends(get_current_user),
+    api=Depends(get_template_api),
+):
+    """List form templates. Non-admins see only approved templates."""
+    from ingestkit_forms.errors import FormIngestException
+
+    is_admin = _is_admin(current_user)
+
+    # Non-admins can only see approved templates
+    if not is_admin:
+        template_status = "approved"
+
+    try:
+        templates = await asyncio.to_thread(
+            api.list_templates,
+            tenant_id=tenant_id,
+            source_format=source_format,
+            status=template_status,
+        )
+    except FormIngestException as exc:
+        raise _map_form_error(exc) from exc
+
+    if is_admin:
+        items = [_template_to_response(t) for t in templates]
+    else:
+        # Strip fields for non-admin users
+        items = [_template_to_response(t).model_copy(update={"fields": []}) for t in templates]
+
+    return FormTemplateListResponse(templates=items, total=len(items))
+
+
+@router.get("/templates/{template_id}", response_model=FormTemplateResponse)
+async def get_template(
+    template_id: str,
+    version: int | None = None,
+    current_user: User = Depends(get_current_user),
+    api=Depends(get_template_api),
+):
+    """Get a specific form template by ID. Non-admins see only approved, no fields."""
+    from ingestkit_forms.errors import FormIngestException
+    from ingestkit_forms.models import TemplateStatus
+
+    try:
+        template = await asyncio.to_thread(api.get_template, template_id, version)
+    except FormIngestException as exc:
+        raise _map_form_error(exc) from exc
+
+    is_admin = _is_admin(current_user)
+
+    # Non-admins cannot access non-approved templates
+    if not is_admin and template.status != TemplateStatus.APPROVED:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+
+    resp = _template_to_response(template)
+
+    # Strip fields for non-admins
+    if not is_admin:
+        resp = resp.model_copy(update={"fields": []})
+
+    return resp
+
+
+@router.post("/templates/{template_id}/approve", response_model=FormTemplateResponse)
+async def approve_template(
+    template_id: str,
+    current_user: User = Depends(require_admin),
+    api=Depends(get_template_api),
+):
+    """Approve a draft template (admin only)."""
+    from ingestkit_forms.errors import FormIngestException
+
+    try:
+        template = await asyncio.to_thread(api.approve_template, template_id, str(current_user.id))
+    except FormIngestException as exc:
+        raise _map_form_error(exc) from exc
+
+    return _template_to_response(template)
+
+
+@router.delete("/templates/{template_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_template(
+    template_id: str,
+    current_user: User = Depends(require_admin),
+    api=Depends(get_template_api),
+):
+    """Archive (soft-delete) a template (admin only)."""
+    from ingestkit_forms.errors import FormIngestException
+
+    try:
+        await asyncio.to_thread(api.delete_template, template_id)
+    except FormIngestException as exc:
+        raise _map_form_error(exc) from exc
+
+    return None
+
+
+@router.post(
+    "/templates/{template_id}/preview",
+    response_model=ExtractionPreviewResponse,
+)
+async def preview_extraction(
+    template_id: str,
+    file: UploadFile,
+    current_user: User = Depends(require_admin),
+    api=Depends(get_template_api),
+):
+    """Preview extraction on an uploaded file (admin only)."""
+    from ingestkit_forms.errors import FormIngestException
+
+    suffix = Path(file.filename).suffix if file.filename else ".pdf"
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        content = await file.read()
+        tmp.write(content)
+        tmp_path = tmp.name
+
+    try:
+        preview = await asyncio.to_thread(api.preview_extraction, tmp_path, template_id)
+    except FormIngestException as exc:
+        raise _map_form_error(exc) from exc
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    return ExtractionPreviewResponse(
+        template_id=preview.template_id,
+        template_name=preview.template_name,
+        template_version=preview.template_version,
+        fields=[
+            ExtractedFieldResponse(
+                field_name=f.field_name,
+                field_label=f.field_label,
+                value=f.value,
+                confidence=f.confidence,
+                extraction_method=f.extraction_method,
+            )
+            for f in preview.fields
+        ],
+        overall_confidence=preview.overall_confidence,
+        extraction_method=preview.extraction_method,
+        warnings=preview.warnings,
+    )

--- a/ai_ready_rag/api/health.py
+++ b/ai_ready_rag/api/health.py
@@ -1,12 +1,68 @@
 """Health check endpoints."""
 
+import logging
+from pathlib import Path
+
 from fastapi import APIRouter, Request
 
 from ai_ready_rag.config import get_settings
 from ai_ready_rag.core.redis import is_redis_available
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 settings = get_settings()
+
+
+def _check_forms_installed() -> bool:
+    """Return True if ingestkit_forms package is importable."""
+    try:
+        import ingestkit_forms  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _check_forms_db(app_settings) -> bool:
+    """Return True if the forms SQLite DB path is writable."""
+    try:
+        db_path = Path(app_settings.forms_db_path)
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        # Try opening the file in append mode to verify writability
+        with open(db_path, "a"):
+            pass
+        return True
+    except Exception:
+        return False
+
+
+def _check_template_store(app_settings) -> bool:
+    """Return True if the template storage directory is readable."""
+    try:
+        store_path = Path(app_settings.forms_template_storage_path)
+        return store_path.is_dir() and any(True for _ in store_path.iterdir())
+    except Exception:
+        return False
+
+
+def _count_templates(app_settings) -> tuple[int, int]:
+    """Count approved and draft templates via FileSystemTemplateStore.
+
+    Returns (approved, draft). Returns (0, 0) if ingestkit_forms is not
+    installed or the store is empty/unreadable.
+    """
+    try:
+        from ingestkit_forms import FileSystemTemplateStore
+
+        store = FileSystemTemplateStore(
+            base_path=app_settings.forms_template_storage_path,
+        )
+        templates = store.list_templates()
+        approved = sum(1 for t in templates if getattr(t, "status", None) == "approved")
+        draft = sum(1 for t in templates if getattr(t, "status", None) == "draft")
+        return approved, draft
+    except Exception:
+        return 0, 0
 
 
 @router.get("/health")
@@ -35,6 +91,16 @@ async def health_check(request: Request):
         eval_status["live_queue_drops"] = 0
         eval_status["live_queue_processed"] = 0
 
+    # Forms health
+    forms_status: dict = {"enabled": settings.use_ingestkit_forms}
+    if settings.use_ingestkit_forms:
+        forms_status["package_installed"] = _check_forms_installed()
+        forms_status["forms_db_writable"] = _check_forms_db(settings)
+        forms_status["template_store_readable"] = _check_template_store(settings)
+        approved, draft = _count_templates(settings)
+        forms_status["templates_approved"] = approved
+        forms_status["templates_draft"] = draft
+
     return {
         "status": "healthy",
         "version": settings.app_version,
@@ -48,6 +114,7 @@ async def health_check(request: Request):
             "ocr_enabled": settings.enable_ocr,
         },
         "evaluation": eval_status,
+        "forms": forms_status,
     }
 
 

--- a/ai_ready_rag/main.py
+++ b/ai_ready_rag/main.py
@@ -343,6 +343,16 @@ app.include_router(jobs.router, prefix="/api/jobs", tags=["Jobs"])
 app.include_router(experimental.router, prefix="/api", tags=["Experimental"])
 app.include_router(evaluations.router, prefix="/api/evaluations", tags=["Evaluations"])
 
+# Form template management (optional -- requires ingestkit-forms)
+if settings.use_ingestkit_forms:
+    try:
+        from ai_ready_rag.api.forms_templates import router as forms_router
+
+        app.include_router(forms_router, prefix="/api/forms", tags=["Form Templates"])
+        logger.info("forms.router.mounted")
+    except ImportError:
+        logger.warning("forms.router.import_failed")
+
 # Serve React frontend static files if dist exists
 FRONTEND_DIR = Path(__file__).parent.parent / "frontend" / "dist"
 if FRONTEND_DIR.exists():

--- a/ai_ready_rag/schemas/forms_template.py
+++ b/ai_ready_rag/schemas/forms_template.py
@@ -1,0 +1,79 @@
+"""Pydantic request/response schemas for form template management endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class FieldMappingResponse(BaseModel):
+    """Serializable field mapping for API responses."""
+
+    field_id: str
+    field_name: str
+    field_label: str
+    field_type: str
+    page_number: int
+    required: bool = False
+    sensitive: bool = False
+
+
+class FormTemplateResponse(BaseModel):
+    """Full template response (admin view)."""
+
+    template_id: str
+    name: str
+    description: str
+    version: int
+    source_format: str
+    page_count: int
+    fields: list[FieldMappingResponse]
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    created_by: str
+    tenant_id: str | None
+    approved_by: str | None
+    approved_at: datetime | None
+
+
+class FormTemplateListResponse(BaseModel):
+    """Template list response."""
+
+    templates: list[FormTemplateResponse]
+    total: int
+
+
+class CreateTemplateRequest(BaseModel):
+    """Request body for POST /templates."""
+
+    name: str
+    description: str = ""
+    source_format: str
+    sample_file_path: str
+    page_count: int = Field(ge=1)
+    fields: list[dict]  # Pass through to ingestkit FieldMapping
+    tenant_id: str | None = None
+
+
+class ExtractedFieldResponse(BaseModel):
+    """Single extracted field in preview."""
+
+    field_name: str
+    field_label: str
+    value: str | bool | float | None
+    confidence: float
+    extraction_method: str
+
+
+class ExtractionPreviewResponse(BaseModel):
+    """Preview extraction result."""
+
+    template_id: str
+    template_name: str
+    template_version: int
+    fields: list[ExtractedFieldResponse]
+    overall_confidence: float
+    extraction_method: str
+    warnings: list[str]

--- a/ai_ready_rag/services/forms_metrics.py
+++ b/ai_ready_rag/services/forms_metrics.py
@@ -1,0 +1,140 @@
+"""Lightweight in-memory metrics for the forms processing pipeline.
+
+Provides thread-safe counters and histograms that track forms processing
+activity. No external dependencies (no prometheus_client). Designed to be
+importable even when ingestkit_forms is not installed.
+
+A future issue can wire these to a /metrics Prometheus-export endpoint.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+
+@dataclass
+class _Histogram:
+    """Simple histogram that stores observations and computes summary stats."""
+
+    _values: list[float] = field(default_factory=list)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def observe(self, value: float) -> None:
+        with self._lock:
+            self._values.append(value)
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            if not self._values:
+                return {"count": 0, "sum": 0.0, "min": 0.0, "max": 0.0, "avg": 0.0}
+            total = sum(self._values)
+            return {
+                "count": len(self._values),
+                "sum": round(total, 6),
+                "min": round(min(self._values), 6),
+                "max": round(max(self._values), 6),
+                "avg": round(total / len(self._values), 6),
+            }
+
+    def reset(self) -> None:
+        with self._lock:
+            self._values.clear()
+
+
+class FormsMetrics:
+    """Thread-safe in-memory metrics registry for forms processing.
+
+    Metrics (per spec Section 15.2):
+        forms_documents_processed_total  -- Counter(status)
+        forms_match_confidence           -- Histogram(template_id)
+        forms_extraction_duration_seconds -- Histogram(extraction_method)
+        forms_fallback_total             -- Counter(reason)
+        forms_compensation_total         -- Counter(target, status)
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._started_at = time.monotonic()
+
+        # Counters: label-key -> int
+        self._documents_processed: dict[str, int] = defaultdict(int)
+        self._fallback: dict[str, int] = defaultdict(int)
+        self._compensation: dict[str, int] = defaultdict(int)
+
+        # Histograms: label-key -> _Histogram
+        self._match_confidence: dict[str, _Histogram] = defaultdict(_Histogram)
+        self._extraction_duration: dict[str, _Histogram] = defaultdict(_Histogram)
+
+    # -- Counter increments ---------------------------------------------------
+
+    def inc_documents_processed(self, status: str) -> None:
+        """Increment forms_documents_processed_total{status=...}."""
+        with self._lock:
+            self._documents_processed[status] += 1
+
+    def inc_fallback(self, reason: str) -> None:
+        """Increment forms_fallback_total{reason=...}."""
+        with self._lock:
+            self._fallback[reason] += 1
+
+    def inc_compensation(self, target: str, status: str) -> None:
+        """Increment forms_compensation_total{target=..., status=...}."""
+        key = f"{target}:{status}"
+        with self._lock:
+            self._compensation[key] += 1
+
+    # -- Histogram observations -----------------------------------------------
+
+    def inc_match_confidence(self, template_id: str, confidence: float) -> None:
+        """Observe forms_match_confidence{template_id=...}."""
+        self._match_confidence[template_id].observe(confidence)
+
+    def observe_extraction_duration(self, extraction_method: str, seconds: float) -> None:
+        """Observe forms_extraction_duration_seconds{extraction_method=...}."""
+        self._extraction_duration[extraction_method].observe(seconds)
+
+    # -- Export ---------------------------------------------------------------
+
+    def snapshot(self) -> dict:
+        """Return a JSON-serialisable snapshot of all metrics."""
+        with self._lock:
+            docs = dict(self._documents_processed)
+            fallback = dict(self._fallback)
+            compensation = dict(self._compensation)
+
+        match_conf = {k: v.snapshot() for k, v in self._match_confidence.items()}
+        extract_dur = {k: v.snapshot() for k, v in self._extraction_duration.items()}
+
+        return {
+            "forms_documents_processed_total": docs,
+            "forms_match_confidence": match_conf,
+            "forms_extraction_duration_seconds": extract_dur,
+            "forms_fallback_total": fallback,
+            "forms_compensation_total": compensation,
+            "uptime_seconds": round(time.monotonic() - self._started_at, 1),
+        }
+
+    def reset(self) -> None:
+        """Reset all metrics (useful for testing)."""
+        with self._lock:
+            self._documents_processed.clear()
+            self._fallback.clear()
+            self._compensation.clear()
+        for h in self._match_confidence.values():
+            h.reset()
+        self._match_confidence.clear()
+        for h in self._extraction_duration.values():
+            h.reset()
+        self._extraction_duration.clear()
+
+
+# Module-level singleton
+metrics = FormsMetrics()
+
+
+def get_forms_metrics() -> dict:
+    """Return a snapshot of all forms metrics (for health/debug endpoints)."""
+    return metrics.snapshot()

--- a/ai_ready_rag/services/ingestkit_adapters.py
+++ b/ai_ready_rag/services/ingestkit_adapters.py
@@ -301,6 +301,7 @@ class VERagFormDBAdapter:
 
         error = validate_table_name(name)
         if error is not None:
+            logger.error("forms.cleanup.unsafe_identifier", extra={"table": name})
             raise ValueError(f"Unsafe table identifier rejected: {name!r} — {error}")
 
     def execute_sql(self, sql: str, params: tuple | None = None) -> None:

--- a/ai_ready_rag/services/processing_service.py
+++ b/ai_ready_rag/services/processing_service.py
@@ -148,6 +148,10 @@ class ProcessingService:
                     )
                 # else: fallback to standard chunker pipeline below
                 logger.info("forms.routing.fallback", extra={"document_id": document.id})
+                from ai_ready_rag.services.forms_metrics import metrics as forms_metrics
+
+                forms_metrics.inc_fallback("no_match")
+                forms_metrics.inc_documents_processed("fallback")
 
             # Route Excel files to ingestkit if enabled
             if file_path.suffix.lower() == ".xlsx" and self._should_use_ingestkit():
@@ -354,7 +358,7 @@ class ProcessingService:
 
             return True
         except ImportError:
-            logger.warning("use_ingestkit_forms=True but ingestkit_forms not importable")
+            logger.warning("forms.dependency.missing")
             return False
 
     async def _process_with_ingestkit_forms(


### PR DESCRIPTION
## Summary

- **#253**: Add `_cleanup_forms_tables()` to `DocumentService.delete_document()` — drops forms DB tables on document deletion with identifier validation
- **#254**: Create `ai_ready_rag/api/forms_templates.py` — 6 REST endpoints for template CRUD, approval lifecycle, and preview with role-based access control
- **#255**: Add forms observability — 10 structured log events, 5 thread-safe metrics, and health check extension

## Test plan
- [ ] Verify `_cleanup_forms_tables()` handles valid/invalid table names and missing DB gracefully
- [ ] Verify template API endpoints enforce authorization matrix (admin-only for create/approve/delete/preview)
- [ ] Verify health endpoint includes `forms` block when `use_ingestkit_forms=True`
- [ ] Verify structured log events emit with correct keys
- [ ] Run `ruff check` and `ruff format --check` on all modified files

Closes #253, closes #254, closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)