### PR TITLE
feat: Add bulk delete all documents and tags (#302, #303)

### DIFF
--- a/ai_ready_rag/api/tags.py
+++ b/ai_ready_rag/api/tags.py
@@ -1,12 +1,23 @@
 """Tag management endpoints."""
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from ai_ready_rag.core.dependencies import get_current_user, require_admin
 from ai_ready_rag.db.database import get_db
 from ai_ready_rag.db.models import Tag, User
-from ai_ready_rag.schemas.tag import TagCreate, TagFacetsResponse, TagResponse, TagUpdate
+from ai_ready_rag.schemas.tag import (
+    DeleteAllTagsRequest,
+    DeleteAllTagsResponse,
+    TagCreate,
+    TagFacetsResponse,
+    TagResponse,
+    TagUpdate,
+)
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -103,3 +114,44 @@ async def delete_tag(
     db.delete(tag)
     db.commit()
     return {"message": "Tag deleted"}
+
+
+@router.delete("", response_model=DeleteAllTagsResponse)
+async def delete_all_tags(
+    request: DeleteAllTagsRequest,
+    current_user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Delete ALL non-system tags (admin only).
+
+    System tags are preserved. Document and user tag associations are
+    removed via CASCADE on the junction tables.
+    Requires confirm: true in request body.
+    """
+    if not request.confirm:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Confirmation required. Set 'confirm: true' to proceed.",
+        )
+
+    # Count system tags (preserved)
+    system_count = db.query(Tag).filter(Tag.is_system == True).count()  # noqa: E712
+
+    # Get non-system tags and delete them
+    non_system_tags = db.query(Tag).filter(Tag.is_system == False).all()  # noqa: E712
+    deleted_count = len(non_system_tags)
+
+    for tag in non_system_tags:
+        db.delete(tag)
+
+    db.commit()
+    logger.info(
+        f"Deleted all non-system tags (count={deleted_count}, "
+        f"system_preserved={system_count}, admin={current_user.email})"
+    )
+
+    return DeleteAllTagsResponse(
+        deleted_count=deleted_count,
+        skipped_system_count=system_count,
+        success=True,
+    )

--- a/ai_ready_rag/schemas/document.py
+++ b/ai_ready_rag/schemas/document.py
@@ -142,6 +142,19 @@ class BulkReprocessResponse(BaseModel):
     skipped_ids: list[str]
 
 
+class DeleteAllDocumentsRequest(BaseModel):
+    """Request to delete all documents."""
+
+    confirm: bool
+
+
+class DeleteAllDocumentsResponse(BaseModel):
+    """Response after deleting all documents."""
+
+    deleted_count: int
+    success: bool
+
+
 class BatchFileResult(BaseModel):
     """Result for a single file in a batch upload."""
 

--- a/ai_ready_rag/schemas/tag.py
+++ b/ai_ready_rag/schemas/tag.py
@@ -44,3 +44,17 @@ class TagResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class DeleteAllTagsRequest(BaseModel):
+    """Request to delete all tags."""
+
+    confirm: bool
+
+
+class DeleteAllTagsResponse(BaseModel):
+    """Response after deleting all tags."""
+
+    deleted_count: int
+    skipped_system_count: int
+    success: bool

--- a/frontend/src/api/documents.ts
+++ b/frontend/src/api/documents.ts
@@ -301,6 +301,33 @@ export async function reprocessDocument(documentId: string): Promise<Document> {
   return response.json();
 }
 
+/**
+ * Delete ALL documents (admin only). Requires confirmation.
+ */
+export async function deleteAllDocuments(): Promise<{
+  deleted_count: number;
+  success: boolean;
+}> {
+  const response = await fetch('/api/documents', {
+    method: 'DELETE',
+    headers: {
+      ...getAuthHeaders(),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ confirm: true }),
+  });
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      useAuthStore.getState().logout();
+    }
+    const error = await response.json().catch(() => ({ detail: 'Failed to delete all documents' }));
+    throw new Error(error.detail || `HTTP ${response.status}`);
+  }
+
+  return response.json();
+}
+
 export interface BulkReprocessResponse {
   queued: number;
   skipped: number;

--- a/frontend/src/api/tags.ts
+++ b/frontend/src/api/tags.ts
@@ -52,6 +52,21 @@ export async function deleteTag(id: string): Promise<{ message: string }> {
 }
 
 /**
+ * Delete ALL non-system tags (admin only). Requires confirmation.
+ */
+export async function deleteAllTags(): Promise<{
+  deleted_count: number;
+  skipped_system_count: number;
+  success: boolean;
+}> {
+  return apiClient.delete<{
+    deleted_count: number;
+    skipped_system_count: number;
+    success: boolean;
+  }>('/api/tags', { confirm: true });
+}
+
+/**
  * Get tag facets grouped by namespace.
  */
 export async function getTagFacets(): Promise<TagFacetsResponse> {


### PR DESCRIPTION
## Summary
- Add admin-only `DELETE /api/documents` endpoint to delete all documents, files, and vector embeddings
- Add admin-only `DELETE /api/tags` endpoint to delete all non-system tags (system tags preserved)
- Both endpoints require `{ "confirm": true }` in request body
- Frontend "Delete All" buttons with confirmation modals on Documents and Tags admin views
- 6 new tests covering auth, confirmation, and successful deletion

## Test plan
- [x] `ruff check ai_ready_rag tests` passes
- [x] `pytest tests/test_documents.py::TestDeleteAllDocuments -v` — 3/3 pass
- [x] `pytest tests/test_tags.py::TestDeleteAllTags -v` — 3/3 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — success
- [ ] Manual: verify Delete All button visible only to admins
- [ ] Manual: verify confirmation modal shows before deletion

Closes #302
Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)