### PR TITLE
fix: Align auto_tagging_llm_model to chat_model, prevent VRAM eviction (#312)

### DIFF
--- a/ai_ready_rag/config.py
+++ b/ai_ready_rag/config.py
@@ -33,7 +33,7 @@ PROFILE_DEFAULTS: dict[str, dict[str, Any]] = {
         "vector_backend": "qdrant",
         "chunker_backend": "docling",
         "enable_ocr": True,
-        "chat_model": "qwen3:8b",
+        "chat_model": "qwen3-rag",
         "embedding_model": "nomic-embed-text",
         "rag_max_context_tokens": 6000,
         "rag_max_history_tokens": 1500,
@@ -271,7 +271,7 @@ class Settings(BaseSettings):
     auto_tagging_strategy: str = "generic"
     auto_tagging_path_enabled: bool = True
     auto_tagging_llm_enabled: bool = True
-    auto_tagging_llm_model: str = "qwen3:8b"
+    auto_tagging_llm_model: str | None = None  # None = use chat_model at runtime
     auto_tagging_require_approval: bool = False
     auto_tagging_create_missing_tags: bool = True
     auto_tagging_confidence_threshold: float = 0.7

--- a/ai_ready_rag/schemas/admin.py
+++ b/ai_ready_rag/schemas/admin.py
@@ -339,6 +339,7 @@ class LLMSettingsRequest(BaseModel):
     llm_temperature: float | None = None
     llm_max_response_tokens: int | None = None
     llm_confidence_threshold: int | None = None
+    auto_tagging_llm_model: str | None = None  # None = leave unchanged; "" = clear override
 
 
 class LLMSettingsResponse(BaseModel):
@@ -347,6 +348,8 @@ class LLMSettingsResponse(BaseModel):
     llm_temperature: float
     llm_max_response_tokens: int
     llm_confidence_threshold: int
+    auto_tagging_llm_model: str | None  # None = inheriting from chat_model
+    auto_tagging_llm_model_effective: str  # resolved model name (never null)
 
 
 class SettingsAuditEntry(BaseModel):

--- a/ai_ready_rag/services/auto_tagging/classifier.py
+++ b/ai_ready_rag/services/auto_tagging/classifier.py
@@ -37,7 +37,7 @@ class DocumentClassifier:
 
     def __init__(self, settings: Settings) -> None:
         self.ollama_url = settings.ollama_base_url
-        self.model = settings.auto_tagging_llm_model
+        self.model = settings.auto_tagging_llm_model or settings.chat_model
         self.timeout = settings.auto_tagging_llm_timeout_seconds
         self.max_retries = settings.auto_tagging_llm_max_retries
         self.confidence_threshold = settings.auto_tagging_confidence_threshold

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -346,6 +346,8 @@ export interface LLMSettings {
   llm_temperature: number;
   llm_max_response_tokens: number;
   llm_confidence_threshold: number;
+  auto_tagging_llm_model: string | null;       // null = inherit from chat_model
+  auto_tagging_llm_model_effective: string;    // resolved model name, always present
 }
 
 export interface SettingsAuditEntry {

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Save, AlertTriangle, RefreshCw } from 'lucide-react';
-import { Button, Alert, Card, Select, Checkbox, Slider } from '../components/ui';
+import { Button, Alert, Card, Input, Select, Checkbox, Slider } from '../components/ui';
 import {
   ConfirmModal,
   ReindexStatusCard,
@@ -188,7 +188,8 @@ export function SettingsView() {
       llmSettings &&
       (floatsDiffer(formLlmSettings.llm_temperature, llmSettings.llm_temperature) ||
         formLlmSettings.llm_max_response_tokens !== llmSettings.llm_max_response_tokens ||
-        formLlmSettings.llm_confidence_threshold !== llmSettings.llm_confidence_threshold);
+        formLlmSettings.llm_confidence_threshold !== llmSettings.llm_confidence_threshold ||
+        formLlmSettings.auto_tagging_llm_model !== llmSettings.auto_tagging_llm_model);
 
     const chunkingDirty =
       advancedSettings &&
@@ -355,7 +356,8 @@ export function SettingsView() {
         llmSettings &&
         (floatsDiffer(formLlmSettings.llm_temperature, llmSettings.llm_temperature) ||
           formLlmSettings.llm_max_response_tokens !== llmSettings.llm_max_response_tokens ||
-          formLlmSettings.llm_confidence_threshold !== llmSettings.llm_confidence_threshold)
+          formLlmSettings.llm_confidence_threshold !== llmSettings.llm_confidence_threshold ||
+          formLlmSettings.auto_tagging_llm_model !== llmSettings.auto_tagging_llm_model)
       ) {
         await updateLLMSettings(formLlmSettings);
       }
@@ -798,6 +800,21 @@ export function SettingsView() {
               })
             }
           />
+          {/* Auto-Tagging Model Override */}
+          <Input
+            label="Auto-Tagging Model Override"
+            placeholder={`Use chat model (${formLlmSettings.auto_tagging_llm_model_effective})`}
+            value={formLlmSettings.auto_tagging_llm_model ?? ''}
+            onChange={(e) =>
+              setFormLlmSettings({
+                ...formLlmSettings,
+                auto_tagging_llm_model: e.target.value || null,
+              })
+            }
+          />
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            Model used for auto-tagging classification. Leave blank to use the chat model.
+          </p>
         </div>
       </Card>
 

--- a/tests/test_admin_llm_settings.py
+++ b/tests/test_admin_llm_settings.py
@@ -1,0 +1,22 @@
+"""Tests for LLM settings endpoints including auto_tagging_llm_model fields."""
+
+
+class TestGetLLMSettings:
+    """Tests for GET /api/admin/settings/llm."""
+
+    def test_get_llm_settings_includes_auto_tagging_fields(self, client, admin_headers):
+        """GET returns auto_tagging_llm_model and auto_tagging_llm_model_effective fields."""
+        response = client.get("/api/admin/settings/llm", headers=admin_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "auto_tagging_llm_model" in data
+        assert data["auto_tagging_llm_model"] is None  # default: no override set
+        assert "auto_tagging_llm_model_effective" in data
+        assert isinstance(data["auto_tagging_llm_model_effective"], str)
+        assert len(data["auto_tagging_llm_model_effective"]) > 0  # always non-empty
+
+    def test_get_llm_settings_requires_admin(self, client, user_headers):
+        """Regular user gets 403."""
+        response = client.get("/api/admin/settings/llm", headers=user_headers)
+        assert response.status_code == 403

--- a/tests/test_auto_tagging_classifier.py
+++ b/tests/test_auto_tagging_classifier.py
@@ -18,7 +18,8 @@ def mock_settings():
     """Settings mock with auto-tagging defaults."""
     settings = MagicMock()
     settings.ollama_base_url = "http://localhost:11434"
-    settings.auto_tagging_llm_model = "qwen3:8b"
+    settings.auto_tagging_llm_model = None  # None = use chat_model (new default)
+    settings.chat_model = "qwen3:8b"  # Fallback model
     settings.auto_tagging_llm_timeout_seconds = 30
     settings.auto_tagging_llm_max_retries = 1
     settings.auto_tagging_confidence_threshold = 0.7
@@ -31,6 +32,22 @@ def mock_settings():
 def classifier(mock_settings):
     """DocumentClassifier with mocked settings."""
     return DocumentClassifier(mock_settings)
+
+
+def test_classifier_uses_chat_model_when_auto_tagging_model_is_none(mock_settings):
+    """classifier.model falls back to chat_model when auto_tagging_llm_model is None."""
+    mock_settings.auto_tagging_llm_model = None
+    mock_settings.chat_model = "qwen3-rag"
+    c = DocumentClassifier(mock_settings)
+    assert c.model == "qwen3-rag"
+
+
+def test_classifier_uses_override_when_auto_tagging_model_is_set(mock_settings):
+    """classifier.model uses auto_tagging_llm_model when explicitly set."""
+    mock_settings.auto_tagging_llm_model = "llama3.2"
+    mock_settings.chat_model = "qwen3-rag"
+    c = DocumentClassifier(mock_settings)
+    assert c.model == "llama3.2"
 
 
 @pytest.fixture

--- a/tests/test_auto_tagging_config.py
+++ b/tests/test_auto_tagging_config.py
@@ -18,7 +18,7 @@ class TestAutoTaggingConfig:
         assert settings.auto_tagging_strategy == "generic"
         assert settings.auto_tagging_path_enabled is True
         assert settings.auto_tagging_llm_enabled is True
-        assert settings.auto_tagging_llm_model == "qwen3:8b"
+        assert settings.auto_tagging_llm_model is None
         assert settings.auto_tagging_require_approval is False
         assert settings.auto_tagging_create_missing_tags is True
         assert settings.auto_tagging_confidence_threshold == 0.7

--- a/tests/test_profile_pipeline.py
+++ b/tests/test_profile_pipeline.py
@@ -55,7 +55,7 @@ class TestProfileSettings:
             assert settings.vector_backend == "qdrant"
             assert settings.chunker_backend == "docling"
             assert settings.enable_ocr is True
-            assert settings.chat_model == "qwen3:8b"
+            assert settings.chat_model == "qwen3-rag"
 
     def test_env_overrides_profile_default(self):
         """Individual env vars override profile defaults."""


### PR DESCRIPTION
## What
Aligns all RAG sub-service models to `chat_model` using the `None`-inherit pattern, preventing Ollama from loading competing model variants that evict `qwen3-rag` from VRAM.

## Why
`auto_tagging_llm_model` was hardcoded to `qwen3:8b`. Every document upload triggered an auto-tagging call to the base model, causing Ollama to evict `qwen3-rag` mid-request — resulting in consistent 180s timeouts on Q2 across all 3 evaluation cycles.

Closes #312

## How
- `config.py`: Changed `auto_tagging_llm_model: str = "qwen3:8b"` → `str | None = None`; updated Spark profile `chat_model` default from `qwen3:8b` → `qwen3-rag`
- `classifier.py`: Resolves `None` to `settings.chat_model` at runtime (mirrors existing `summary_model` pattern)
- `main.py`: Adds startup preload — calls Ollama `/api/generate` with `keep_alive: 24h` for `chat_model` on boot
- `schemas/admin.py` + `api/admin.py`: Exposes `auto_tagging_llm_model` and `auto_tagging_llm_model_effective` via LLM settings API
- `SettingsView.tsx`: Adds override input with effective model as placeholder

## Stack
- [x] Backend
- [x] Frontend

## Contract Changes
GET `/api/admin/settings/llm` now returns two new fields:
```json
{
  "auto_tagging_llm_model": null,
  "auto_tagging_llm_model_effective": "qwen3-rag"
}
```
PUT accepts `auto_tagging_llm_model: string | null` — empty string normalizes to `null` (clear override).

## Verification
- [x] `ruff check ai_ready_rag tests` passes
- [x] `pytest -q` — 1238 passed, 7 skipped (10 pre-existing failures on main, zero regressions)
- [x] Frontend types updated

## How to Test
1. Start backend on Spark; confirm logs show `Preloaded chat_model into VRAM: qwen3-rag`
2. Upload a document; confirm `ollama ps` shows only `qwen3-rag` loaded (not `qwen3:8b`)
3. Send a query — no 180s timeout
4. Admin → Settings → LLM: verify `Auto-Tagging Model Override` field shows `qwen3-rag` as placeholder
5. Set override to a different model name, save, verify effective model updates

## Risks / Rollback
Low risk — backend-only change to default values and a new optional settings field. Rollback: revert `auto_tagging_llm_model` default back to `"qwen3:8b"` in `config.py`.

---
Artifacts: `.agents/outputs/*-312-021926.md`