### PR TITLE
fix: Resolve 12 failing tests post-merge (#337, #338)

### DIFF
--- a/ai_ready_rag/api/admin.py
+++ b/ai_ready_rag/api/admin.py
@@ -2767,8 +2767,6 @@ async def list_completed_warming_jobs(
 
     Admin only.
     """
-    from datetime import date
-
     query = db.query(WarmingBatch).filter(
         WarmingBatch.status.in_(["completed", "completed_with_errors"])
     )
@@ -2782,7 +2780,7 @@ async def list_completed_warming_jobs(
                 detail="Invalid date format. Use YYYY-MM-DD.",
             ) from None
     else:
-        filter_date = date.today()
+        filter_date = datetime.now(UTC).date()
 
     query = query.filter(
         WarmingBatch.completed_at >= datetime.combine(filter_date, datetime.min.time()),

--- a/ai_ready_rag/services/rag_service.py
+++ b/ai_ready_rag/services/rag_service.py
@@ -1803,7 +1803,7 @@ class RAGService:
         # 1. Find primary tag from context
         tag_counts: dict[str, int] = {}
         for result in context_results:
-            for tag in getattr(result, "tags", []):
+            for tag in result.tags or []:
                 if tag != "public":  # Skip public tag for routing
                     tag_counts[tag] = tag_counts.get(tag, 0) + 1
 

--- a/tests/test_cache_integration.py
+++ b/tests/test_cache_integration.py
@@ -47,6 +47,8 @@ def mock_settings():
     settings.rag_chunk_overlap_threshold = 0.9
     settings.rag_enable_query_expansion = False  # Disable for predictable tests
     settings.rag_enable_hallucination_check = False  # Disable for speed
+    settings.rag_recency_weight = 0.15
+    settings.rag_intent_boost_weight = 0.35
     return settings
 
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -460,14 +460,23 @@ class TestDocumentTagUpdate:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
+@patch(
+    "ai_ready_rag.api.documents.get_redis_pool",
+    new_callable=AsyncMock,
+)
 class TestUploadWithProcessingOptions:
-    """Tests for per-upload processing options."""
+    """Tests for per-upload processing options.
+
+    Redis is mocked to None at class level so uploads fall back to
+    BackgroundTasks, letting us assert on process_document_task call args.
+    """
 
     @patch("ai_ready_rag.api.documents.process_document_task")
     def test_upload_with_enable_ocr_false(
-        self, mock_task, client, admin_headers, test_tag, tmp_path
+        self, mock_task, mock_redis, client, admin_headers, test_tag, tmp_path
     ):
         """Upload with enable_ocr=false passes option to background task."""
+        mock_redis.return_value = None
         test_file = tmp_path / "test.txt"
         test_file.write_text("Test content")
 
@@ -492,9 +501,10 @@ class TestUploadWithProcessingOptions:
 
     @patch("ai_ready_rag.api.documents.process_document_task")
     def test_upload_without_options_passes_none(
-        self, mock_task, client, admin_headers, test_tag, tmp_path
+        self, mock_task, mock_redis, client, admin_headers, test_tag, tmp_path
     ):
         """Upload without processing options passes None to background task."""
+        mock_redis.return_value = None
         test_file = tmp_path / "test.txt"
         test_file.write_text("Test content")
 
@@ -514,9 +524,10 @@ class TestUploadWithProcessingOptions:
 
     @patch("ai_ready_rag.api.documents.process_document_task")
     def test_upload_with_multiple_options(
-        self, mock_task, client, admin_headers, test_tag, tmp_path
+        self, mock_task, mock_redis, client, admin_headers, test_tag, tmp_path
     ):
         """Upload with multiple processing options passes all to task."""
+        mock_redis.return_value = None
         test_file = tmp_path / "test.txt"
         test_file.write_text("Test content")
 
@@ -544,9 +555,10 @@ class TestUploadWithProcessingOptions:
 
     @patch("ai_ready_rag.api.documents.process_document_task")
     def test_upload_with_include_image_descriptions(
-        self, mock_task, client, admin_headers, test_tag, tmp_path
+        self, mock_task, mock_redis, client, admin_headers, test_tag, tmp_path
     ):
         """Upload with include_image_descriptions option."""
+        mock_redis.return_value = None
         test_file = tmp_path / "test.txt"
         test_file.write_text("Test content")
 
@@ -567,7 +579,7 @@ class TestUploadWithProcessingOptions:
         assert options_dict["include_image_descriptions"] is True
 
     def test_upload_with_invalid_table_extraction_mode(
-        self, client, admin_headers, test_tag, tmp_path
+        self, mock_redis, client, admin_headers, test_tag, tmp_path
     ):
         """Upload with invalid table_extraction_mode returns 400."""
         test_file = tmp_path / "test.txt"

--- a/tests/test_structured_logging.py
+++ b/tests/test_structured_logging.py
@@ -154,9 +154,12 @@ class TestNoPrintStatements:
     def test_no_print_in_source(self):
         """No print() statements in ai_ready_rag source."""
         import pathlib
+        import re
 
         source_dir = pathlib.Path(__file__).parent.parent / "ai_ready_rag"
         violations = []
+        # Match print( only when not preceded by an identifier character (word boundary)
+        _print_re = re.compile(r"(?<![a-zA-Z0-9_])print\s*\(")
 
         for py_file in source_dir.rglob("*.py"):
             content = py_file.read_text()
@@ -165,7 +168,7 @@ class TestNoPrintStatements:
                 # Skip comments
                 if stripped.startswith("#"):
                     continue
-                if "print(" in stripped:
+                if _print_re.search(stripped):
                     violations.append(f"{py_file.relative_to(source_dir.parent)}:{i}: {stripped}")
 
         assert violations == [], "Found print() statements:\n" + "\n".join(violations)


### PR DESCRIPTION
## Summary

- Fixed 12 test failures introduced when merging PR #337 (fix/issue-305-kb-delete-sqlite) and PR #338 (feat/chunk-size-optimization) into main

## Root Causes & Fixes

| Tests | Root Cause | Fix |
|-------|-----------|-----|
| `test_cache_integration` (5) | PR #338 added `rag_recency_weight` + `rag_intent_boost_weight` config fields; mock Settings fixture didn't include them | Added both fields to mock fixture |
| `rag_service.py` bug | `SearchResult.tags` defaults to `None`; `getattr(result, 'tags', [])` returns `None` when attr exists (not missing) | Changed to `result.tags or []` |
| `test_structured_logging` (1) | False positive: `compute_fingerprint(file_path)` contains `print(` as substring | Added regex negative lookbehind `(?<![a-zA-Z0-9_])print\s*\(` |
| `test_documents::TestUploadWithProcessingOptions` (4) | Upload route uses ARQ/Redis when available; tests patched `process_document_task` but not Redis, so ARQ path was taken | Added class-level `@patch(get_redis_pool, return_value=None)` to force BackgroundTask fallback |
| `test_warming_api::TestListCompletedBatches` (2) | `date.today()` returns local date; stored UTC timestamps mismatch when server local timezone ≠ UTC | Changed to `datetime.now(UTC).date()` for UTC consistency |

## Test Plan

- [x] All 12 previously-failing tests now pass
- [x] Full suite: **1283 passed, 0 failed**, 7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)