### PR TITLE
feat: Increase rag_max_chunks_per_doc from 3 to 5 (#313)

### DIFF
--- a/ai_ready_rag/config.py
+++ b/ai_ready_rag/config.py
@@ -147,7 +147,7 @@ class Settings(BaseSettings):
 
     # Retrieval Quality
     rag_min_similarity_score: float = 0.3
-    rag_max_chunks_per_doc: int = 3
+    rag_max_chunks_per_doc: int = 5
     rag_total_context_chunks: int = 8  # Increased from 5 per Spark config
     rag_dedup_candidates_cap: int = 15
     rag_chunk_overlap_threshold: float = 0.9

--- a/tests/test_cache_integration.py
+++ b/tests/test_cache_integration.py
@@ -41,7 +41,7 @@ def mock_settings():
     settings.rag_max_response_tokens = 1024
     settings.rag_system_prompt_tokens = 500
     settings.rag_min_similarity_score = 0.3
-    settings.rag_max_chunks_per_doc = 3
+    settings.rag_max_chunks_per_doc = 5
     settings.rag_total_context_chunks = 8
     settings.rag_dedup_candidates_cap = 15
     settings.rag_chunk_overlap_threshold = 0.9

--- a/tests/test_intent_detection.py
+++ b/tests/test_intent_detection.py
@@ -166,7 +166,7 @@ class TestApplyIntentBoost:
         settings.rag_recency_weight = 0.0
         settings.ollama_base_url = "http://localhost:11434"
         settings.chat_model = "test"
-        settings.rag_max_chunks_per_doc = 3
+        settings.rag_max_chunks_per_doc = 5
         settings.rag_chunk_overlap_threshold = 0.9
         settings.rag_dedup_candidates_cap = 15
         settings.rag_enable_hallucination_check = False

--- a/tests/test_rag_service.py
+++ b/tests/test_rag_service.py
@@ -54,7 +54,7 @@ def mock_settings():
     settings.rag_max_response_tokens = 1024
     settings.rag_system_prompt_tokens = 500
     settings.rag_min_similarity_score = 0.3
-    settings.rag_max_chunks_per_doc = 3
+    settings.rag_max_chunks_per_doc = 5
     settings.rag_total_context_chunks = 8
     settings.rag_dedup_candidates_cap = 15
     settings.rag_chunk_overlap_threshold = 0.9


### PR DESCRIPTION
## What
Increases `rag_max_chunks_per_doc` from 3 to 5, allowing the pipeline to surface more content from dense policy documents.

## Why
Q6 ("What are the exclusions in the Cervantes D&O policy?") only found 1-3 exclusions from a 171-chunk document because the per-doc cap of 3 was too low for deep policy questions. With 5 chunks per doc, the LLM gets broader coverage of scattered exclusion clauses.

Closes #313

## How
- `config.py:150`: `rag_max_chunks_per_doc: int = 3` → `5`
- 3 test fixtures updated to match new default

Total context chunks still capped at `rag_total_context_chunks=8`. Worst case: 8 × 400 tokens = 3,200 tokens against Spark budget of 6,000 — 52% headroom. `TokenBudget` enforcement provides hard safety net.

## Stack
- [x] Backend
- [ ] Frontend

## Contract Changes
N/A

## Verification
- [x] `ruff check` passes
- [x] `pytest -q` — 1238 passed, 0 regressions (10 pre-existing failures on main)

## Risks / Rollback
Low risk — config default increase only. Rollback: revert `rag_max_chunks_per_doc` back to `3` in `config.py`.

---
Artifacts: `.agents/outputs/*-313-021926.md`