### PR TITLE
feat(auto-tagging): Phase 2 - health status, access control, frontend toggle

### DIFF
--- a/ai_ready_rag/api/chat.py
+++ b/ai_ready_rag/api/chat.py
@@ -543,6 +543,9 @@ async def send_message(
         # Admin bypasses tag filtering - get all tags
         all_tags = db.query(Tag).all()
         user_tags = [tag.name for tag in all_tags]
+    elif not getattr(current_user, "tag_access_enabled", True):
+        # tag_access_enabled=False: bypass tag filtering entirely
+        user_tags = None
     else:
         user_tags = [tag.name for tag in current_user.tags]
 

--- a/ai_ready_rag/api/documents.py
+++ b/ai_ready_rag/api/documents.py
@@ -325,11 +325,13 @@ async def list_documents(
 
     is_admin = current_user.role == "admin"
     user_tags = [tag.name for tag in current_user.tags]
+    tag_access_enabled = getattr(current_user, "tag_access_enabled", True)
 
     documents, total = service.list_documents(
         user_id=current_user.id,
         user_tags=user_tags,
         is_admin=is_admin,
+        tag_access_enabled=tag_access_enabled,
         limit=limit,
         offset=offset,
         status_filter=status,
@@ -362,12 +364,14 @@ async def get_document(
 
     is_admin = current_user.role == "admin"
     user_tags = [tag.name for tag in current_user.tags]
+    tag_access_enabled = getattr(current_user, "tag_access_enabled", True)
 
     document = service.get_document(
         document_id=document_id,
         user_id=current_user.id,
         user_tags=user_tags,
         is_admin=is_admin,
+        tag_access_enabled=tag_access_enabled,
     )
 
     if not document:

--- a/ai_ready_rag/db/database.py
+++ b/ai_ready_rag/db/database.py
@@ -140,6 +140,12 @@ _TRACKED_MIGRATIONS = [
             "ALTER TABLE documents ADD COLUMN auto_tag_source TEXT",
         ],
     ),
+    (
+        "access_control_v1_columns",
+        [
+            "ALTER TABLE users ADD COLUMN tag_access_enabled BOOLEAN DEFAULT 1 NOT NULL",
+        ],
+    ),
 ]
 
 

--- a/ai_ready_rag/db/models/user.py
+++ b/ai_ready_rag/db/models/user.py
@@ -19,6 +19,7 @@ class User(TimestampMixin, Base):
     must_reset_password = Column(Boolean, default=False)
     failed_login_attempts = Column(Integer, default=0)
     locked_until = Column(DateTime, nullable=True)
+    tag_access_enabled = Column(Boolean, default=True, nullable=False)
     created_by = Column(String, nullable=True)  # Removed FK to avoid circular ref
     last_login = Column(DateTime, nullable=True)
     login_count = Column(Integer, default=0)

--- a/ai_ready_rag/schemas/user.py
+++ b/ai_ready_rag/schemas/user.py
@@ -15,6 +15,7 @@ class UserUpdate(BaseModel):
     display_name: str | None = None
     role: str | None = None
     is_active: bool | None = None
+    tag_access_enabled: bool | None = None
 
 
 class UserResponse(BaseModel):
@@ -24,6 +25,7 @@ class UserResponse(BaseModel):
     role: str
     is_active: bool
     must_reset_password: bool
+    tag_access_enabled: bool = True
     tags: list[dict] = []
 
     class Config:
@@ -32,3 +34,9 @@ class UserResponse(BaseModel):
 
 class TagAssignment(BaseModel):
     tag_ids: list[str]
+
+
+class BulkAutoTagAssignment(BaseModel):
+    client_names: list[str]
+    include_doctypes: bool = True
+    include_entities: bool = False

--- a/ai_ready_rag/services/document_service.py
+++ b/ai_ready_rag/services/document_service.py
@@ -377,6 +377,7 @@ class DocumentService:
         user_id: str,
         user_tags: list[str],
         is_admin: bool,
+        tag_access_enabled: bool = True,
     ) -> Document | None:
         """Get document if user has access.
 
@@ -399,9 +400,10 @@ class DocumentService:
             return document
 
         # Users can only see documents with matching tags
-        doc_tag_names = {tag.name for tag in document.tags}
-        if not doc_tag_names.intersection(set(user_tags)):
-            return None
+        if tag_access_enabled:
+            doc_tag_names = {tag.name for tag in document.tags}
+            if not doc_tag_names.intersection(set(user_tags)):
+                return None
 
         return document
 
@@ -410,6 +412,7 @@ class DocumentService:
         user_id: str,
         user_tags: list[str],
         is_admin: bool,
+        tag_access_enabled: bool = True,
         limit: int = 20,
         offset: int = 0,
         status_filter: str | None = None,
@@ -440,7 +443,7 @@ class DocumentService:
         query = self.db.query(Document)
 
         # Access control for non-admins
-        if not is_admin:
+        if not is_admin and tag_access_enabled:
             query = query.join(Document.tags).filter(Tag.name.in_(user_tags)).distinct()
 
         # Filter by status

--- a/ai_ready_rag/services/vector_service.py
+++ b/ai_ready_rag/services/vector_service.py
@@ -545,7 +545,7 @@ class VectorService:
         Args:
             query: Natural language query.
             user_tags: Tags the user has access to. None = no tag filtering
-                (system admin bypass), empty list = public only.
+                (admin bypass or tag_access_enabled=False), empty list = public only.
             limit: Maximum results to return (1-100, default: 5).
             score_threshold: Minimum similarity score (0.0-1.0, default: 0.0).
             tenant_id: Tenant to search within (defaults to service's tenant_id).
@@ -558,7 +558,7 @@ class VectorService:
 
         Note:
             Access control filter is applied BEFORE vector search (pre-retrieval).
-            - user_tags=None: No tag filtering (system admin cache warming)
+            - user_tags=None: No tag filtering (admin or tag_access_enabled=False users)
             - user_tags=[]: Only documents with "public" tag
             - user_tags=["hr"]: Public + hr documents
         """

--- a/frontend/src/components/features/admin/UserForm.tsx
+++ b/frontend/src/components/features/admin/UserForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Modal, Button, Input, Select } from '../../ui';
+import { Modal, Button, Input, Select, Checkbox } from '../../ui';
 import type { UserWithTags, UserCreate, UserUpdate, UserRole } from '../../../types';
 
 interface UserFormProps {
@@ -22,6 +22,7 @@ export function UserForm({ isOpen, onClose, onSave, user, isLoading = false }: U
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [role, setRole] = useState<UserRole>('user');
+  const [tagAccessEnabled, setTagAccessEnabled] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const isEditing = Boolean(user);
@@ -33,6 +34,7 @@ export function UserForm({ isOpen, onClose, onSave, user, isLoading = false }: U
         setEmail(user.email);
         setDisplayName(user.display_name);
         setRole(user.role);
+        setTagAccessEnabled(user.tag_access_enabled ?? true);
         setPassword('');
         setConfirmPassword('');
       } else {
@@ -41,6 +43,7 @@ export function UserForm({ isOpen, onClose, onSave, user, isLoading = false }: U
         setPassword('');
         setConfirmPassword('');
         setRole('user');
+        setTagAccessEnabled(true);
       }
       setError(null);
     }
@@ -88,6 +91,7 @@ export function UserForm({ isOpen, onClose, onSave, user, isLoading = false }: U
           email: email.trim(),
           display_name: displayName.trim(),
           role,
+          tag_access_enabled: tagAccessEnabled,
         } as UserUpdate);
       } else {
         await onSave({
@@ -138,6 +142,19 @@ export function UserForm({ isOpen, onClose, onSave, user, isLoading = false }: U
           onChange={(e) => setRole(e.target.value as UserRole)}
           options={ROLE_OPTIONS}
         />
+
+        {isEditing && (
+          <div>
+            <Checkbox
+              label="Enable tag-based access"
+              checked={tagAccessEnabled}
+              onChange={(e) => setTagAccessEnabled((e.target as HTMLInputElement).checked)}
+            />
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 ml-7">
+              When disabled, user can access all documents regardless of tag assignments.
+            </p>
+          </div>
+        )}
 
         {!isEditing && (
           <>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -6,6 +6,7 @@ export interface User {
   display_name: string;
   role: UserRole;
   is_active: boolean;
+  tag_access_enabled: boolean;
 }
 
 export interface NavItem {
@@ -159,6 +160,7 @@ export interface UserUpdate {
   display_name?: string;
   role?: UserRole;
   is_active?: boolean;
+  tag_access_enabled?: boolean;
 }
 
 // Admin types

--- a/frontend/src/views/UsersView.tsx
+++ b/frontend/src/views/UsersView.tsx
@@ -281,7 +281,9 @@ export function UsersView() {
                     </td>
                     <td className="py-3 px-4">
                       <div className="flex flex-wrap gap-1">
-                        {user.tags.length === 0 ? (
+                        {!user.tag_access_enabled ? (
+                          <Badge variant="warning">All Access</Badge>
+                        ) : user.tags.length === 0 ? (
                           <span className="text-gray-400 text-sm">No tags</span>
                         ) : user.role === 'admin' || user.role === 'customer_admin' ? (
                           <Badge variant="primary">All</Badge>
@@ -290,7 +292,8 @@ export function UsersView() {
                             <Badge key={tag.id}>{tag.display_name}</Badge>
                           ))
                         )}
-                        {user.tags.length > 3 &&
+                        {user.tag_access_enabled &&
+                          user.tags.length > 3 &&
                           user.role !== 'admin' &&
                           user.role !== 'customer_admin' && (
                             <Badge>+{user.tags.length - 3}</Badge>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,6 +197,41 @@ def system_admin_headers(system_admin_token) -> dict:
 
 
 @pytest.fixture(scope="function")
+def unrestricted_user(db) -> User:
+    """Create a user with tag_access_enabled=False (sees all documents)."""
+    user = User(
+        email="unrestricted@test.com",
+        display_name="Unrestricted User",
+        password_hash=hash_password("UnrestrictedPassword123"),
+        role="user",
+        is_active=True,
+        tag_access_enabled=False,
+    )
+    db.add(user)
+    db.flush()
+    db.refresh(user)
+    return user
+
+
+@pytest.fixture(scope="function")
+def unrestricted_token(unrestricted_user) -> str:
+    """Get JWT token for unrestricted user."""
+    return create_access_token(
+        data={
+            "sub": unrestricted_user.id,
+            "email": unrestricted_user.email,
+            "role": unrestricted_user.role,
+        }
+    )
+
+
+@pytest.fixture(scope="function")
+def unrestricted_headers(unrestricted_token) -> dict:
+    """Authorization headers for unrestricted user."""
+    return {"Authorization": f"Bearer {unrestricted_token}"}
+
+
+@pytest.fixture(scope="function")
 def sample_tag(db, admin_user) -> Tag:
     """Create a sample tag."""
     tag = Tag(

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,5 +1,7 @@
 """Tests for health check endpoints."""
 
+from unittest.mock import patch
+
 
 class TestHealth:
     """Health endpoint tests."""
@@ -32,3 +34,161 @@ class TestHealth:
             data = response.json()
             assert "message" in data
             assert "version" in data
+
+
+class TestHealthAutoTagging:
+    """Auto-tagging section in health endpoint."""
+
+    def test_health_includes_auto_tagging_key(self, client):
+        """Health response always contains auto_tagging key."""
+        response = client.get("/api/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert "auto_tagging" in data
+
+    def test_auto_tagging_disabled(self, client):
+        """When auto_tagging_enabled=False, returns minimal block."""
+        with patch("ai_ready_rag.api.health.settings") as mock_settings:
+            # Copy real settings attributes needed by health_check
+            from ai_ready_rag.config import get_settings
+
+            real = get_settings()
+            for attr in dir(real):
+                if not attr.startswith("_"):
+                    try:
+                        setattr(mock_settings, attr, getattr(real, attr))
+                    except (AttributeError, TypeError):
+                        pass
+            mock_settings.auto_tagging_enabled = False
+
+            response = client.get("/api/health")
+            assert response.status_code == 200
+            data = response.json()
+            at = data["auto_tagging"]
+            assert at == {"enabled": False}
+
+    def test_auto_tagging_enabled_no_strategy_file(self, client):
+        """When enabled but strategy file missing, returns error or fallback status."""
+        with patch("ai_ready_rag.api.health.settings") as mock_settings:
+            from ai_ready_rag.config import get_settings
+
+            real = get_settings()
+            for attr in dir(real):
+                if not attr.startswith("_"):
+                    try:
+                        setattr(mock_settings, attr, getattr(real, attr))
+                    except (AttributeError, TypeError):
+                        pass
+            mock_settings.auto_tagging_enabled = True
+            mock_settings.auto_tagging_strategy = "nonexistent_strategy"
+            mock_settings.auto_tagging_strategies_dir = "/tmp/no_such_dir"
+
+            response = client.get("/api/health")
+            assert response.status_code == 200
+            data = response.json()
+            at = data["auto_tagging"]
+            assert at["enabled"] is True
+            assert at["strategy_status"] in ("fallback_generic", "error")
+
+    def test_auto_tagging_enabled_has_expected_keys(self, client):
+        """When enabled, all spec-required keys are present."""
+        with patch("ai_ready_rag.api.health.settings") as mock_settings:
+            from ai_ready_rag.config import get_settings
+
+            real = get_settings()
+            for attr in dir(real):
+                if not attr.startswith("_"):
+                    try:
+                        setattr(mock_settings, attr, getattr(real, attr))
+                    except (AttributeError, TypeError):
+                        pass
+            mock_settings.auto_tagging_enabled = True
+            mock_settings.auto_tagging_strategy = "test_missing"
+            mock_settings.auto_tagging_strategies_dir = "/tmp/no_such_dir"
+
+            response = client.get("/api/health")
+            assert response.status_code == 200
+            at = response.json()["auto_tagging"]
+
+            expected_keys = {
+                "enabled",
+                "strategy",
+                "strategy_name",
+                "strategy_version",
+                "strategy_status",
+                "path_enabled",
+                "llm_enabled",
+                "llm_model",
+                "require_approval",
+                "namespaces",
+                "document_types",
+                "path_rules",
+                "guardrails",
+            }
+            assert expected_keys.issubset(at.keys()), f"Missing keys: {expected_keys - at.keys()}"
+
+            # Validate guardrails sub-keys
+            guardrails = at["guardrails"]
+            assert "max_tags_per_doc" in guardrails
+            assert "max_client_tags" in guardrails
+            assert "current_client_tags" in guardrails
+            assert isinstance(guardrails["current_client_tags"], int)
+
+    def test_auto_tagging_error_status_defaults(self, client):
+        """When strategy_status is error, strategy fields have safe defaults."""
+        with patch("ai_ready_rag.api.health.settings") as mock_settings:
+            from ai_ready_rag.config import get_settings
+
+            real = get_settings()
+            for attr in dir(real):
+                if not attr.startswith("_"):
+                    try:
+                        setattr(mock_settings, attr, getattr(real, attr))
+                    except (AttributeError, TypeError):
+                        pass
+            mock_settings.auto_tagging_enabled = True
+            mock_settings.auto_tagging_strategy = "nonexistent"
+            mock_settings.auto_tagging_strategies_dir = "/tmp/no_such_dir"
+
+            response = client.get("/api/health")
+            at = response.json()["auto_tagging"]
+
+            if at["strategy_status"] == "error":
+                assert at["strategy_name"] is None
+                assert at["strategy_version"] is None
+                assert at["namespaces"] == []
+                assert at["document_types"] == 0
+                assert at["path_rules"] == 0
+
+    def test_auto_tagging_client_tags_counted(self, client, db):
+        """current_client_tags reflects actual DB count of client: tags."""
+        from ai_ready_rag.db.models import Tag
+
+        # Create some client namespace tags
+        for i in range(3):
+            tag = Tag(
+                name=f"client:test-client-{i}",
+                display_name=f"Test Client {i}",
+                description="Test",
+                color="#000000",
+            )
+            db.add(tag)
+        db.flush()
+
+        with patch("ai_ready_rag.api.health.settings") as mock_settings:
+            from ai_ready_rag.config import get_settings
+
+            real = get_settings()
+            for attr in dir(real):
+                if not attr.startswith("_"):
+                    try:
+                        setattr(mock_settings, attr, getattr(real, attr))
+                    except (AttributeError, TypeError):
+                        pass
+            mock_settings.auto_tagging_enabled = True
+            mock_settings.auto_tagging_strategy = "nonexistent"
+            mock_settings.auto_tagging_strategies_dir = "/tmp/no_such_dir"
+
+            response = client.get("/api/health")
+            at = response.json()["auto_tagging"]
+            assert at["guardrails"]["current_client_tags"] == 3


### PR DESCRIPTION
## Summary

- **#267**: Add auto-tagging status block to `/api/health` endpoint with strategy metadata, config flags, and live guardrail counts (current_client_tags)
- **#268**: Implement `tag_access_enabled` column on User model with 3-point access control enforcement: admin bypass → unrestricted bypass → tag filtering. Enforced in document list, document get, and chat/vector endpoints. Add bulk auto-tag assignment endpoint (`POST /api/users/{id}/tags/auto`)
- **#269**: Frontend checkbox toggle in UserForm (edit mode) and "All Access" warning badge in UsersView table

## Changes

| Area | Files | Lines |
|------|-------|-------|
| Backend API | chat.py, documents.py, health.py, users.py | +137 |
| Database | database.py, user.py | +7 |
| Schemas | user.py | +8 |
| Services | document_service.py, vector_service.py | +15 |
| Frontend | UserForm.tsx, types/index.ts, UsersView.tsx | +28 |
| Tests | conftest.py, test_documents.py, test_health.py, test_users.py | +485 |

## Access Control Invariant

Verified at all 3 enforcement points:
1. `chat.py` — admin check → tag_access_enabled check → tag filter
2. `document_service.get_document()` — same order
3. `document_service.list_documents()` — same order

## Test plan

- [x] 6 new health endpoint tests (auto-tagging status block)
- [x] 17 new access control tests (5 toggle + 6 bulk endpoint + 6 integration)
- [x] Frontend TypeScript compiles cleanly (`tsc -b`)
- [x] Production build passes (`vite build`)
- [x] Backend lint clean (`ruff check`)
- [x] 1007 tests passing (6 pre-existing failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)