### PR TITLE
feat(auto-tagging): Phase 3 - LLM classifier, pipeline integration, conflict resolution, strategies

### DIFF
--- a/ai_ready_rag/services/auto_tagging/__init__.py
+++ b/ai_ready_rag/services/auto_tagging/__init__.py
@@ -1,5 +1,11 @@
 """Auto-tagging strategy engine for hybrid path-based and LLM-based tagging."""
 
+from ai_ready_rag.services.auto_tagging.classifier import ClassificationResult, DocumentClassifier
+from ai_ready_rag.services.auto_tagging.conflict import (
+    build_provenance,
+    enforce_guardrail,
+    resolve_conflicts,
+)
 from ai_ready_rag.services.auto_tagging.models import (
     AutoTag,
     DocumentTypeConfig,
@@ -26,7 +32,13 @@ from ai_ready_rag.services.auto_tagging.transforms import (
 __all__ = [
     # Strategy
     "AutoTagStrategy",
+    "ClassificationResult",
+    "DocumentClassifier",
     "PathRule",
+    # Conflict resolution
+    "build_provenance",
+    "enforce_guardrail",
+    "resolve_conflicts",
     # Models
     "AutoTag",
     "DocumentTypeConfig",

--- a/ai_ready_rag/services/auto_tagging/classifier.py
+++ b/ai_ready_rag/services/auto_tagging/classifier.py
@@ -1,0 +1,188 @@
+"""LLM-based document classification using strategy prompts.
+
+Orchestrates the LLM call, JSON parsing with repair logic, and the
+confidence decision table to produce ClassificationResult objects.
+"""
+
+import asyncio
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+
+import httpx
+
+from ai_ready_rag.config import Settings
+from ai_ready_rag.services.auto_tagging.models import AutoTag
+from ai_ready_rag.services.auto_tagging.strategy import AutoTagStrategy
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ClassificationResult:
+    """Result of LLM-based document classification."""
+
+    tags: list[AutoTag] = field(default_factory=list)
+    suggested: list[AutoTag] = field(default_factory=list)
+    discarded: list[AutoTag] = field(default_factory=list)
+    raw_response: str = ""
+    parsed_response: dict | None = None
+    status: str = "completed"
+    error: str | None = None
+
+
+class DocumentClassifier:
+    """LLM-based document classification using strategy prompts."""
+
+    def __init__(self, settings: Settings) -> None:
+        self.ollama_url = settings.ollama_base_url
+        self.model = settings.auto_tagging_llm_model
+        self.timeout = settings.auto_tagging_llm_timeout_seconds
+        self.max_retries = settings.auto_tagging_llm_max_retries
+        self.confidence_threshold = settings.auto_tagging_confidence_threshold
+        self.suggestion_threshold = settings.auto_tagging_suggestion_threshold
+        self.require_approval = settings.auto_tagging_require_approval
+
+    async def classify(
+        self,
+        strategy: AutoTagStrategy,
+        filename: str,
+        source_path: str,
+        content_preview: str,
+    ) -> ClassificationResult:
+        """Classify a document using LLM and strategy prompts.
+
+        Args:
+            strategy: The loaded auto-tag strategy.
+            filename: Original filename.
+            source_path: Upload source path.
+            content_preview: First 2000 chars of extracted text.
+
+        Returns:
+            ClassificationResult with applied, suggested, and discarded tags.
+        """
+        prompt = strategy.build_llm_prompt(filename, source_path, content_preview)
+
+        raw_text = await self._call_llm(prompt)
+        if raw_text is None:
+            return ClassificationResult(
+                status="partial",
+                error="LLM call failed after retries",
+            )
+
+        parsed = self._parse_json_response(raw_text)
+        if parsed is None:
+            return ClassificationResult(
+                raw_response=raw_text,
+                status="partial",
+                error="Failed to parse LLM response as JSON",
+            )
+
+        all_tags = strategy.parse_llm_response(parsed)
+        applied, suggested, discarded = self._apply_decision_table(all_tags)
+
+        logger.info(
+            "Classification complete: %d applied, %d suggested, %d discarded",
+            len(applied),
+            len(suggested),
+            len(discarded),
+        )
+
+        return ClassificationResult(
+            tags=applied,
+            suggested=suggested,
+            discarded=discarded,
+            raw_response=raw_text,
+            parsed_response=parsed,
+            status="completed",
+            error=None,
+        )
+
+    async def _call_llm(self, prompt: str) -> str | None:
+        """Call Ollama /api/generate with timeout and exponential backoff retry."""
+        for attempt in range(self.max_retries + 1):
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    response = await client.post(
+                        f"{self.ollama_url}/api/generate",
+                        json={"model": self.model, "prompt": prompt, "stream": False},
+                    )
+                    response.raise_for_status()
+                    return response.json().get("response", "").strip()
+            except (httpx.TimeoutException, httpx.ConnectError) as e:
+                if attempt < self.max_retries:
+                    backoff = 2**attempt
+                    logger.warning(
+                        "LLM call attempt %d failed: %s, retrying in %ds",
+                        attempt + 1,
+                        e,
+                        backoff,
+                    )
+                    await asyncio.sleep(backoff)
+                else:
+                    logger.error(
+                        "LLM call failed after %d attempts: %s",
+                        self.max_retries + 1,
+                        e,
+                    )
+                    return None
+            except httpx.HTTPStatusError as e:
+                logger.error("LLM HTTP error (no retry): %s", e)
+                return None
+        return None
+
+    def _parse_json_response(self, raw_text: str) -> dict | None:
+        """Parse JSON from LLM response with repair attempts.
+
+        Tries three strategies in order:
+        1. Strict JSON parse
+        2. Strip markdown code fences and parse
+        3. Extract first {...} block and parse
+        """
+        # 1. Strict parse
+        try:
+            return json.loads(raw_text)
+        except json.JSONDecodeError:
+            pass
+
+        # 2. Strip markdown fences
+        cleaned = re.sub(r"^```(?:json)?\s*", "", raw_text.strip(), flags=re.MULTILINE)
+        cleaned = re.sub(r"\s*```$", "", cleaned.strip(), flags=re.MULTILINE)
+        try:
+            return json.loads(cleaned)
+        except json.JSONDecodeError:
+            pass
+
+        # 3. Extract first {...} block
+        match = re.search(r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}", cleaned, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group())
+            except json.JSONDecodeError:
+                pass
+
+        logger.error("Failed to parse LLM response as JSON after all repair attempts")
+        return None
+
+    def _apply_decision_table(
+        self, tags: list[AutoTag]
+    ) -> tuple[list[AutoTag], list[AutoTag], list[AutoTag]]:
+        """Apply the 6-cell confidence decision table.
+
+        Returns:
+            Tuple of (applied, suggested, discarded) tag lists.
+        """
+        applied: list[AutoTag] = []
+        suggested: list[AutoTag] = []
+        discarded: list[AutoTag] = []
+
+        for tag in tags:
+            if tag.confidence < self.suggestion_threshold:
+                discarded.append(tag)
+            elif self.require_approval:
+                suggested.append(tag)
+            else:
+                applied.append(tag)
+
+        return applied, suggested, discarded

--- a/ai_ready_rag/services/auto_tagging/conflict.py
+++ b/ai_ready_rag/services/auto_tagging/conflict.py
@@ -1,0 +1,241 @@
+"""Conflict resolution, guardrail enforcement, and provenance for auto-tagging.
+
+Resolves namespace-specific conflicts between path-based and LLM-based tags,
+enforces max_tags_per_doc guardrails, and builds provenance JSON for the
+auto_tag_source column.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from ai_ready_rag.services.auto_tagging.classifier import ClassificationResult
+from ai_ready_rag.services.auto_tagging.models import AutoTag
+
+# Namespace authority table: which source wins on conflict
+PATH_AUTHORITATIVE = {"client", "year", "stage"}
+LLM_AUTHORITATIVE = {"doctype", "topic", "entity"}
+
+
+class ConflictRecord(TypedDict):
+    """Record of a single namespace conflict between path and LLM tags."""
+
+    namespace: str
+    path_value: str
+    llm_value: str
+    winner: str  # "path" | "llm"
+    reason: str
+
+
+class Provenance(TypedDict, total=False):
+    """Provenance JSON matching spec Section 8.5 schema."""
+
+    strategy_id: str
+    strategy_version: str
+    path_candidates: list[dict]
+    llm_candidates: list[dict]
+    conflicts: list[ConflictRecord]
+    applied: list[str]
+    discarded: list[str]
+    suggested: list[str]
+    truncated: list[str]
+
+
+def resolve_conflicts(
+    path_tags: list[AutoTag],
+    llm_result: ClassificationResult,
+    confidence_threshold: float,
+) -> tuple[list[AutoTag], list[AutoTag], list[ConflictRecord]]:
+    """Resolve namespace conflicts between path and LLM tags.
+
+    Args:
+        path_tags: Tags from path parsing (already applied at upload).
+        llm_result: ClassificationResult from DocumentClassifier.
+        confidence_threshold: Minimum confidence for LLM to win conflict.
+
+    Returns:
+        Tuple of (winning_llm_tags, losing_path_tags, conflict_records).
+        - winning_llm_tags: LLM tags that should be ADDED to document.tags
+          (includes non-conflicting and conflict-winners).
+        - losing_path_tags: Path tags that should be REMOVED from document.tags
+          (only when LLM won a conflict in their namespace).
+        - conflict_records: List of conflict records for provenance.
+    """
+    # Build dict of path tags by namespace
+    path_by_ns: dict[str, list[AutoTag]] = {}
+    for pt in path_tags:
+        path_by_ns.setdefault(pt.namespace, []).append(pt)
+
+    winning_llm: list[AutoTag] = []
+    losing_path: list[AutoTag] = []
+    conflicts: list[ConflictRecord] = []
+
+    for llm_tag in llm_result.tags:
+        ns = llm_tag.namespace
+        path_in_ns = path_by_ns.get(ns)
+
+        if not path_in_ns:
+            # No conflict: LLM tag passes through
+            winning_llm.append(llm_tag)
+            continue
+
+        # Conflict exists
+        if ns in PATH_AUTHORITATIVE:
+            # Path wins unconditionally
+            for pt in path_in_ns:
+                conflicts.append(
+                    ConflictRecord(
+                        namespace=ns,
+                        path_value=pt.value,
+                        llm_value=llm_tag.value,
+                        winner="path",
+                        reason=f"{ns}: path is authoritative",
+                    )
+                )
+        elif ns in LLM_AUTHORITATIVE:
+            if llm_tag.confidence >= confidence_threshold:
+                # LLM wins
+                winning_llm.append(llm_tag)
+                for pt in path_in_ns:
+                    if pt not in losing_path:
+                        losing_path.append(pt)
+                    conflicts.append(
+                        ConflictRecord(
+                            namespace=ns,
+                            path_value=pt.value,
+                            llm_value=llm_tag.value,
+                            winner="llm",
+                            reason=(
+                                f"{ns}: LLM confidence {llm_tag.confidence} "
+                                f">= threshold {confidence_threshold}"
+                            ),
+                        )
+                    )
+            else:
+                # LLM below threshold, path wins
+                for pt in path_in_ns:
+                    conflicts.append(
+                        ConflictRecord(
+                            namespace=ns,
+                            path_value=pt.value,
+                            llm_value=llm_tag.value,
+                            winner="path",
+                            reason=(
+                                f"{ns}: LLM confidence {llm_tag.confidence} "
+                                f"below threshold {confidence_threshold}, path wins"
+                            ),
+                        )
+                    )
+        else:
+            # Unknown namespace: default to path wins
+            for pt in path_in_ns:
+                conflicts.append(
+                    ConflictRecord(
+                        namespace=ns,
+                        path_value=pt.value,
+                        llm_value=llm_tag.value,
+                        winner="path",
+                        reason=f"{ns}: unknown namespace, path wins by default",
+                    )
+                )
+
+    return winning_llm, losing_path, conflicts
+
+
+def enforce_guardrail(
+    manual_tag_names: set[str],
+    path_tags: list[AutoTag],
+    llm_tags: list[AutoTag],
+    max_tags: int,
+) -> tuple[list[AutoTag], list[AutoTag], list[str]]:
+    """Enforce max_tags_per_doc guardrail.
+
+    Priority order: manual first, then path (by rule order), then LLM (by
+    confidence descending).
+
+    Args:
+        manual_tag_names: Set of manual tag names (always kept).
+        path_tags: Path-derived AutoTag objects (kept after manual).
+        llm_tags: LLM-derived AutoTag objects (kept last, sorted by confidence desc).
+        max_tags: Maximum total tags allowed.
+
+    Returns:
+        Tuple of (kept_path_tags, kept_llm_tags, truncated_tag_names).
+    """
+    manual_count = len(manual_tag_names)
+    budget = max_tags - manual_count
+
+    if budget <= 0:
+        # No room for any auto tags
+        truncated = [at.tag_name for at in path_tags] + [at.tag_name for at in llm_tags]
+        return [], [], truncated
+
+    # Keep path tags up to budget
+    kept_path: list[AutoTag] = []
+    truncated: list[str] = []
+
+    for pt in path_tags:
+        if len(kept_path) < budget:
+            kept_path.append(pt)
+        else:
+            truncated.append(pt.tag_name)
+
+    remaining_budget = budget - len(kept_path)
+
+    # Sort LLM tags by confidence descending, keep up to remaining budget
+    sorted_llm = sorted(llm_tags, key=lambda t: t.confidence, reverse=True)
+    kept_llm: list[AutoTag] = []
+
+    for lt in sorted_llm:
+        if len(kept_llm) < remaining_budget:
+            kept_llm.append(lt)
+        else:
+            truncated.append(lt.tag_name)
+
+    return kept_path, kept_llm, truncated
+
+
+def build_provenance(
+    strategy_id: str,
+    strategy_version: str,
+    path_tags: list[AutoTag],
+    llm_result: ClassificationResult | None,
+    conflicts: list[ConflictRecord],
+    applied_tag_names: list[str],
+    discarded_tag_names: list[str],
+    suggested_tag_names: list[str],
+    truncated_tag_names: list[str] | None = None,
+) -> dict:
+    """Build provenance JSON for auto_tag_source column.
+
+    Returns dict matching spec Section 8.5 schema.
+    """
+    path_candidates = [
+        {"namespace": t.namespace, "value": t.value, "confidence": t.confidence} for t in path_tags
+    ]
+
+    llm_candidates: list[dict] = []
+    if llm_result is not None:
+        all_llm_tags = (
+            list(llm_result.tags) + list(llm_result.suggested) + list(llm_result.discarded)
+        )
+        llm_candidates = [
+            {"namespace": t.namespace, "value": t.value, "confidence": t.confidence}
+            for t in all_llm_tags
+        ]
+
+    provenance: dict = {
+        "strategy_id": strategy_id,
+        "strategy_version": strategy_version,
+        "path_candidates": path_candidates,
+        "llm_candidates": llm_candidates,
+        "conflicts": list(conflicts),
+        "applied": applied_tag_names,
+        "discarded": discarded_tag_names,
+        "suggested": suggested_tag_names,
+    }
+
+    if truncated_tag_names:
+        provenance["truncated"] = truncated_tag_names
+
+    return provenance

--- a/data/auto_tag_strategies/construction.yaml
+++ b/data/auto_tag_strategies/construction.yaml
@@ -1,0 +1,139 @@
+strategy:
+  id: "construction"
+  name: "Construction"
+  description: "For construction companies managing project documentation"
+  version: "1.0"
+
+namespaces:
+  client:
+    display: "Project"
+    color: "#6366f1"
+  year:
+    display: "Year"
+    color: "#f59e0b"
+  doctype:
+    display: "Document Type"
+    color: "#10b981"
+  stage:
+    display: "Project Phase"
+    color: "#64748b"
+  entity:
+    display: "Subcontractor/Vendor"
+    color: "#0ea5e9"
+  topic:
+    display: "Trade/Discipline"
+    color: "#f43f5e"
+
+path_rules:
+  - namespace: "client"
+    level: 0
+    pattern: "^(.+?)(?:\\s*Phase.*)?$"
+    capture_group: 1
+    transform: "slugify"
+
+  - namespace: "stage"
+    level: 1
+    mapping:
+      "Bids": "bidding"
+      "Contracts": "contract"
+      "Submittals": "submittal"
+      "RFIs": "rfi"
+      "Change Orders": "change-order"
+      "Pay Applications": "pay-app"
+      "Inspections": "inspection"
+      "Punch List": "punch-list"
+      "Close-Out": "close-out"
+      "Safety": "safety"
+      "Photos": "photos"
+      "Drawings": "drawings"
+
+document_types:
+  bid:
+    display: "Bid/Proposal"
+    keywords: ["bid", "proposal", "estimate", "scope of work"]
+  contract:
+    display: "Contract"
+    keywords: ["contract", "agreement", "aia", "subcontract"]
+  change_order:
+    display: "Change Order"
+    keywords: ["change order", "co", "modification", "amendment"]
+  submittal:
+    display: "Submittal"
+    keywords: ["submittal", "shop drawing", "product data", "sample"]
+  rfi:
+    display: "RFI"
+    keywords: ["request for information", "rfi", "clarification"]
+  pay_app:
+    display: "Pay Application"
+    keywords: ["pay application", "aia g702", "g703", "schedule of values"]
+  inspection:
+    display: "Inspection Report"
+    keywords: ["inspection", "report", "punch list", "deficiency"]
+  drawing:
+    display: "Drawing/Plan"
+    keywords: ["drawing", "plan", "elevation", "detail", "blueprint"]
+  permit:
+    display: "Permit"
+    keywords: ["permit", "building permit", "variance", "approval"]
+  safety:
+    display: "Safety Document"
+    keywords: ["safety", "osha", "incident", "toolbox talk"]
+  correspondence:
+    display: "Correspondence"
+    keywords: ["letter", "email", "memo", "notice"]
+  unknown:
+    display: "Unknown"
+    keywords: []
+
+entity_extraction:
+  namespace: "entity"
+  prompt_label: "subcontractor or vendor"
+  prompt_instruction: "Identify the subcontractor, vendor, or supplier named in this document. Return null if not identifiable."
+  aliases: {}
+
+topic_extraction:
+  namespace: "topic"
+  prompt_label: "construction trades"
+  prompt_instruction: "List the construction trades or disciplines relevant to this document."
+  values:
+    - id: "electrical"
+      display: "Electrical"
+      keywords: ["electrical", "wiring", "conduit", "panel"]
+    - id: "plumbing"
+      display: "Plumbing"
+      keywords: ["plumbing", "piping", "fixture", "drain"]
+    - id: "hvac"
+      display: "HVAC"
+      keywords: ["hvac", "mechanical", "ductwork", "air handling"]
+    - id: "structural"
+      display: "Structural"
+      keywords: ["structural", "foundation", "framing", "steel"]
+    - id: "concrete"
+      display: "Concrete"
+      keywords: ["concrete", "formwork", "rebar", "pour"]
+    - id: "roofing"
+      display: "Roofing"
+      keywords: ["roofing", "membrane", "flashing", "gutter"]
+    - id: "sitework"
+      display: "Sitework"
+      keywords: ["grading", "excavation", "paving", "landscaping"]
+    - id: "fire-protection"
+      display: "Fire Protection"
+      keywords: ["fire", "sprinkler", "alarm", "suppression"]
+
+llm_prompt: |
+  Classify this construction project document. Return JSON only.
+
+  Document filename: {filename}
+  First 2000 characters of content:
+  {content_preview}
+
+  Return this exact JSON structure:
+  {{
+    "document_type": "<one of: {document_type_ids}>",
+    "entity": "<subcontractor or vendor name or null>",
+    "topics": [<list of: {topic_ids}>],
+    "year_start": "<YYYY or null>",
+    "year_end": "<YYYY or null>",
+    "confidence": <0.0 to 1.0>
+  }}

--- a/data/auto_tag_strategies/law_firm.yaml
+++ b/data/auto_tag_strategies/law_firm.yaml
@@ -1,0 +1,129 @@
+strategy:
+  id: "law_firm"
+  name: "Law Firm"
+  description: "For legal practices managing client matter folders"
+  version: "1.0"
+
+namespaces:
+  client:
+    display: "Client"
+    color: "#6366f1"
+  year:
+    display: "Year"
+    color: "#f59e0b"
+  doctype:
+    display: "Document Type"
+    color: "#10b981"
+  stage:
+    display: "Matter Stage"
+    color: "#64748b"
+  entity:
+    display: "Opposing Party"
+    color: "#0ea5e9"
+  topic:
+    display: "Practice Area"
+    color: "#f43f5e"
+
+path_rules:
+  - namespace: "client"
+    level: 0
+    pattern: "^(.+)$"
+    capture_group: 1
+    transform: "slugify"
+
+  - namespace: "stage"
+    level: 1
+    mapping:
+      "Pleadings": "pleadings"
+      "Discovery": "discovery"
+      "Depositions": "depositions"
+      "Motions": "motions"
+      "Correspondence": "correspondence"
+      "Billing": "billing"
+      "Research": "research"
+      "Trial": "trial"
+      "Appeals": "appeals"
+      "Settlement": "settlement"
+      "Close-Out": "close-out"
+
+document_types:
+  pleading:
+    display: "Pleading"
+    keywords: ["complaint", "answer", "motion", "brief", "memorandum"]
+  deposition:
+    display: "Deposition"
+    keywords: ["deposition", "transcript", "testimony"]
+  contract:
+    display: "Contract"
+    keywords: ["agreement", "contract", "settlement", "release"]
+  discovery:
+    display: "Discovery"
+    keywords: ["interrogatory", "request for production", "subpoena"]
+  correspondence:
+    display: "Correspondence"
+    keywords: ["letter", "dear", "re:", "counsel"]
+  court_order:
+    display: "Court Order"
+    keywords: ["order", "ruling", "judgment", "decree"]
+  billing:
+    display: "Billing"
+    keywords: ["invoice", "time entry", "retainer", "trust account"]
+  research:
+    display: "Research Memo"
+    keywords: ["research", "memorandum", "analysis", "case law"]
+  evidence:
+    display: "Evidence"
+    keywords: ["exhibit", "evidence", "photograph", "record"]
+  unknown:
+    display: "Unknown"
+    keywords: []
+
+entity_extraction:
+  namespace: "entity"
+  prompt_label: "opposing party"
+  prompt_instruction: "Identify the opposing party or adverse entity in this legal document. Return null if not identifiable."
+  aliases: {}
+
+topic_extraction:
+  namespace: "topic"
+  prompt_label: "practice areas"
+  prompt_instruction: "List the areas of law relevant to this document."
+  values:
+    - id: "litigation"
+      display: "Litigation"
+      keywords: ["litigation", "lawsuit", "court", "trial"]
+    - id: "corporate"
+      display: "Corporate"
+      keywords: ["corporate", "formation", "merger", "acquisition"]
+    - id: "real-estate"
+      display: "Real Estate"
+      keywords: ["property", "lease", "deed", "easement", "zoning"]
+    - id: "employment"
+      display: "Employment"
+      keywords: ["employment", "termination", "discrimination", "wage"]
+    - id: "ip"
+      display: "Intellectual Property"
+      keywords: ["patent", "trademark", "copyright", "trade secret"]
+    - id: "tax"
+      display: "Tax"
+      keywords: ["tax", "irs", "assessment", "deduction"]
+    - id: "estate"
+      display: "Estate Planning"
+      keywords: ["trust", "will", "estate", "probate", "beneficiary"]
+
+llm_prompt: |
+  Classify this legal document. Return JSON only.
+
+  Document filename: {filename}
+  First 2000 characters of content:
+  {content_preview}
+
+  Return this exact JSON structure:
+  {{
+    "document_type": "<one of: {document_type_ids}>",
+    "entity": "<opposing party name or null>",
+    "topics": [<list of: {topic_ids}>],
+    "year_start": "<YYYY or null>",
+    "year_end": "<YYYY or null>",
+    "confidence": <0.0 to 1.0>
+  }}

--- a/tests/test_auto_tagging_classifier.py
+++ b/tests/test_auto_tagging_classifier.py
@@ -1,0 +1,330 @@
+"""Tests for the DocumentClassifier LLM-based classification service."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from ai_ready_rag.services.auto_tagging.classifier import (
+    ClassificationResult,
+    DocumentClassifier,
+)
+from ai_ready_rag.services.auto_tagging.models import AutoTag
+
+
+@pytest.fixture
+def mock_settings():
+    """Settings mock with auto-tagging defaults."""
+    settings = MagicMock()
+    settings.ollama_base_url = "http://localhost:11434"
+    settings.auto_tagging_llm_model = "qwen3:8b"
+    settings.auto_tagging_llm_timeout_seconds = 30
+    settings.auto_tagging_llm_max_retries = 1
+    settings.auto_tagging_confidence_threshold = 0.7
+    settings.auto_tagging_suggestion_threshold = 0.4
+    settings.auto_tagging_require_approval = False
+    return settings
+
+
+@pytest.fixture
+def classifier(mock_settings):
+    """DocumentClassifier with mocked settings."""
+    return DocumentClassifier(mock_settings)
+
+
+@pytest.fixture
+def mock_strategy():
+    """Mocked AutoTagStrategy."""
+    strategy = MagicMock()
+    strategy.id = "test_strategy"
+    strategy.version = "1.0"
+    strategy.build_llm_prompt.return_value = "test prompt"
+    strategy.parse_llm_response.return_value = []
+    return strategy
+
+
+def _make_tag(confidence: float = 0.9) -> AutoTag:
+    """Helper to create an AutoTag with a given confidence."""
+    return AutoTag(
+        namespace="doctype",
+        value="policy",
+        source="llm",
+        confidence=confidence,
+        strategy_id="test",
+        strategy_version="1.0",
+    )
+
+
+def _mock_httpx_response(body: dict, status_code: int = 200) -> MagicMock:
+    """Create a mock httpx.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = body
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+class TestJsonParsing:
+    """Test _parse_json_response with various LLM output formats."""
+
+    def test_parse_valid_json(self, classifier):
+        raw = '{"document_type": "policy", "confidence": 0.9}'
+        result = classifier._parse_json_response(raw)
+        assert result == {"document_type": "policy", "confidence": 0.9}
+
+    def test_parse_markdown_fenced_json(self, classifier):
+        raw = '```json\n{"document_type": "policy"}\n```'
+        result = classifier._parse_json_response(raw)
+        assert result == {"document_type": "policy"}
+
+    def test_parse_embedded_json(self, classifier):
+        raw = 'Here is my analysis:\n{"document_type": "policy"}\nThat is all.'
+        result = classifier._parse_json_response(raw)
+        assert result == {"document_type": "policy"}
+
+    def test_parse_completely_invalid(self, classifier):
+        raw = "This is not JSON at all"
+        result = classifier._parse_json_response(raw)
+        assert result is None
+
+
+class TestConfidenceDecisionTable:
+    """Test all 6 cells of the confidence decision table."""
+
+    def test_high_confidence_no_approval(self, classifier):
+        tag = _make_tag(0.9)
+        applied, suggested, discarded = classifier._apply_decision_table([tag])
+        assert len(applied) == 1
+        assert len(suggested) == 0
+        assert len(discarded) == 0
+
+    def test_high_confidence_with_approval(self, mock_settings):
+        mock_settings.auto_tagging_require_approval = True
+        cls = DocumentClassifier(mock_settings)
+        tag = _make_tag(0.9)
+        applied, suggested, discarded = cls._apply_decision_table([tag])
+        assert len(applied) == 0
+        assert len(suggested) == 1
+        assert len(discarded) == 0
+
+    def test_mid_confidence_no_approval(self, classifier):
+        tag = _make_tag(0.5)
+        applied, suggested, discarded = classifier._apply_decision_table([tag])
+        assert len(applied) == 1
+        assert len(suggested) == 0
+        assert len(discarded) == 0
+
+    def test_mid_confidence_with_approval(self, mock_settings):
+        mock_settings.auto_tagging_require_approval = True
+        cls = DocumentClassifier(mock_settings)
+        tag = _make_tag(0.5)
+        applied, suggested, discarded = cls._apply_decision_table([tag])
+        assert len(applied) == 0
+        assert len(suggested) == 1
+        assert len(discarded) == 0
+
+    def test_low_confidence_no_approval(self, classifier):
+        tag = _make_tag(0.2)
+        applied, suggested, discarded = classifier._apply_decision_table([tag])
+        assert len(applied) == 0
+        assert len(suggested) == 0
+        assert len(discarded) == 1
+
+    def test_low_confidence_with_approval(self, mock_settings):
+        mock_settings.auto_tagging_require_approval = True
+        cls = DocumentClassifier(mock_settings)
+        tag = _make_tag(0.2)
+        applied, suggested, discarded = cls._apply_decision_table([tag])
+        assert len(applied) == 0
+        assert len(suggested) == 0
+        assert len(discarded) == 1
+
+
+class TestRetryBehavior:
+    """Test LLM call retry logic with mocked httpx."""
+
+    @pytest.mark.asyncio
+    async def test_success_first_attempt(self, classifier):
+        response = _mock_httpx_response({"response": "hello world"})
+        mock_client = AsyncMock()
+        mock_client.post.return_value = response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "ai_ready_rag.services.auto_tagging.classifier.httpx.AsyncClient",
+            return_value=mock_client,
+        ):
+            result = await classifier._call_llm("test prompt")
+
+        assert result == "hello world"
+        assert mock_client.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_success_on_retry(self, classifier):
+        response = _mock_httpx_response({"response": "retry success"})
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = [
+            httpx.TimeoutException("timeout"),
+            response,
+        ]
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "ai_ready_rag.services.auto_tagging.classifier.httpx.AsyncClient",
+                return_value=mock_client,
+            ),
+            patch(
+                "ai_ready_rag.services.auto_tagging.classifier.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await classifier._call_llm("test prompt")
+
+        assert result == "retry success"
+        assert mock_client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_failure_after_max_retries(self, classifier):
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = httpx.TimeoutException("timeout")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "ai_ready_rag.services.auto_tagging.classifier.httpx.AsyncClient",
+                return_value=mock_client,
+            ),
+            patch(
+                "ai_ready_rag.services.auto_tagging.classifier.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await classifier._call_llm("test prompt")
+
+        assert result is None
+        assert mock_client.post.call_count == 2  # initial + 1 retry
+
+
+class TestClassifyEndToEnd:
+    """Test the full classify() flow with mocked LLM."""
+
+    @pytest.mark.asyncio
+    async def test_classify_success(self, classifier, mock_strategy):
+        llm_json = json.dumps({"document_type": "policy", "confidence": 0.9})
+        response = _mock_httpx_response({"response": llm_json})
+        mock_client = AsyncMock()
+        mock_client.post.return_value = response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        high_tag = _make_tag(0.9)
+        mock_strategy.parse_llm_response.return_value = [high_tag]
+
+        with patch(
+            "ai_ready_rag.services.auto_tagging.classifier.httpx.AsyncClient",
+            return_value=mock_client,
+        ):
+            result = await classifier.classify(
+                mock_strategy, "test.pdf", "/uploads/test.pdf", "preview text"
+            )
+
+        assert result.status == "completed"
+        assert result.error is None
+        assert len(result.tags) == 1
+        assert len(result.suggested) == 0
+        assert len(result.discarded) == 0
+        assert result.parsed_response is not None
+
+    @pytest.mark.asyncio
+    async def test_classify_llm_failure(self, classifier, mock_strategy):
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = httpx.TimeoutException("timeout")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "ai_ready_rag.services.auto_tagging.classifier.httpx.AsyncClient",
+                return_value=mock_client,
+            ),
+            patch(
+                "ai_ready_rag.services.auto_tagging.classifier.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await classifier.classify(
+                mock_strategy, "test.pdf", "/uploads/test.pdf", "preview text"
+            )
+
+        assert result.status == "partial"
+        assert result.error == "LLM call failed after retries"
+        assert len(result.tags) == 0
+        assert len(result.suggested) == 0
+
+    @pytest.mark.asyncio
+    async def test_classify_invalid_json(self, classifier, mock_strategy):
+        response = _mock_httpx_response({"response": "This is not JSON at all"})
+        mock_client = AsyncMock()
+        mock_client.post.return_value = response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "ai_ready_rag.services.auto_tagging.classifier.httpx.AsyncClient",
+            return_value=mock_client,
+        ):
+            result = await classifier.classify(
+                mock_strategy, "test.pdf", "/uploads/test.pdf", "preview text"
+            )
+
+        assert result.status == "partial"
+        assert "JSON" in result.error
+        assert result.raw_response == "This is not JSON at all"
+        assert result.parsed_response is None
+
+    @pytest.mark.asyncio
+    async def test_classify_with_suggestions(self, mock_settings, mock_strategy):
+        mock_settings.auto_tagging_require_approval = True
+        cls = DocumentClassifier(mock_settings)
+
+        llm_json = json.dumps({"document_type": "policy", "confidence": 0.8})
+        response = _mock_httpx_response({"response": llm_json})
+        mock_client = AsyncMock()
+        mock_client.post.return_value = response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        tag = _make_tag(0.8)
+        mock_strategy.parse_llm_response.return_value = [tag]
+
+        with patch(
+            "ai_ready_rag.services.auto_tagging.classifier.httpx.AsyncClient",
+            return_value=mock_client,
+        ):
+            result = await cls.classify(
+                mock_strategy, "test.pdf", "/uploads/test.pdf", "preview text"
+            )
+
+        assert result.status == "completed"
+        assert len(result.tags) == 0
+        assert len(result.suggested) == 1
+        assert len(result.discarded) == 0
+
+
+class TestClassificationResult:
+    """Test ClassificationResult dataclass."""
+
+    def test_result_dataclass_fields(self):
+        result = ClassificationResult()
+        assert result.tags == []
+        assert result.suggested == []
+        assert result.discarded == []
+        assert result.raw_response == ""
+        assert result.parsed_response is None
+        assert result.status == "completed"
+        assert result.error is None

--- a/tests/test_auto_tagging_conflict.py
+++ b/tests/test_auto_tagging_conflict.py
@@ -1,0 +1,420 @@
+"""Tests for auto-tagging conflict resolution, guardrail enforcement, and provenance."""
+
+import pytest
+
+from ai_ready_rag.services.auto_tagging.classifier import ClassificationResult
+from ai_ready_rag.services.auto_tagging.conflict import (
+    build_provenance,
+    enforce_guardrail,
+    resolve_conflicts,
+)
+from ai_ready_rag.services.auto_tagging.models import AutoTag
+
+
+def _make_path_tag(namespace: str, value: str) -> AutoTag:
+    """Create a path-derived AutoTag."""
+    return AutoTag(namespace=namespace, value=value, source="path", confidence=1.0)
+
+
+def _make_llm_tag(namespace: str, value: str, confidence: float = 0.9) -> AutoTag:
+    """Create an LLM-derived AutoTag."""
+    return AutoTag(
+        namespace=namespace,
+        value=value,
+        source="llm",
+        confidence=confidence,
+        strategy_id="test",
+        strategy_version="1.0",
+    )
+
+
+@pytest.fixture
+def path_tags() -> list[AutoTag]:
+    """Sample path-derived tags."""
+    return [
+        _make_path_tag("client", "bethany-terrace"),
+        _make_path_tag("year", "2024-2025"),
+        _make_path_tag("entity", "cna"),
+    ]
+
+
+@pytest.fixture
+def llm_result_no_conflict() -> ClassificationResult:
+    """LLM result with tags that don't conflict with path tags."""
+    return ClassificationResult(
+        tags=[
+            _make_llm_tag("doctype", "policy", 0.92),
+            _make_llm_tag("topic", "cyber-liability", 0.85),
+        ],
+        suggested=[],
+        discarded=[],
+        status="completed",
+    )
+
+
+@pytest.fixture
+def llm_result_with_conflicts() -> ClassificationResult:
+    """LLM result with tags that conflict in multiple namespaces."""
+    return ClassificationResult(
+        tags=[
+            _make_llm_tag("client", "other-client", 0.8),
+            _make_llm_tag("entity", "hartford", 0.9),
+            _make_llm_tag("doctype", "quote", 0.75),
+            _make_llm_tag("topic", "umbrella", 0.6),
+        ],
+        suggested=[_make_llm_tag("topic", "property", 0.5)],
+        discarded=[_make_llm_tag("doctype", "invoice", 0.2)],
+        status="completed",
+    )
+
+
+class TestResolveConflicts:
+    """Tests for the resolve_conflicts function."""
+
+    def test_no_conflicts_all_llm_tags_pass_through(self, path_tags, llm_result_no_conflict):
+        """LLM tags in namespaces not covered by path tags are all added."""
+        winning, losing, conflicts = resolve_conflicts(path_tags, llm_result_no_conflict, 0.7)
+        assert len(winning) == 2
+        assert len(losing) == 0
+        assert len(conflicts) == 0
+        assert winning[0].namespace == "doctype"
+        assert winning[1].namespace == "topic"
+
+    def test_path_wins_client_namespace(self, path_tags):
+        """client: conflict: path tag kept, LLM tag discarded."""
+        llm = ClassificationResult(tags=[_make_llm_tag("client", "other-client", 0.95)])
+        winning, losing, conflicts = resolve_conflicts(path_tags, llm, 0.7)
+        assert len(winning) == 0
+        assert len(losing) == 0
+        assert len(conflicts) == 1
+        assert conflicts[0]["winner"] == "path"
+        assert conflicts[0]["namespace"] == "client"
+
+    def test_path_wins_year_namespace(self, path_tags):
+        """year: conflict: path tag kept, LLM tag discarded."""
+        llm = ClassificationResult(tags=[_make_llm_tag("year", "2023-2024", 0.99)])
+        winning, losing, conflicts = resolve_conflicts(path_tags, llm, 0.7)
+        assert len(winning) == 0
+        assert len(conflicts) == 1
+        assert conflicts[0]["winner"] == "path"
+        assert conflicts[0]["namespace"] == "year"
+
+    def test_path_wins_stage_namespace(self):
+        """stage: conflict: path tag kept, LLM tag discarded."""
+        ptags = [_make_path_tag("stage", "renewal")]
+        llm = ClassificationResult(tags=[_make_llm_tag("stage", "new-business", 0.95)])
+        winning, losing, conflicts = resolve_conflicts(ptags, llm, 0.7)
+        assert len(winning) == 0
+        assert len(conflicts) == 1
+        assert conflicts[0]["winner"] == "path"
+
+    def test_llm_wins_doctype_above_threshold(self):
+        """doctype: conflict with LLM confidence >= 0.7: LLM wins."""
+        ptags = [_make_path_tag("doctype", "unknown")]
+        llm = ClassificationResult(tags=[_make_llm_tag("doctype", "policy", 0.85)])
+        winning, losing, conflicts = resolve_conflicts(ptags, llm, 0.7)
+        assert len(winning) == 1
+        assert winning[0].value == "policy"
+        assert len(losing) == 1
+        assert losing[0].value == "unknown"
+        assert conflicts[0]["winner"] == "llm"
+
+    def test_path_wins_doctype_below_threshold(self):
+        """doctype: conflict with LLM confidence < 0.7: path wins."""
+        ptags = [_make_path_tag("doctype", "unknown")]
+        llm = ClassificationResult(tags=[_make_llm_tag("doctype", "policy", 0.5)])
+        winning, losing, conflicts = resolve_conflicts(ptags, llm, 0.7)
+        assert len(winning) == 0
+        assert len(losing) == 0
+        assert conflicts[0]["winner"] == "path"
+
+    def test_llm_wins_entity_above_threshold(self, path_tags):
+        """entity: conflict with high confidence: LLM wins."""
+        llm = ClassificationResult(tags=[_make_llm_tag("entity", "hartford", 0.9)])
+        winning, losing, conflicts = resolve_conflicts(path_tags, llm, 0.7)
+        assert len(winning) == 1
+        assert winning[0].value == "hartford"
+        assert len(losing) == 1
+        assert losing[0].value == "cna"
+        assert conflicts[0]["winner"] == "llm"
+
+    def test_path_wins_entity_below_threshold(self, path_tags):
+        """entity: conflict with low confidence: path wins."""
+        llm = ClassificationResult(tags=[_make_llm_tag("entity", "hartford", 0.5)])
+        winning, losing, conflicts = resolve_conflicts(path_tags, llm, 0.7)
+        assert len(winning) == 0
+        assert len(losing) == 0
+        assert conflicts[0]["winner"] == "path"
+
+    def test_llm_wins_topic_above_threshold(self):
+        """topic: conflict: LLM wins when above threshold."""
+        ptags = [_make_path_tag("topic", "general")]
+        llm = ClassificationResult(tags=[_make_llm_tag("topic", "cyber-liability", 0.88)])
+        winning, losing, conflicts = resolve_conflicts(ptags, llm, 0.7)
+        assert len(winning) == 1
+        assert winning[0].value == "cyber-liability"
+        assert len(losing) == 1
+        assert conflicts[0]["winner"] == "llm"
+
+    def test_conflict_records_populated(self, path_tags, llm_result_with_conflicts):
+        """Verify conflict records contain correct namespace, values, winner, reason."""
+        _, _, conflicts = resolve_conflicts(path_tags, llm_result_with_conflicts, 0.7)
+        assert len(conflicts) >= 2
+        namespaces = {c["namespace"] for c in conflicts}
+        assert "client" in namespaces
+        assert "entity" in namespaces
+        for c in conflicts:
+            assert "namespace" in c
+            assert "path_value" in c
+            assert "llm_value" in c
+            assert "winner" in c
+            assert "reason" in c
+
+    def test_unknown_namespace_defaults_to_path(self):
+        """Namespace not in authority table defaults to path winning."""
+        ptags = [_make_path_tag("custom_ns", "val1")]
+        llm = ClassificationResult(tags=[_make_llm_tag("custom_ns", "val2", 0.99)])
+        winning, losing, conflicts = resolve_conflicts(ptags, llm, 0.7)
+        assert len(winning) == 0
+        assert len(losing) == 0
+        assert conflicts[0]["winner"] == "path"
+        assert "unknown namespace" in conflicts[0]["reason"]
+
+    def test_empty_llm_result(self, path_tags):
+        """No LLM tags: returns empty winning list, no conflicts."""
+        llm = ClassificationResult(tags=[])
+        winning, losing, conflicts = resolve_conflicts(path_tags, llm, 0.7)
+        assert len(winning) == 0
+        assert len(losing) == 0
+        assert len(conflicts) == 0
+
+    def test_empty_path_tags(self, llm_result_no_conflict):
+        """No path tags: all LLM tags pass through, no conflicts."""
+        winning, losing, conflicts = resolve_conflicts([], llm_result_no_conflict, 0.7)
+        assert len(winning) == 2
+        assert len(losing) == 0
+        assert len(conflicts) == 0
+
+
+class TestEnforceGuardrail:
+    """Tests for the enforce_guardrail function."""
+
+    def test_under_limit_all_kept(self):
+        """Total tags below max: all kept, no truncation."""
+        path = [_make_path_tag("client", "acme")]
+        llm = [_make_llm_tag("doctype", "policy", 0.9)]
+        kept_p, kept_l, truncated = enforce_guardrail({"manual:tag"}, path, llm, 20)
+        assert len(kept_p) == 1
+        assert len(kept_l) == 1
+        assert len(truncated) == 0
+
+    def test_over_limit_llm_truncated_first(self):
+        """LLM tags truncated before path tags."""
+        manual = {"manual:one", "manual:two"}
+        path = [_make_path_tag("client", "acme")]
+        llm = [
+            _make_llm_tag("doctype", "policy", 0.9),
+            _make_llm_tag("topic", "cyber", 0.8),
+        ]
+        # max=4, manual=2, budget=2: path gets 1, llm gets 1 of 2
+        kept_p, kept_l, truncated = enforce_guardrail(manual, path, llm, 4)
+        assert len(kept_p) == 1
+        assert len(kept_l) == 1
+        assert len(truncated) == 1
+        # The lower confidence LLM tag should be truncated
+        assert kept_l[0].confidence == 0.9
+
+    def test_over_limit_path_truncated_after_llm(self):
+        """When budget exhausted by path tags, LLM tags are fully truncated."""
+        manual = {"m1"}
+        path = [
+            _make_path_tag("client", "acme"),
+            _make_path_tag("year", "2024"),
+            _make_path_tag("stage", "renewal"),
+        ]
+        llm = [_make_llm_tag("doctype", "policy", 0.9)]
+        # max=3, manual=1, budget=2: path gets 2, 1 path truncated, llm fully truncated
+        kept_p, kept_l, truncated = enforce_guardrail(manual, path, llm, 3)
+        assert len(kept_p) == 2
+        assert len(kept_l) == 0
+        assert len(truncated) == 2  # 1 path + 1 llm
+
+    def test_manual_tags_never_truncated(self):
+        """Manual tags always survive (counted but never removed)."""
+        manual = {"m1", "m2", "m3"}
+        path = [_make_path_tag("client", "acme")]
+        llm = [_make_llm_tag("doctype", "policy", 0.9)]
+        # max=3, manual=3, budget=0: all auto tags truncated
+        kept_p, kept_l, truncated = enforce_guardrail(manual, path, llm, 3)
+        assert len(kept_p) == 0
+        assert len(kept_l) == 0
+        assert len(truncated) == 2
+
+    def test_llm_sorted_by_confidence_desc(self):
+        """Higher confidence LLM tags kept over lower."""
+        llm = [
+            _make_llm_tag("topic", "low", 0.5),
+            _make_llm_tag("doctype", "high", 0.95),
+            _make_llm_tag("entity", "mid", 0.75),
+        ]
+        # max=2, no manual, no path: budget=2, keep top 2 LLM by confidence
+        kept_p, kept_l, truncated = enforce_guardrail(set(), [], llm, 2)
+        assert len(kept_l) == 2
+        assert kept_l[0].confidence == 0.95
+        assert kept_l[1].confidence == 0.75
+        assert len(truncated) == 1
+        assert "topic:low" in truncated
+
+    def test_exact_limit(self):
+        """Exactly at max: no truncation."""
+        manual = {"m1"}
+        path = [_make_path_tag("client", "acme")]
+        llm = [_make_llm_tag("doctype", "policy", 0.9)]
+        # max=3, manual=1, budget=2: fits exactly
+        kept_p, kept_l, truncated = enforce_guardrail(manual, path, llm, 3)
+        assert len(kept_p) == 1
+        assert len(kept_l) == 1
+        assert len(truncated) == 0
+
+    def test_truncated_names_returned(self):
+        """Truncated tag names appear in return value."""
+        llm = [
+            _make_llm_tag("doctype", "policy", 0.9),
+            _make_llm_tag("topic", "cyber", 0.3),
+        ]
+        kept_p, kept_l, truncated = enforce_guardrail(set(), [], llm, 1)
+        assert len(truncated) == 1
+        assert "topic:cyber" in truncated
+
+
+class TestBuildProvenance:
+    """Tests for the build_provenance function."""
+
+    def test_provenance_schema_matches_spec(self):
+        """Output dict has all required keys from Section 8.5."""
+        result = build_provenance(
+            strategy_id="generic",
+            strategy_version="1.0",
+            path_tags=[_make_path_tag("client", "acme")],
+            llm_result=ClassificationResult(tags=[_make_llm_tag("doctype", "policy", 0.9)]),
+            conflicts=[],
+            applied_tag_names=["client:acme", "doctype:policy"],
+            discarded_tag_names=[],
+            suggested_tag_names=[],
+        )
+        required_keys = {
+            "strategy_id",
+            "strategy_version",
+            "path_candidates",
+            "llm_candidates",
+            "conflicts",
+            "applied",
+            "discarded",
+            "suggested",
+        }
+        assert required_keys.issubset(set(result.keys()))
+
+    def test_path_candidates_populated(self):
+        """Path tags appear in path_candidates."""
+        ptags = [_make_path_tag("client", "acme"), _make_path_tag("year", "2024")]
+        result = build_provenance(
+            strategy_id="generic",
+            strategy_version="1.0",
+            path_tags=ptags,
+            llm_result=None,
+            conflicts=[],
+            applied_tag_names=[],
+            discarded_tag_names=[],
+            suggested_tag_names=[],
+        )
+        assert len(result["path_candidates"]) == 2
+        assert result["path_candidates"][0]["namespace"] == "client"
+        assert result["path_candidates"][0]["confidence"] == 1.0
+
+    def test_llm_candidates_include_all(self):
+        """Applied + suggested + discarded LLM tags all appear in llm_candidates."""
+        llm_result = ClassificationResult(
+            tags=[_make_llm_tag("doctype", "policy", 0.9)],
+            suggested=[_make_llm_tag("topic", "cyber", 0.55)],
+            discarded=[_make_llm_tag("entity", "old", 0.2)],
+        )
+        result = build_provenance(
+            strategy_id="generic",
+            strategy_version="1.0",
+            path_tags=[],
+            llm_result=llm_result,
+            conflicts=[],
+            applied_tag_names=[],
+            discarded_tag_names=[],
+            suggested_tag_names=[],
+        )
+        assert len(result["llm_candidates"]) == 3
+        namespaces = {c["namespace"] for c in result["llm_candidates"]}
+        assert namespaces == {"doctype", "topic", "entity"}
+
+    def test_conflicts_recorded(self):
+        """Conflict records appear in conflicts list."""
+        conflict = {
+            "namespace": "entity",
+            "path_value": "cna",
+            "llm_value": "hartford",
+            "winner": "llm",
+            "reason": "entity: LLM confidence 0.9 >= threshold 0.7",
+        }
+        result = build_provenance(
+            strategy_id="generic",
+            strategy_version="1.0",
+            path_tags=[],
+            llm_result=None,
+            conflicts=[conflict],
+            applied_tag_names=[],
+            discarded_tag_names=[],
+            suggested_tag_names=[],
+        )
+        assert len(result["conflicts"]) == 1
+        assert result["conflicts"][0]["winner"] == "llm"
+
+    def test_truncated_key_added_when_present(self):
+        """truncated key present only when tags were truncated."""
+        # Without truncated
+        result_no = build_provenance(
+            strategy_id="generic",
+            strategy_version="1.0",
+            path_tags=[],
+            llm_result=None,
+            conflicts=[],
+            applied_tag_names=[],
+            discarded_tag_names=[],
+            suggested_tag_names=[],
+        )
+        assert "truncated" not in result_no
+
+        # With truncated
+        result_yes = build_provenance(
+            strategy_id="generic",
+            strategy_version="1.0",
+            path_tags=[],
+            llm_result=None,
+            conflicts=[],
+            applied_tag_names=[],
+            discarded_tag_names=[],
+            suggested_tag_names=[],
+            truncated_tag_names=["topic:overflow"],
+        )
+        assert "truncated" in result_yes
+        assert result_yes["truncated"] == ["topic:overflow"]
+
+    def test_provenance_with_no_llm_result(self):
+        """When llm_result=None, llm_candidates is empty."""
+        result = build_provenance(
+            strategy_id="generic",
+            strategy_version="1.0",
+            path_tags=[_make_path_tag("client", "acme")],
+            llm_result=None,
+            conflicts=[],
+            applied_tag_names=["client:acme"],
+            discarded_tag_names=[],
+            suggested_tag_names=[],
+        )
+        assert result["llm_candidates"] == []
+        assert len(result["path_candidates"]) == 1


### PR DESCRIPTION
## Summary

- **#270**: LLM `DocumentClassifier` service — prompt rendering via strategy, Ollama `/api/generate` with timeout + retry + exponential backoff, JSON repair (strip markdown fences, extract first `{...}` block), 6-cell confidence decision table (threshold/suggestion × require_approval)
- **#271**: Pipeline integration — LLM classification step in `processing_service.py` (between summary and vector indexing), namespace-specific conflict resolution (path wins client/year/stage, LLM wins doctype/topic/entity), Section 8.5 provenance recording, guardrail enforcement with priority ordering (manual > path > LLM by confidence)
- **#272**: Built-in strategies — `law_firm.yaml` (6 namespaces, 10 doc types, 7 practice areas) and `construction.yaml` (6 namespaces, 12 doc types, Phase-stripping regex, 8 trades)

## Changes

| Area | Files | Lines |
|------|-------|-------|
| Classifier service | classifier.py | +188 |
| Conflict resolution | conflict.py | +241 |
| Pipeline integration | processing_service.py | +147 |
| Module exports | __init__.py | +12 |
| Strategy YAMLs | law_firm.yaml, construction.yaml | +268 |
| Tests | 3 test files | +857 |

## Conflict Resolution Authority Table

| Namespace | Authoritative Source |
|-----------|---------------------|
| client, year, stage | Path (always) |
| doctype, topic | LLM (if confidence >= threshold) |
| entity | LLM (if confidence >= threshold), else Path |

## Test plan

- [x] 18 classifier tests (JSON parsing, decision table, retry, end-to-end)
- [x] 26 conflict resolution tests (all namespace rules, guardrail, provenance)
- [x] 13 strategy tests (YAML loading, path parsing for both new strategies)
- [x] 9 manual tests passed (strategy loading, path parsing, JSON repair, decision table, conflict resolution, provenance, guardrails)
- [x] Backend lint clean (`ruff check`)
- [x] 1064 tests passing (6 pre-existing failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)