### PR TITLE
feat(auto-tagging): Phase 1 - strategy engine, config, upload integration

### DIFF
--- a/ai_ready_rag/api/documents.py
+++ b/ai_ready_rag/api/documents.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-from typing import Annotated
 
 from fastapi import (
     APIRouter,
@@ -214,8 +213,8 @@ async def check_duplicates(
 @router.post("/upload", response_model=DocumentResponse, status_code=status.HTTP_201_CREATED)
 async def upload_document(
     file: UploadFile,
-    tag_ids: Annotated[list[str], Form()],
     background_tasks: BackgroundTasks,
+    tag_ids: list[str] = Form(default=[]),
     title: str | None = Form(None),
     description: str | None = Form(None),
     enable_ocr: bool | None = Form(None),
@@ -223,6 +222,8 @@ async def upload_document(
     ocr_language: str | None = Form(None),
     table_extraction_mode: str | None = Form(None),
     include_image_descriptions: bool | None = Form(None),
+    source_path: str | None = Form(None),
+    auto_tag: bool | None = Form(None),
     replace: bool = Query(False, description="Replace existing duplicate if found"),
     current_user: User = Depends(require_admin),
     db: Session = Depends(get_db),
@@ -268,6 +269,8 @@ async def upload_document(
         description=description,
         replace=replace,
         vector_service=vector_service,
+        source_path=source_path,
+        auto_tag=auto_tag,
     )
 
     # Build processing options if any are provided

--- a/ai_ready_rag/config.py
+++ b/ai_ready_rag/config.py
@@ -248,6 +248,25 @@ class Settings(BaseSettings):
     forms_redact_high_risk_fields: bool = True  # Redact SSN, tax ID, account numbers
     forms_template_require_approval: bool = True  # Templates must be approved before matching
 
+    # Auto-tagging
+    auto_tagging_enabled: bool = False
+    auto_tagging_strategy: str = "generic"
+    auto_tagging_path_enabled: bool = True
+    auto_tagging_llm_enabled: bool = True
+    auto_tagging_llm_model: str = "qwen3:8b"
+    auto_tagging_require_approval: bool = False
+    auto_tagging_create_missing_tags: bool = True
+    auto_tagging_confidence_threshold: float = 0.7
+    auto_tagging_suggestion_threshold: float = 0.4
+    auto_tagging_strategies_dir: str = "./data/auto_tag_strategies"
+
+    # Auto-tagging guardrails
+    auto_tagging_max_tags_per_doc: int = 20
+    auto_tagging_max_tag_name_length: int = 100
+    auto_tagging_max_client_tags: int = 500
+    auto_tagging_llm_timeout_seconds: int = 30
+    auto_tagging_llm_max_retries: int = 1
+
     # Document Processing
     enable_ocr: bool | None = None  # None = use profile default
     ocr_language: str = "eng"

--- a/ai_ready_rag/db/models/document.py
+++ b/ai_ready_rag/db/models/document.py
@@ -45,4 +45,11 @@ class Document(Base):
     forms_ingest_key = Column(String, nullable=True, index=True)
     forms_db_table_names = Column(Text, nullable=True)  # JSON array of table names
 
+    # Auto-tagging fields (all nullable — only populated when auto-tagging is enabled)
+    auto_tag_status = Column(String, nullable=True)  # null|pending|completed|partial|failed
+    auto_tag_strategy = Column(String, nullable=True)  # Strategy ID used
+    auto_tag_version = Column(String, nullable=True)  # Strategy version used
+    auto_tag_source = Column(Text, nullable=True)  # JSON provenance
+    source_path = Column(String, nullable=True)  # Original folder path from upload
+
     tags = relationship("Tag", secondary=document_tags, back_populates="documents")

--- a/ai_ready_rag/schemas/document.py
+++ b/ai_ready_rag/schemas/document.py
@@ -37,6 +37,11 @@ class DocumentResponse(BaseModel):
     page_count: int | None
     word_count: int | None
     processing_time_ms: int | None
+    auto_tag_status: str | None = None
+    auto_tag_strategy: str | None = None
+    auto_tag_version: str | None = None
+    auto_tag_source: str | None = None
+    source_path: str | None = None
     error_message: str | None
     tags: list[TagInfo]
     uploaded_by: str

--- a/ai_ready_rag/services/auto_tagging/__init__.py
+++ b/ai_ready_rag/services/auto_tagging/__init__.py
@@ -1,0 +1,49 @@
+"""Auto-tagging strategy engine for hybrid path-based and LLM-based tagging."""
+
+from ai_ready_rag.services.auto_tagging.models import (
+    AutoTag,
+    DocumentTypeConfig,
+    EmailPattern,
+    EmailPatternTag,
+    EntityExtractionConfig,
+    NamespaceConfig,
+    StrategyMetadata,
+    StrategyYAML,
+    TopicExtractionConfig,
+    TopicValue,
+)
+from ai_ready_rag.services.auto_tagging.strategy import AutoTagStrategy, PathRule
+from ai_ready_rag.services.auto_tagging.transforms import (
+    TRANSFORM_REGISTRY,
+    get_transform,
+    identity,
+    lowercase,
+    resolve_entity,
+    slugify,
+    year_range,
+)
+
+__all__ = [
+    # Strategy
+    "AutoTagStrategy",
+    "PathRule",
+    # Models
+    "AutoTag",
+    "DocumentTypeConfig",
+    "EmailPattern",
+    "EmailPatternTag",
+    "EntityExtractionConfig",
+    "NamespaceConfig",
+    "StrategyMetadata",
+    "StrategyYAML",
+    "TopicExtractionConfig",
+    "TopicValue",
+    # Transforms
+    "TRANSFORM_REGISTRY",
+    "get_transform",
+    "identity",
+    "lowercase",
+    "resolve_entity",
+    "slugify",
+    "year_range",
+]

--- a/ai_ready_rag/services/auto_tagging/models.py
+++ b/ai_ready_rag/services/auto_tagging/models.py
@@ -1,0 +1,188 @@
+"""Pydantic models for auto-tagging strategy configuration and runtime tags."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+
+class NamespaceConfig(BaseModel):
+    """Configuration for a tag namespace."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    display: str
+    color: str = "#6B7280"
+    description: str = ""
+
+
+class DocumentTypeConfig(BaseModel):
+    """Configuration for a document type in the taxonomy."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    display: str
+    description: str = ""
+    keywords: list[str] = []
+
+
+class EntityExtractionConfig(BaseModel):
+    """Configuration for domain-specific entity extraction."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    namespace: str
+    prompt_label: str
+    prompt_instruction: str
+    aliases: dict[str, str] = {}
+
+
+class TopicValue(BaseModel):
+    """A single topic value with keywords for matching."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    display: str
+    keywords: list[str] = []
+
+
+class TopicExtractionConfig(BaseModel):
+    """Configuration for topic extraction from document content."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    namespace: str
+    prompt_label: str
+    prompt_instruction: str
+    values: list[TopicValue] = []
+
+
+class EmailPatternTag(BaseModel):
+    """A tag to apply when an email pattern matches."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    namespace: str
+    value: str
+
+
+class EmailPattern(BaseModel):
+    """A regex pattern for matching email subjects to tags."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pattern: str
+    tags: list[EmailPatternTag]
+
+
+class StrategyMetadata(BaseModel):
+    """Metadata block for a strategy YAML file."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    name: str
+    version: str
+    description: str = ""
+
+
+_NAMESPACE_ID_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_DOCTYPE_ID_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+class StrategyYAML(BaseModel):
+    """Top-level validation model for strategy YAML files."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    strategy: StrategyMetadata
+    namespaces: dict[str, NamespaceConfig]
+    document_types: dict[str, DocumentTypeConfig]
+    llm_prompt: str
+    path_rules: list[dict] = []
+    entity_extraction: EntityExtractionConfig | None = None
+    topic_extraction: TopicExtractionConfig | None = None
+    email_patterns: list[EmailPattern] = []
+
+    @field_validator("namespaces")
+    @classmethod
+    def validate_namespaces(cls, v: dict[str, NamespaceConfig]) -> dict[str, NamespaceConfig]:
+        """Validate namespace IDs are lowercase alphanumeric, max 20 chars."""
+        for ns_id in v:
+            if len(ns_id) > 20:
+                msg = f"Namespace ID '{ns_id}' exceeds 20 characters"
+                raise ValueError(msg)
+            if not _NAMESPACE_ID_RE.match(ns_id):
+                msg = f"Namespace ID '{ns_id}' must match [a-z][a-z0-9_]*"
+                raise ValueError(msg)
+        return v
+
+    @field_validator("document_types")
+    @classmethod
+    def validate_document_types(
+        cls, v: dict[str, DocumentTypeConfig]
+    ) -> dict[str, DocumentTypeConfig]:
+        """Validate document type IDs and ensure 'unknown' exists."""
+        if "unknown" not in v:
+            msg = "document_types must contain an 'unknown' entry"
+            raise ValueError(msg)
+        for dt_id in v:
+            if len(dt_id) > 30:
+                msg = f"Document type ID '{dt_id}' exceeds 30 characters"
+                raise ValueError(msg)
+            if not _DOCTYPE_ID_RE.match(dt_id):
+                msg = f"Document type ID '{dt_id}' must match [a-z][a-z0-9_]*"
+                raise ValueError(msg)
+        return v
+
+    @field_validator("llm_prompt")
+    @classmethod
+    def validate_llm_prompt(cls, v: str) -> str:
+        """Ensure LLM prompt contains required placeholder."""
+        if "{document_type_ids}" not in v:
+            msg = "llm_prompt must contain {document_type_ids} placeholder"
+            raise ValueError(msg)
+        return v
+
+    @model_validator(mode="after")
+    def validate_path_rules(self) -> StrategyYAML:
+        """Validate path rule structure."""
+        for i, rule in enumerate(self.path_rules):
+            if "namespace" not in rule:
+                msg = f"Path rule {i} missing required 'namespace' field"
+                raise ValueError(msg)
+            if not isinstance(rule.get("namespace"), str):
+                msg = f"Path rule {i} 'namespace' must be a string"
+                raise ValueError(msg)
+            if "level" not in rule:
+                msg = f"Path rule {i} missing required 'level' field"
+                raise ValueError(msg)
+            level = rule.get("level")
+            if not isinstance(level, int) or level < 0:
+                msg = f"Path rule {i} 'level' must be a non-negative integer"
+                raise ValueError(msg)
+        return self
+
+
+class AutoTag(BaseModel):
+    """A tag produced by the auto-tagging pipeline."""
+
+    namespace: str
+    value: str
+    source: Literal["path", "llm", "email", "manual"]
+    confidence: float = 1.0
+    strategy_id: str = ""
+    strategy_version: str = ""
+
+    @property
+    def tag_name(self) -> str:
+        """Full namespaced tag name for DB storage."""
+        return f"{self.namespace}:{self.value}"
+
+    @property
+    def display_name(self) -> str:
+        """Human-readable display name."""
+        return self.value.replace("-", " ").title()

--- a/ai_ready_rag/services/auto_tagging/strategy.py
+++ b/ai_ready_rag/services/auto_tagging/strategy.py
@@ -1,0 +1,400 @@
+"""AutoTagStrategy class and PathRule dataclass for the auto-tagging engine."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+from pydantic import ValidationError
+
+from ai_ready_rag.services.auto_tagging.models import (
+    AutoTag,
+    DocumentTypeConfig,
+    EmailPattern,
+    EntityExtractionConfig,
+    NamespaceConfig,
+    StrategyYAML,
+    TopicExtractionConfig,
+)
+from ai_ready_rag.services.auto_tagging.transforms import get_transform, resolve_entity
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PathRule:
+    """A rule for extracting a tag from a specific folder level in a path."""
+
+    namespace: str
+    level: int
+    pattern: str | None = None
+    capture_group: int = 1
+    transform: str | None = None
+    mapping: dict[str, str] | None = None
+    parent_match: str | None = None
+    _compiled_pattern: re.Pattern | None = field(default=None, repr=False, compare=False)
+    _compiled_parent: re.Pattern | None = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        """Compile regex patterns after initialization."""
+        if self.pattern is not None:
+            self._compiled_pattern = re.compile(self.pattern)
+        if self.parent_match is not None:
+            self._compiled_parent = re.compile(self.parent_match)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> PathRule:
+        """Create a PathRule from a dictionary, validating required fields.
+
+        Raises:
+            ValueError: If required fields are missing or invalid.
+        """
+        namespace = data.get("namespace")
+        if not isinstance(namespace, str):
+            msg = "PathRule requires a string 'namespace'"
+            raise ValueError(msg)
+        level = data.get("level")
+        if not isinstance(level, int) or level < 0:
+            msg = "PathRule requires a non-negative integer 'level'"
+            raise ValueError(msg)
+        return cls(
+            namespace=namespace,
+            level=level,
+            pattern=data.get("pattern"),
+            capture_group=data.get("capture_group", 1),
+            transform=data.get("transform"),
+            mapping=data.get("mapping"),
+            parent_match=data.get("parent_match"),
+        )
+
+
+class AutoTagStrategy:
+    """Loaded from YAML, drives both path-based and LLM-based tagging."""
+
+    def __init__(
+        self,
+        *,
+        id: str,
+        name: str,
+        description: str,
+        version: str,
+        namespaces: dict[str, NamespaceConfig],
+        path_rules: list[PathRule],
+        document_types: dict[str, DocumentTypeConfig],
+        entity_extraction: EntityExtractionConfig | None,
+        topic_extraction: TopicExtractionConfig | None,
+        llm_prompt_template: str,
+        email_patterns: list[EmailPattern],
+    ) -> None:
+        self.id = id
+        self.name = name
+        self.description = description
+        self.version = version
+        self.namespaces = namespaces
+        self.path_rules = path_rules
+        self.document_types = document_types
+        self.entity_extraction = entity_extraction
+        self.topic_extraction = topic_extraction
+        self.llm_prompt_template = llm_prompt_template
+        self.email_patterns = email_patterns
+
+    @classmethod
+    def load(cls, path: str) -> AutoTagStrategy:
+        """Load a strategy from a YAML file.
+
+        Validates the YAML against the StrategyYAML schema, checks that
+        strategy.id matches the filename, and compiles PathRule regex patterns.
+
+        Raises:
+            FileNotFoundError: If the YAML file does not exist.
+            ValueError: If validation fails (schema, id mismatch, etc.).
+        """
+        filepath = Path(path)
+        if not filepath.exists():
+            msg = f"Strategy file not found: {path}"
+            raise FileNotFoundError(msg)
+
+        with open(filepath) as f:
+            raw = yaml.safe_load(f)
+
+        if not isinstance(raw, dict):
+            msg = f"Strategy file must contain a YAML mapping, got {type(raw).__name__}"
+            raise ValueError(msg)
+
+        try:
+            validated = StrategyYAML(**raw)
+        except ValidationError as e:
+            msg = f"Strategy validation failed for {filepath.name}: {e}"
+            raise ValueError(msg) from e
+
+        expected_id = filepath.stem
+        if validated.strategy.id != expected_id:
+            msg = f"Strategy ID '{validated.strategy.id}' does not match filename '{expected_id}'"
+            raise ValueError(msg)
+
+        compiled_rules: list[PathRule] = []
+        for rule_dict in validated.path_rules:
+            try:
+                compiled_rules.append(PathRule.from_dict(rule_dict))
+            except (ValueError, re.error) as e:
+                msg = f"Invalid path rule: {e}"
+                raise ValueError(msg) from e
+
+        return cls(
+            id=validated.strategy.id,
+            name=validated.strategy.name,
+            description=validated.strategy.description,
+            version=validated.strategy.version,
+            namespaces=validated.namespaces,
+            path_rules=compiled_rules,
+            document_types=validated.document_types,
+            entity_extraction=validated.entity_extraction,
+            topic_extraction=validated.topic_extraction,
+            llm_prompt_template=validated.llm_prompt,
+            email_patterns=validated.email_patterns,
+        )
+
+    def parse_path(self, source_path: str) -> list[AutoTag]:
+        """Apply path rules to extract tags from folder structure.
+
+        Strips the filename from the path (last component if it contains a dot),
+        then splits by '/' into folder components. Each PathRule is applied by
+        its level index.
+        """
+        if not source_path or not source_path.strip():
+            return []
+
+        normalized = source_path.replace("\\", "/").strip("/")
+        parts = normalized.split("/")
+
+        if not parts:
+            return []
+
+        if "." in parts[-1]:
+            parts = parts[:-1]
+
+        if not parts:
+            return []
+
+        tags: list[AutoTag] = []
+
+        for rule in self.path_rules:
+            try:
+                if rule.level >= len(parts):
+                    continue
+
+                folder = parts[rule.level]
+
+                if rule.parent_match is not None:
+                    if rule.level == 0:
+                        continue
+                    parent = parts[rule.level - 1]
+                    if rule._compiled_parent and not rule._compiled_parent.match(parent):
+                        continue
+
+                if rule.mapping is not None:
+                    mapped_value = rule.mapping.get(folder)
+                    if mapped_value is not None:
+                        tags.append(
+                            AutoTag(
+                                namespace=rule.namespace,
+                                value=mapped_value,
+                                source="path",
+                                confidence=1.0,
+                                strategy_id=self.id,
+                                strategy_version=self.version,
+                            )
+                        )
+                    continue
+
+                transform_fn = get_transform(rule.transform)
+
+                if rule.pattern is not None and rule._compiled_pattern is not None:
+                    m = rule._compiled_pattern.match(folder)
+                    if m:
+                        try:
+                            captured = m.group(rule.capture_group)
+                        except IndexError:
+                            captured = m.group(0)
+                        value = transform_fn(captured)
+                        tags.append(
+                            AutoTag(
+                                namespace=rule.namespace,
+                                value=value,
+                                source="path",
+                                confidence=1.0,
+                                strategy_id=self.id,
+                                strategy_version=self.version,
+                            )
+                        )
+                else:
+                    value = transform_fn(folder)
+                    tags.append(
+                        AutoTag(
+                            namespace=rule.namespace,
+                            value=value,
+                            source="path",
+                            confidence=1.0,
+                            strategy_id=self.id,
+                            strategy_version=self.version,
+                        )
+                    )
+
+            except Exception:
+                logger.warning(
+                    "Skipping path rule (namespace=%s, level=%d) due to error",
+                    rule.namespace,
+                    rule.level,
+                    exc_info=True,
+                )
+
+        return tags
+
+    def build_llm_prompt(self, filename: str, source_path: str, content_preview: str) -> str:
+        """Render the LLM prompt template with strategy-specific values.
+
+        Uses a two-pass approach:
+        1. Replace dot-notation placeholders manually
+        2. Use str.format_map with a defaultdict for simple placeholders
+        """
+        template = self.llm_prompt_template
+
+        entity_label = self.entity_extraction.prompt_label if self.entity_extraction else "entity"
+        entity_instruction = (
+            self.entity_extraction.prompt_instruction if self.entity_extraction else ""
+        )
+        topic_instruction = (
+            self.topic_extraction.prompt_instruction if self.topic_extraction else ""
+        )
+
+        template = template.replace("{entity_extraction.prompt_label}", entity_label)
+        template = template.replace("{entity_extraction.prompt_instruction}", entity_instruction)
+        template = template.replace("{topic_extraction.prompt_instruction}", topic_instruction)
+
+        document_type_ids = ", ".join(self.document_types.keys())
+        document_type_rules = "\n".join(
+            f"- {dt_id}: {dt_config.description}"
+            for dt_id, dt_config in self.document_types.items()
+        )
+        topic_ids = ""
+        if self.topic_extraction:
+            topic_ids = ", ".join(v.id for v in self.topic_extraction.values)
+
+        values = defaultdict(
+            str,
+            {
+                "filename": filename,
+                "source_path": source_path,
+                "content_preview": content_preview,
+                "document_type_ids": document_type_ids,
+                "document_type_rules": document_type_rules,
+                "topic_ids": topic_ids,
+            },
+        )
+
+        return template.format_map(values)
+
+    def parse_llm_response(self, response: dict) -> list[AutoTag]:
+        """Convert an LLM JSON response into a list of AutoTag objects.
+
+        Handles document_type, entity, topics, confidence, and year extraction.
+        """
+        tags: list[AutoTag] = []
+        confidence = float(response.get("confidence", 0.5))
+
+        doc_type = response.get("document_type", "unknown")
+        if doc_type not in self.document_types:
+            logger.warning("Unknown document type '%s', mapping to 'unknown'", doc_type)
+            doc_type = "unknown"
+        tags.append(
+            AutoTag(
+                namespace="doctype",
+                value=doc_type,
+                source="llm",
+                confidence=confidence,
+                strategy_id=self.id,
+                strategy_version=self.version,
+            )
+        )
+
+        entity_raw = response.get("entity")
+        if entity_raw and self.entity_extraction:
+            entity_value = resolve_entity(entity_raw, self.entity_extraction.aliases)
+            tags.append(
+                AutoTag(
+                    namespace=self.entity_extraction.namespace,
+                    value=entity_value,
+                    source="llm",
+                    confidence=confidence,
+                    strategy_id=self.id,
+                    strategy_version=self.version,
+                )
+            )
+
+        topics_raw = response.get("topics")
+        if topics_raw and self.topic_extraction:
+            known_ids = {v.id for v in self.topic_extraction.values}
+            for topic_id in topics_raw:
+                if topic_id in known_ids:
+                    tags.append(
+                        AutoTag(
+                            namespace=self.topic_extraction.namespace,
+                            value=topic_id,
+                            source="llm",
+                            confidence=confidence,
+                            strategy_id=self.id,
+                            strategy_version=self.version,
+                        )
+                    )
+
+        year_start = response.get("year_start")
+        year_end = response.get("year_end")
+        if year_start and year_end:
+            tags.append(
+                AutoTag(
+                    namespace="year",
+                    value=f"{year_start}-{year_end}",
+                    source="llm",
+                    confidence=confidence,
+                    strategy_id=self.id,
+                    strategy_version=self.version,
+                )
+            )
+
+        return tags
+
+    def parse_email_subject(self, subject: str) -> list[AutoTag]:
+        """Apply email subject patterns to extract tags.
+
+        Returns deduplicated tags (by tag_name).
+        """
+        tags: list[AutoTag] = []
+        seen: set[str] = set()
+
+        for email_pattern in self.email_patterns:
+            try:
+                if re.search(email_pattern.pattern, subject):
+                    for tag_def in email_pattern.tags:
+                        tag = AutoTag(
+                            namespace=tag_def.namespace,
+                            value=tag_def.value,
+                            source="email",
+                            confidence=1.0,
+                            strategy_id=self.id,
+                            strategy_version=self.version,
+                        )
+                        if tag.tag_name not in seen:
+                            seen.add(tag.tag_name)
+                            tags.append(tag)
+            except re.error:
+                logger.warning(
+                    "Invalid email pattern '%s', skipping",
+                    email_pattern.pattern,
+                    exc_info=True,
+                )
+
+        return tags

--- a/ai_ready_rag/services/auto_tagging/transforms.py
+++ b/ai_ready_rag/services/auto_tagging/transforms.py
@@ -1,0 +1,99 @@
+"""Transform functions for auto-tag value normalization and entity resolution."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+
+
+def slugify(value: str) -> str:
+    """Normalize a string to a URL-safe slug.
+
+    Rules (per spec Section 11.3):
+    1. Lowercase
+    2. Replace spaces and underscores with hyphens
+    3. Strip non-alphanumeric characters (except hyphens)
+    4. Collapse multiple hyphens to single
+    5. Trim leading/trailing hyphens
+    """
+    result = value.lower()
+    result = re.sub(r"[\s_]+", "-", result)
+    result = re.sub(r"[^a-z0-9-]", "", result)
+    result = re.sub(r"-{2,}", "-", result)
+    result = result.strip("-")
+    return result
+
+
+def year_range(value: str) -> str:
+    """Convert a 1-2 digit year to a year range string.
+
+    Always assumes 2000s century. Two-digit years are mapped as 20XX to 20(XX+1).
+
+    Examples:
+        "24" -> "2024-2025"
+        "5"  -> "2005-2006"
+        "0"  -> "2000-2001"
+        "99" -> "2099-2100"
+
+    Raises:
+        ValueError: If input is not a valid 1-2 digit number.
+    """
+    stripped = value.strip()
+    if not stripped.isdigit():
+        msg = f"year_range requires a numeric string, got '{value}'"
+        raise ValueError(msg)
+    year_num = int(stripped)
+    if year_num < 0 or year_num > 99:
+        msg = f"year_range requires a 0-99 value, got {year_num}"
+        raise ValueError(msg)
+    start = 2000 + year_num
+    end = start + 1
+    return f"{start}-{end}"
+
+
+def lowercase(value: str) -> str:
+    """Convert value to lowercase."""
+    return value.lower()
+
+
+def identity(value: str) -> str:
+    """Return value unchanged."""
+    return value
+
+
+TRANSFORM_REGISTRY: dict[str | None, Callable[[str], str]] = {
+    "slugify": slugify,
+    "year_range": year_range,
+    "lowercase": lowercase,
+    "none": identity,
+    None: identity,
+}
+
+
+def get_transform(name: str | None) -> Callable[[str], str]:
+    """Look up a transform function by name.
+
+    Raises:
+        ValueError: If the transform name is not recognized.
+    """
+    if name in TRANSFORM_REGISTRY:
+        return TRANSFORM_REGISTRY[name]
+    msg = f"Unknown transform '{name}'. Valid transforms: {list(TRANSFORM_REGISTRY.keys())}"
+    raise ValueError(msg)
+
+
+def resolve_entity(raw_name: str, aliases: dict[str, str]) -> str:
+    """Normalize an entity name using the alias table.
+
+    Resolution order:
+    1. Exact match in aliases
+    2. Case-insensitive match in aliases
+    3. Fallback to slugify(raw_name)
+    """
+    if raw_name in aliases:
+        return aliases[raw_name]
+    raw_lower = raw_name.lower()
+    for alias, slug in aliases.items():
+        if raw_lower == alias.lower():
+            return slug
+    return slugify(raw_name)

--- a/data/auto_tag_strategies/generic.yaml
+++ b/data/auto_tag_strategies/generic.yaml
@@ -1,0 +1,77 @@
+strategy:
+  id: "generic"
+  name: "Generic"
+  description: "Universal strategy — extracts client from top folder, basic doc classification"
+  version: "1.0"
+
+namespaces:
+  client:
+    display: "Client"
+    color: "#6366f1"
+  year:
+    display: "Year"
+    color: "#f59e0b"
+  doctype:
+    display: "Document Type"
+    color: "#10b981"
+
+path_rules:
+  - namespace: "client"
+    level: 0
+    pattern: "^(.+)$"
+    capture_group: 1
+    transform: "slugify"
+
+document_types:
+  contract:
+    display: "Contract"
+    keywords: ["contract", "agreement", "terms and conditions", "msa"]
+  report:
+    display: "Report"
+    keywords: ["report", "summary", "analysis", "findings"]
+  financial:
+    display: "Financial"
+    keywords: ["invoice", "budget", "p&l", "balance sheet", "financial"]
+  correspondence:
+    display: "Correspondence"
+    keywords: ["dear", "re:", "fwd:", "please find", "attached"]
+  proposal:
+    display: "Proposal"
+    keywords: ["proposal", "quote", "estimate", "bid"]
+  form:
+    display: "Form"
+    keywords: ["application", "form", "questionnaire", "survey"]
+  legal:
+    display: "Legal Document"
+    keywords: ["amendment", "addendum", "exhibit", "declaration", "resolution"]
+  reference:
+    display: "Reference Material"
+    keywords: ["manual", "guide", "handbook", "specification", "standard"]
+  photo:
+    display: "Photo/Image"
+    keywords: []
+  unknown:
+    display: "Unknown"
+    keywords: []
+
+entity_extraction: null
+topic_extraction: null
+
+llm_prompt: |
+  Classify this document. Return JSON only.
+
+  Document filename: {filename}
+  First 2000 characters of content:
+  {content_preview}
+
+  Return this exact JSON structure:
+  {{
+    "document_type": "<one of: {document_type_ids}>",
+    "year_start": "<YYYY or null>",
+    "year_end": "<YYYY or null>",
+    "confidence": <0.0 to 1.0>
+  }}
+
+email_patterns:
+  - pattern: "(?i)invoice|payment"
+    tags: [{namespace: "doctype", value: "financial"}]

--- a/data/auto_tag_strategies/insurance_agency.yaml
+++ b/data/auto_tag_strategies/insurance_agency.yaml
@@ -1,0 +1,216 @@
+strategy:
+  id: "insurance_agency"
+  name: "Insurance Agency"
+  description: "For insurance brokerages managing customer policy folders"
+  version: "1.0"
+
+namespaces:
+  client:
+    display: "Client"
+    color: "#6366f1"
+    description: "Customer or insured name"
+  year:
+    display: "Policy Year"
+    color: "#f59e0b"
+    description: "Policy effective period"
+  doctype:
+    display: "Document Type"
+    color: "#10b981"
+    description: "Classification of document"
+  stage:
+    display: "Workflow Stage"
+    color: "#64748b"
+    description: "Where in the workflow this document belongs"
+  entity:
+    display: "Carrier"
+    color: "#0ea5e9"
+    description: "Insurance carrier or underwriter"
+  topic:
+    display: "Coverage Line"
+    color: "#f43f5e"
+    description: "Type of insurance coverage"
+
+path_rules:
+  - namespace: "client"
+    level: 0
+    pattern: "^(.+?)(?:\\s*\\(.*\\))?$"
+    capture_group: 1
+    transform: "slugify"
+
+  - namespace: "year"
+    level: 1
+    pattern: "^(\\d{2})\\s+(?:NB|Renewal)$"
+    capture_group: 1
+    transform: "year_range"
+
+  - namespace: "stage"
+    level: 2
+    mapping:
+      "Bind": "bind"
+      "Quote": "quote"
+      "Sub": "submission"
+      "Policy": "policy"
+      "Misc": "miscellaneous"
+      "Docs": "governing-docs"
+      "Pics": "photos"
+
+  - namespace: "entity"
+    level: 3
+    parent_match: "^(Quote|Sub)$"
+    transform: "slugify"
+
+document_types:
+  policy:
+    display: "Policy"
+    description: "Active insurance policy with terms and conditions"
+    keywords: ["policy", "declarations", "dec page", "coverage form"]
+  certificate:
+    display: "Certificate"
+    description: "ACORD 25/28 certificate of insurance"
+    keywords: ["certificate of liability", "acord 25", "acord 28", "evidence of"]
+  quote:
+    display: "Quote"
+    description: "Carrier proposal with pricing"
+    keywords: ["quote", "proposal", "indication", "premium"]
+  application:
+    display: "Application"
+    description: "Completed insurance application"
+    keywords: ["application", "supplemental", "acord 125", "acord 126"]
+  loss_run:
+    display: "Loss Run"
+    description: "Claims history report from carrier"
+    keywords: ["loss run", "loss history", "claims experience", "loss ratio"]
+  financial:
+    display: "Financial Statement"
+    description: "Balance sheet, budget, P&L, or financial report"
+    keywords: ["balance sheet", "budget", "financial", "p&l", "income statement"]
+  reserve_study:
+    display: "Reserve Study"
+    description: "Capital reserve study or maintenance plan"
+    keywords: ["reserve study", "reserve fund", "capital plan", "component list"]
+  coverage_summary:
+    display: "Coverage Summary"
+    description: "Side-by-side carrier or year-over-year comparison"
+    keywords: ["coverage summary", "comparison", "expiring vs", "side by side"]
+  bor_letter:
+    display: "BOR Letter"
+    description: "Broker of record change letter"
+    keywords: ["broker of record", "bor", "agent of record"]
+  endorsement:
+    display: "Endorsement"
+    description: "Policy amendment, rider, or endorsement"
+    keywords: ["endorsement", "amendment", "rider", "schedule change"]
+  governing_docs:
+    display: "Governing Documents"
+    description: "CC&Rs, bylaws, articles of incorporation, plat maps"
+    keywords: ["cc&r", "bylaws", "covenants", "plat", "declaration"]
+  correspondence:
+    display: "Correspondence"
+    description: "Emails, memos, and general communications"
+    keywords: ["re:", "fwd:", "dear", "please find"]
+  invoice:
+    display: "Invoice"
+    description: "Premium invoice or billing statement"
+    keywords: ["invoice", "premium due", "billing", "payment"]
+  sov:
+    display: "Schedule of Values"
+    description: "Property schedule with building values"
+    keywords: ["schedule of values", "sov", "building schedule", "tiv"]
+  unknown:
+    display: "Unknown"
+    description: "Could not classify"
+    keywords: []
+
+entity_extraction:
+  namespace: "entity"
+  prompt_label: "carrier"
+  prompt_instruction: "Identify the insurance carrier or underwriting company. Use the carrier's legal name, not the MGA or broker name. Return null if not carrier-specific."
+  aliases:
+    "Continental Casualty Company": "cna"
+    "Continental Casualty": "cna"
+    "CNA": "cna"
+    "LIO Insurance Company": "lio"
+    "LIO Insurance": "lio"
+    "USLI": "usli"
+    "United States Liability Insurance": "usli"
+    "Philadelphia Indemnity": "phly"
+    "PHLY": "phly"
+    "Chubb": "chubb"
+    "ACE American Insurance": "chubb"
+
+topic_extraction:
+  namespace: "topic"
+  prompt_label: "coverage lines"
+  prompt_instruction: "List the insurance coverage lines discussed in this document."
+  values:
+    - id: "gl"
+      display: "General Liability"
+      keywords: ["general liability", "cgl", "bodily injury", "property damage"]
+    - id: "property"
+      display: "Property"
+      keywords: ["property coverage", "building", "blanket", "bpp"]
+    - id: "do"
+      display: "D&O"
+      keywords: ["directors and officers", "d&o", "management liability"]
+    - id: "crime"
+      display: "Crime"
+      keywords: ["crime", "fidelity", "employee theft", "dishonesty"]
+    - id: "auto"
+      display: "Auto"
+      keywords: ["auto", "automobile", "hired and non-owned"]
+    - id: "wc"
+      display: "Workers Comp"
+      keywords: ["workers comp", "workers' compensation", "wc"]
+    - id: "umbrella"
+      display: "Umbrella/Excess"
+      keywords: ["umbrella", "excess liability"]
+    - id: "epli"
+      display: "EPLI"
+      keywords: ["employment practices", "epli", "wrongful termination"]
+    - id: "cyber"
+      display: "Cyber"
+      keywords: ["cyber", "data breach", "network security"]
+    - id: "earthquake"
+      display: "Earthquake"
+      keywords: ["earthquake", "seismic"]
+
+llm_prompt: |
+  Classify this document from an insurance agency file system. Return JSON only.
+
+  Document filename: {filename}
+  Source path: {source_path}
+  First 2000 characters of content:
+  {content_preview}
+
+  Return this exact JSON structure:
+  {{
+    "document_type": "<one of: {document_type_ids}>",
+    "entity": "<{entity_extraction.prompt_label} or null>",
+    "topics": [<list of: {topic_ids}>],
+    "year_start": "<YYYY or null>",
+    "year_end": "<YYYY or null>",
+    "confidence": <0.0 to 1.0>
+  }}
+
+  Classification rules:
+  {document_type_rules}
+
+  Entity rules:
+  {entity_extraction.prompt_instruction}
+
+  Topic rules:
+  {topic_extraction.prompt_instruction}
+
+email_patterns:
+  - pattern: "(?i)bind|bound"
+    tags: [{namespace: "stage", value: "bind"}]
+  - pattern: "(?i)quote|proposal|indication"
+    tags: [{namespace: "stage", value: "quote"}]
+  - pattern: "(?i)submit|submission"
+    tags: [{namespace: "stage", value: "submission"}]
+  - pattern: "(?i)policy|certificate"
+    tags: [{namespace: "stage", value: "policy"}]
+  - pattern: "(?i)loss.?run|claims"
+    tags: [{namespace: "doctype", value: "loss-run"}]
+  - pattern: "(?i)endorse|change"
+    tags: [{namespace: "doctype", value: "endorsement"}]

--- a/tests/test_auto_tagging_config.py
+++ b/tests/test_auto_tagging_config.py
@@ -1,0 +1,129 @@
+"""Tests for auto-tagging configuration settings and document model columns."""
+
+import json
+
+from ai_ready_rag.config import Settings
+from ai_ready_rag.db.models.document import Document
+
+
+class TestAutoTaggingConfig:
+    """Test auto-tagging configuration settings."""
+
+    def test_default_settings(self):
+        """All auto-tagging settings have correct defaults."""
+        settings = Settings()
+
+        # Feature settings
+        assert settings.auto_tagging_enabled is False
+        assert settings.auto_tagging_strategy == "generic"
+        assert settings.auto_tagging_path_enabled is True
+        assert settings.auto_tagging_llm_enabled is True
+        assert settings.auto_tagging_llm_model == "qwen3:8b"
+        assert settings.auto_tagging_require_approval is False
+        assert settings.auto_tagging_create_missing_tags is True
+        assert settings.auto_tagging_confidence_threshold == 0.7
+        assert settings.auto_tagging_suggestion_threshold == 0.4
+        assert settings.auto_tagging_strategies_dir == "./data/auto_tag_strategies"
+
+        # Guardrail settings
+        assert settings.auto_tagging_max_tags_per_doc == 20
+        assert settings.auto_tagging_max_tag_name_length == 100
+        assert settings.auto_tagging_max_client_tags == 500
+        assert settings.auto_tagging_llm_timeout_seconds == 30
+        assert settings.auto_tagging_llm_max_retries == 1
+
+    def test_auto_tagging_disabled_by_default(self):
+        """Auto-tagging is disabled by default."""
+        settings = Settings()
+        assert settings.auto_tagging_enabled is False
+
+    def test_env_var_overrides(self, monkeypatch):
+        """Environment variables override defaults."""
+        monkeypatch.setenv("AUTO_TAGGING_ENABLED", "true")
+        monkeypatch.setenv("AUTO_TAGGING_STRATEGY", "insurance")
+        monkeypatch.setenv("AUTO_TAGGING_CONFIDENCE_THRESHOLD", "0.85")
+        monkeypatch.setenv("AUTO_TAGGING_MAX_TAGS_PER_DOC", "10")
+
+        settings = Settings()
+        assert settings.auto_tagging_enabled is True
+        assert settings.auto_tagging_strategy == "insurance"
+        assert settings.auto_tagging_confidence_threshold == 0.85
+        assert settings.auto_tagging_max_tags_per_doc == 10
+
+    def test_confidence_thresholds(self):
+        """Confidence threshold > suggestion threshold by default."""
+        settings = Settings()
+        assert (
+            settings.auto_tagging_confidence_threshold > settings.auto_tagging_suggestion_threshold
+        )
+
+
+class TestDocumentAutoTagColumns:
+    """Test Document model auto-tag columns."""
+
+    def test_auto_tag_columns_nullable(self, db):
+        """Auto-tag columns accept null values."""
+        doc = Document(
+            filename="test.pdf",
+            original_filename="test.pdf",
+            file_path="/tmp/test.pdf",
+            file_type="pdf",
+            file_size=1024,
+            uploaded_by="test-user-id",
+        )
+        db.add(doc)
+        db.flush()
+        db.refresh(doc)
+
+        assert doc.auto_tag_status is None
+        assert doc.auto_tag_strategy is None
+        assert doc.auto_tag_version is None
+        assert doc.auto_tag_source is None
+
+    def test_auto_tag_status_values(self, db):
+        """Auto-tag status accepts valid status strings."""
+        for status_value in ["pending", "completed", "partial", "failed"]:
+            doc = Document(
+                filename=f"test_{status_value}.pdf",
+                original_filename=f"test_{status_value}.pdf",
+                file_path=f"/tmp/test_{status_value}.pdf",
+                file_type="pdf",
+                file_size=1024,
+                uploaded_by="test-user-id",
+                auto_tag_status=status_value,
+            )
+            db.add(doc)
+            db.flush()
+            db.refresh(doc)
+            assert doc.auto_tag_status == status_value
+
+    def test_auto_tag_source_stores_json(self, db):
+        """auto_tag_source stores JSON text."""
+        provenance = json.dumps(
+            {
+                "strategy": "generic",
+                "version": "1.0",
+                "tags_applied": ["hr", "finance"],
+                "confidence_scores": {"hr": 0.9, "finance": 0.75},
+            }
+        )
+        doc = Document(
+            filename="test_json.pdf",
+            original_filename="test_json.pdf",
+            file_path="/tmp/test_json.pdf",
+            file_type="pdf",
+            file_size=1024,
+            uploaded_by="test-user-id",
+            auto_tag_status="completed",
+            auto_tag_strategy="generic",
+            auto_tag_version="1.0",
+            auto_tag_source=provenance,
+        )
+        db.add(doc)
+        db.flush()
+        db.refresh(doc)
+
+        parsed = json.loads(doc.auto_tag_source)
+        assert parsed["strategy"] == "generic"
+        assert "hr" in parsed["tags_applied"]
+        assert parsed["confidence_scores"]["hr"] == 0.9

--- a/tests/test_auto_tagging_strategy.py
+++ b/tests/test_auto_tagging_strategy.py
@@ -1,0 +1,516 @@
+"""Comprehensive tests for the auto-tagging strategy engine."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ai_ready_rag.services.auto_tagging import (
+    AutoTag,
+    AutoTagStrategy,
+    PathRule,
+    get_transform,
+    identity,
+    lowercase,
+    resolve_entity,
+    slugify,
+    year_range,
+)
+
+STRATEGIES_DIR = Path(__file__).resolve().parent.parent / "data" / "auto_tag_strategies"
+
+
+@pytest.fixture
+def generic_strategy() -> AutoTagStrategy:
+    """Load the built-in generic strategy."""
+    return AutoTagStrategy.load(str(STRATEGIES_DIR / "generic.yaml"))
+
+
+@pytest.fixture
+def insurance_strategy() -> AutoTagStrategy:
+    """Load the built-in insurance agency strategy."""
+    return AutoTagStrategy.load(str(STRATEGIES_DIR / "insurance_agency.yaml"))
+
+
+@pytest.fixture
+def tmp_strategy_file(tmp_path):
+    """Helper that writes a YAML dict to a temp file and returns the path."""
+
+    def _write(data: dict, filename: str = "test_strategy.yaml") -> str:
+        filepath = tmp_path / filename
+        filepath.write_text(yaml.dump(data, default_flow_style=False))
+        return str(filepath)
+
+    return _write
+
+
+# ============================================================
+# Transform Tests
+# ============================================================
+
+
+class TestTransforms:
+    def test_slugify_basic(self):
+        assert slugify("Bethany Terrace") == "bethany-terrace"
+
+    def test_slugify_special_chars(self):
+        assert slugify("D&O Quote") == "do-quote"
+
+    def test_slugify_underscores(self):
+        assert slugify("some_name") == "some-name"
+
+    def test_slugify_multiple_hyphens(self):
+        assert slugify("a--b") == "a-b"
+
+    def test_slugify_leading_trailing(self):
+        assert slugify("-test-") == "test"
+
+    def test_year_range_basic(self):
+        assert year_range("24") == "2024-2025"
+
+    def test_year_range_single_digit(self):
+        assert year_range("5") == "2005-2006"
+
+    def test_year_range_zero(self):
+        assert year_range("0") == "2000-2001"
+
+    def test_year_range_99(self):
+        assert year_range("99") == "2099-2100"
+
+    def test_year_range_invalid(self):
+        with pytest.raises(ValueError, match="numeric"):
+            year_range("abc")
+
+    def test_lowercase(self):
+        assert lowercase("CNA") == "cna"
+
+    def test_identity(self):
+        assert identity("Quote") == "Quote"
+
+    def test_get_transform_valid(self):
+        assert get_transform("slugify") is slugify
+        assert get_transform("year_range") is year_range
+        assert get_transform("lowercase") is lowercase
+        assert get_transform("none") is identity
+
+    def test_get_transform_none(self):
+        assert get_transform(None) is identity
+
+    def test_get_transform_unknown(self):
+        with pytest.raises(ValueError, match="Unknown transform"):
+            get_transform("bogus")
+
+
+# ============================================================
+# Entity Resolution Tests
+# ============================================================
+
+
+class TestResolveEntity:
+    ALIASES = {
+        "CNA": "cna",
+        "Continental Casualty Company": "cna",
+        "USLI": "usli",
+    }
+
+    def test_exact_match(self):
+        assert resolve_entity("CNA", self.ALIASES) == "cna"
+
+    def test_case_insensitive(self):
+        assert resolve_entity("cna", self.ALIASES) == "cna"
+
+    def test_full_name_match(self):
+        assert resolve_entity("Continental Casualty Company", self.ALIASES) == "cna"
+
+    def test_unknown_entity_slugified(self):
+        assert resolve_entity("Some New Carrier", self.ALIASES) == "some-new-carrier"
+
+    def test_empty_aliases(self):
+        assert resolve_entity("Some Carrier", {}) == "some-carrier"
+
+
+# ============================================================
+# AutoTag Model Tests
+# ============================================================
+
+
+class TestAutoTag:
+    def test_tag_name_property(self):
+        tag = AutoTag(namespace="client", value="bethany-terrace", source="path")
+        assert tag.tag_name == "client:bethany-terrace"
+
+    def test_display_name_property(self):
+        tag = AutoTag(namespace="client", value="bethany-terrace", source="path")
+        assert tag.display_name == "Bethany Terrace"
+
+    def test_default_confidence(self):
+        tag = AutoTag(namespace="doctype", value="policy", source="llm")
+        assert tag.confidence == 1.0
+
+    def test_source_literal(self):
+        for source in ("path", "llm", "email", "manual"):
+            tag = AutoTag(namespace="test", value="v", source=source)
+            assert tag.source == source
+
+    def test_source_invalid(self):
+        with pytest.raises(ValueError):
+            AutoTag(namespace="test", value="v", source="invalid")
+
+
+# ============================================================
+# PathRule Tests
+# ============================================================
+
+
+class TestPathRule:
+    def test_from_dict_minimal(self):
+        rule = PathRule.from_dict({"namespace": "client", "level": 0})
+        assert rule.namespace == "client"
+        assert rule.level == 0
+        assert rule.pattern is None
+        assert rule.mapping is None
+
+    def test_from_dict_full(self):
+        rule = PathRule.from_dict(
+            {
+                "namespace": "year",
+                "level": 1,
+                "pattern": r"^(\d{2})\s+(?:NB|Renewal)$",
+                "capture_group": 1,
+                "transform": "year_range",
+                "parent_match": "^Client$",
+            }
+        )
+        assert rule.namespace == "year"
+        assert rule.level == 1
+        assert rule._compiled_pattern is not None
+        assert rule._compiled_parent is not None
+
+    def test_from_dict_invalid_level(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            PathRule.from_dict({"namespace": "test", "level": -1})
+
+
+# ============================================================
+# Strategy Load Tests
+# ============================================================
+
+
+class TestStrategyLoad:
+    def test_load_generic_yaml(self, generic_strategy):
+        assert generic_strategy.id == "generic"
+        assert generic_strategy.name == "Generic"
+        assert "unknown" in generic_strategy.document_types
+        assert len(generic_strategy.path_rules) >= 1
+
+    def test_load_insurance_yaml(self, insurance_strategy):
+        assert insurance_strategy.id == "insurance_agency"
+        assert insurance_strategy.name == "Insurance Agency"
+        assert insurance_strategy.entity_extraction is not None
+        assert insurance_strategy.topic_extraction is not None
+        assert len(insurance_strategy.path_rules) == 4
+
+    def test_load_validates_id_matches_filename(self, tmp_strategy_file):
+        data = _minimal_strategy("wrong_id")
+        path = tmp_strategy_file(data, "test_strategy.yaml")
+        with pytest.raises(ValueError, match="does not match"):
+            AutoTagStrategy.load(path)
+
+    def test_load_rejects_unknown_fields(self, tmp_strategy_file):
+        data = _minimal_strategy("test_strategy")
+        data["bogus_field"] = "should fail"
+        path = tmp_strategy_file(data)
+        with pytest.raises(ValueError):
+            AutoTagStrategy.load(path)
+
+    def test_load_rejects_missing_required(self, tmp_strategy_file):
+        data = {"namespaces": {}, "document_types": {"unknown": {"display": "U"}}}
+        path = tmp_strategy_file(data)
+        with pytest.raises(ValueError):
+            AutoTagStrategy.load(path)
+
+    def test_load_rejects_missing_unknown_doctype(self, tmp_strategy_file):
+        data = _minimal_strategy("test_strategy")
+        data["document_types"] = {"policy": {"display": "Policy"}}
+        path = tmp_strategy_file(data)
+        with pytest.raises(Exception, match="unknown"):
+            AutoTagStrategy.load(path)
+
+    def test_load_rejects_invalid_namespace_id(self, tmp_strategy_file):
+        data = _minimal_strategy("test_strategy")
+        data["namespaces"]["Invalid"] = {"display": "Bad"}
+        path = tmp_strategy_file(data)
+        with pytest.raises(Exception, match="must match"):
+            AutoTagStrategy.load(path)
+
+    def test_load_rejects_missing_prompt_placeholder(self, tmp_strategy_file):
+        data = _minimal_strategy("test_strategy")
+        data["llm_prompt"] = "No placeholder here"
+        path = tmp_strategy_file(data)
+        with pytest.raises(Exception, match="document_type_ids"):
+            AutoTagStrategy.load(path)
+
+    def test_load_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            AutoTagStrategy.load("/nonexistent/path.yaml")
+
+
+# ============================================================
+# parse_path Tests
+# ============================================================
+
+
+class TestParsePath:
+    def test_insurance_full_path(self, insurance_strategy):
+        tags = insurance_strategy.parse_path("Bethany Terrace (12-13)/24 NB/Quote/CNA/DO_Quote.pdf")
+        tag_map = {t.namespace: t.value for t in tags}
+        assert tag_map["client"] == "bethany-terrace"
+        assert tag_map["year"] == "2024-2025"
+        assert tag_map["stage"] == "quote"
+        assert tag_map["entity"] == "cna"
+
+    def test_insurance_partial_path(self, insurance_strategy):
+        tags = insurance_strategy.parse_path("Bethany Terrace/24 NB/file.pdf")
+        namespaces = {t.namespace for t in tags}
+        assert "client" in namespaces
+        assert "year" in namespaces
+        assert "stage" not in namespaces
+
+    def test_mapping_rule(self, insurance_strategy):
+        tags = insurance_strategy.parse_path("Client/24 NB/Quote/file.pdf")
+        stage_tags = [t for t in tags if t.namespace == "stage"]
+        assert len(stage_tags) == 1
+        assert stage_tags[0].value == "quote"
+
+    def test_parent_match_filters(self, insurance_strategy):
+        tags = insurance_strategy.parse_path("Client/24 NB/Quote/CNA/file.pdf")
+        entity_tags = [t for t in tags if t.namespace == "entity"]
+        assert len(entity_tags) == 1
+        assert entity_tags[0].value == "cna"
+
+    def test_parent_match_skips(self, insurance_strategy):
+        tags = insurance_strategy.parse_path("Client/24 NB/Bind/CNA/file.pdf")
+        entity_tags = [t for t in tags if t.namespace == "entity"]
+        assert len(entity_tags) == 0
+
+    def test_empty_path(self, insurance_strategy):
+        assert insurance_strategy.parse_path("") == []
+
+    def test_short_path(self, insurance_strategy):
+        tags = insurance_strategy.parse_path("OnlyOneFolder/file.pdf")
+        assert len(tags) >= 1
+        assert all(t.namespace == "client" for t in tags)
+
+    def test_regex_error_skipped(self, tmp_strategy_file):
+        data = _minimal_strategy("test_strategy")
+        data["path_rules"] = [{"namespace": "test", "level": 0, "pattern": "[invalid(regex"}]
+        path = tmp_strategy_file(data)
+        with pytest.raises(ValueError):
+            AutoTagStrategy.load(path)
+
+    def test_all_tags_have_source_path(self, insurance_strategy):
+        tags = insurance_strategy.parse_path("Bethany Terrace (12-13)/24 NB/Quote/CNA/file.pdf")
+        for tag in tags:
+            assert tag.source == "path"
+            assert tag.confidence == 1.0
+            assert tag.strategy_id == "insurance_agency"
+
+
+# ============================================================
+# build_llm_prompt Tests
+# ============================================================
+
+
+class TestBuildLlmPrompt:
+    def test_basic_placeholders(self, generic_strategy):
+        prompt = generic_strategy.build_llm_prompt(
+            filename="test.pdf",
+            source_path="/docs/test.pdf",
+            content_preview="Sample content",
+        )
+        assert "test.pdf" in prompt
+        assert "Sample content" in prompt
+
+    def test_document_type_ids_filled(self, generic_strategy):
+        prompt = generic_strategy.build_llm_prompt("f.pdf", "", "c")
+        for dt_id in generic_strategy.document_types:
+            assert dt_id in prompt
+
+    def test_document_type_rules_filled(self, insurance_strategy):
+        prompt = insurance_strategy.build_llm_prompt("f.pdf", "", "c")
+        assert "Active insurance policy" in prompt
+
+    def test_entity_extraction_dot_notation(self, insurance_strategy):
+        prompt = insurance_strategy.build_llm_prompt("f.pdf", "", "c")
+        assert "carrier" in prompt
+        assert "{entity_extraction.prompt_label}" not in prompt
+
+    def test_topic_ids_filled(self, insurance_strategy):
+        prompt = insurance_strategy.build_llm_prompt("f.pdf", "", "c")
+        assert "gl" in prompt
+        assert "property" in prompt
+
+    def test_no_entity_extraction(self, generic_strategy):
+        prompt = generic_strategy.build_llm_prompt("f.pdf", "", "c")
+        assert "{entity_extraction.prompt_label}" not in prompt
+        assert "{entity_extraction.prompt_instruction}" not in prompt
+
+    def test_json_braces_preserved(self, generic_strategy):
+        prompt = generic_strategy.build_llm_prompt("f.pdf", "", "c")
+        assert '"document_type"' in prompt
+
+
+# ============================================================
+# parse_llm_response Tests
+# ============================================================
+
+
+class TestParseLlmResponse:
+    def test_full_response(self, insurance_strategy):
+        response = {
+            "document_type": "policy",
+            "entity": "CNA",
+            "topics": ["gl", "property"],
+            "year_start": "2024",
+            "year_end": "2025",
+            "confidence": 0.92,
+        }
+        tags = insurance_strategy.parse_llm_response(response)
+        tag_map = {t.namespace: t.value for t in tags}
+        assert tag_map["doctype"] == "policy"
+        assert tag_map["entity"] == "cna"
+        assert tag_map["year"] == "2024-2025"
+        topic_tags = [t for t in tags if t.namespace == "topic"]
+        assert len(topic_tags) == 2
+
+    def test_unknown_doctype_maps_to_unknown(self, insurance_strategy):
+        response = {"document_type": "martian_document", "confidence": 0.5}
+        tags = insurance_strategy.parse_llm_response(response)
+        doctype_tags = [t for t in tags if t.namespace == "doctype"]
+        assert doctype_tags[0].value == "unknown"
+
+    def test_entity_with_alias(self, insurance_strategy):
+        response = {
+            "document_type": "policy",
+            "entity": "Continental Casualty Company",
+            "confidence": 0.9,
+        }
+        tags = insurance_strategy.parse_llm_response(response)
+        entity_tags = [t for t in tags if t.namespace == "entity"]
+        assert entity_tags[0].value == "cna"
+
+    def test_entity_without_alias(self, insurance_strategy):
+        response = {
+            "document_type": "policy",
+            "entity": "Some New Carrier",
+            "confidence": 0.8,
+        }
+        tags = insurance_strategy.parse_llm_response(response)
+        entity_tags = [t for t in tags if t.namespace == "entity"]
+        assert entity_tags[0].value == "some-new-carrier"
+
+    def test_topics_filtered(self, insurance_strategy):
+        response = {
+            "document_type": "policy",
+            "topics": ["gl", "unknown_topic", "cyber"],
+            "confidence": 0.85,
+        }
+        tags = insurance_strategy.parse_llm_response(response)
+        topic_tags = [t for t in tags if t.namespace == "topic"]
+        topic_values = {t.value for t in topic_tags}
+        assert "gl" in topic_values
+        assert "cyber" in topic_values
+        assert "unknown_topic" not in topic_values
+
+    def test_missing_optional_fields(self, insurance_strategy):
+        response = {"document_type": "quote", "confidence": 0.7}
+        tags = insurance_strategy.parse_llm_response(response)
+        assert len(tags) == 1
+        assert tags[0].namespace == "doctype"
+
+    def test_year_extraction(self, insurance_strategy):
+        response = {
+            "document_type": "policy",
+            "year_start": "2024",
+            "year_end": "2025",
+            "confidence": 0.9,
+        }
+        tags = insurance_strategy.parse_llm_response(response)
+        year_tags = [t for t in tags if t.namespace == "year"]
+        assert len(year_tags) == 1
+        assert year_tags[0].value == "2024-2025"
+
+    def test_confidence_applied(self, insurance_strategy):
+        response = {"document_type": "policy", "confidence": 0.75}
+        tags = insurance_strategy.parse_llm_response(response)
+        for tag in tags:
+            assert tag.confidence == 0.75
+
+    def test_default_confidence(self, insurance_strategy):
+        response = {"document_type": "policy"}
+        tags = insurance_strategy.parse_llm_response(response)
+        for tag in tags:
+            assert tag.confidence == 0.5
+
+
+# ============================================================
+# parse_email_subject Tests
+# ============================================================
+
+
+class TestParseEmailSubject:
+    def test_bind_pattern(self, insurance_strategy):
+        tags = insurance_strategy.parse_email_subject("RE: Bind confirmation")
+        tag_map = {t.tag_name: t for t in tags}
+        assert "stage:bind" in tag_map
+
+    def test_quote_pattern(self, insurance_strategy):
+        tags = insurance_strategy.parse_email_subject("Quote from CNA")
+        tag_map = {t.tag_name: t for t in tags}
+        assert "stage:quote" in tag_map
+
+    def test_no_match(self, insurance_strategy):
+        tags = insurance_strategy.parse_email_subject("General update")
+        assert tags == []
+
+    def test_multiple_matches(self, insurance_strategy):
+        tags = insurance_strategy.parse_email_subject("RE: Loss run and endorsement changes")
+        tag_names = {t.tag_name for t in tags}
+        assert "doctype:loss-run" in tag_names
+        assert "doctype:endorsement" in tag_names
+
+    def test_deduplication(self, insurance_strategy):
+        tags = insurance_strategy.parse_email_subject("bind bound confirmation")
+        bind_tags = [t for t in tags if t.tag_name == "stage:bind"]
+        assert len(bind_tags) == 1
+
+    def test_email_tags_have_source(self, insurance_strategy):
+        tags = insurance_strategy.parse_email_subject("RE: Bind confirmation")
+        for tag in tags:
+            assert tag.source == "email"
+            assert tag.confidence == 1.0
+
+
+# ============================================================
+# Helpers
+# ============================================================
+
+
+def _minimal_strategy(strategy_id: str) -> dict:
+    """Create a minimal valid strategy dict for testing."""
+    return {
+        "strategy": {
+            "id": strategy_id,
+            "name": "Test Strategy",
+            "version": "1.0",
+        },
+        "namespaces": {
+            "doctype": {"display": "Document Type"},
+        },
+        "document_types": {
+            "unknown": {"display": "Unknown"},
+        },
+        "llm_prompt": "Classify: {document_type_ids}",
+    }


### PR DESCRIPTION
## Summary

Implements Auto-Tagging Phase 1 from the AUTO_TAGGING_v1 spec, covering three issues:

- **#263** — Strategy engine: YAML loader, PathRule processing, transforms, entity resolution, LLM prompt rendering
- **#264** — Config settings (15 auto-tagging settings) + Document model extensions (5 new columns)
- **#265** — Upload API integration: `source_path`/`auto_tag` params, path-based tag application, `ensure_tag_exists()`, guardrails

### Key changes
- New `ai_ready_rag/services/auto_tagging/` package (models, transforms, strategy)
- Built-in strategy YAML files (`generic.yaml`, `insurance_agency.yaml`)
- Upload endpoint accepts `source_path` and `auto_tag` params for automatic tag assignment
- Tag validation relaxed when auto-tagging is active (tag_ids may be empty)
- Guardrails: max tags per doc, tag name length, namespace cardinality
- 85 new tests across 3 test files

## Test plan

- [x] `ruff check` and `ruff format --check` pass
- [x] 85 new tests pass (68 strategy + 7 config + 10 upload)
- [x] Full suite: 984 passed, 0 regressions (6 pre-existing failures)
- [x] PROVE verification passed for all 3 issues
- [ ] Manual test: upload with `source_path` creates auto-tags
- [ ] Manual test: upload without tags fails when auto-tagging disabled

Closes #263, closes #264, closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)