### PR TITLE
feat: Add CA SQL template catalog — 12 parameterized templates (#365)

### DIFF
--- a/ai_ready_rag/modules/community_associations/services/sql_template_catalog.py
+++ b/ai_ready_rag/modules/community_associations/services/sql_template_catalog.py
@@ -1,0 +1,151 @@
+"""SQL template catalog loader and validator.
+
+Loads sql_templates.yaml and validates all templates at startup.
+Templates are registered via ModuleRegistry.register_sql_templates().
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import re
+from dataclasses import dataclass, field
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# SQL statements that are forbidden in templates (read-only enforcement)
+_DML_PATTERN = re.compile(
+    r"\b(INSERT|UPDATE|DELETE|DROP|ALTER|TRUNCATE|CREATE|GRANT|REVOKE)\b",
+    re.IGNORECASE,
+)
+
+# Required safety clause in all templates
+_LIMIT_PATTERN = re.compile(r"\bLIMIT\b", re.IGNORECASE)
+
+# Forbidden interpolation patterns (f-string or % formatting)
+_INTERPOLATION_PATTERN = re.compile(r"\{[^}]+\}|%s|%\(")
+
+
+@dataclass
+class SQLTemplateParam:
+    """Parameter definition for a SQL template."""
+
+    name: str
+    type: str
+    required: bool = True
+    default: object = None
+
+
+@dataclass
+class SQLTemplate:
+    """A validated SQL template with metadata."""
+
+    name: str
+    display_name: str
+    trigger_phrases: list[str]
+    params: list[SQLTemplateParam]
+    sql: str
+
+    def validate(self) -> list[str]:
+        """Validate template safety. Returns list of violations (empty = valid)."""
+        violations = []
+
+        if _DML_PATTERN.search(self.sql):
+            violations.append(f"Template '{self.name}' contains forbidden DML statement")
+
+        if not _LIMIT_PATTERN.search(self.sql):
+            violations.append(f"Template '{self.name}' missing required LIMIT clause")
+
+        if _INTERPOLATION_PATTERN.search(self.sql):
+            violations.append(
+                f"Template '{self.name}' contains forbidden string interpolation (use :param_name)"
+            )
+
+        return violations
+
+
+@dataclass
+class SQLTemplateCatalog:
+    """Collection of validated SQL templates for a module."""
+
+    module_id: str
+    default_row_cap: int
+    default_timeout_seconds: int
+    templates: list[SQLTemplate] = field(default_factory=list)
+
+    def get(self, name: str) -> SQLTemplate | None:
+        """Return template by name, or None if not found."""
+        return next((t for t in self.templates if t.name == name), None)
+
+    def as_dict(self) -> dict[str, str]:
+        """Return {template_name: sql_string} dict for ModuleRegistry registration."""
+        return {t.name: t.sql for t in self.templates}
+
+    def trigger_map(self) -> dict[str, str]:
+        """Return {trigger_phrase: template_name} for QueryRouter routing."""
+        result = {}
+        for template in self.templates:
+            for phrase in template.trigger_phrases:
+                result[phrase.lower()] = template.name
+        return result
+
+
+def load_sql_template_catalog(
+    yaml_path: str | pathlib.Path | None = None,
+) -> SQLTemplateCatalog:
+    """Load and validate the CA SQL template catalog from YAML.
+
+    Args:
+        yaml_path: Path to sql_templates.yaml. Defaults to module's sql_templates.yaml.
+
+    Returns:
+        Validated SQLTemplateCatalog.
+
+    Raises:
+        ValueError: If any template fails validation.
+    """
+    if yaml_path is None:
+        yaml_path = pathlib.Path(__file__).parent.parent / "sql_templates.yaml"
+
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f)
+
+    catalog = SQLTemplateCatalog(
+        module_id=data["module_id"],
+        default_row_cap=data.get("default_row_cap", 1000),
+        default_timeout_seconds=data.get("default_timeout_seconds", 5),
+    )
+
+    all_violations = []
+    for tpl_data in data.get("templates", []):
+        params = [
+            SQLTemplateParam(
+                name=p["name"],
+                type=p["type"],
+                required=p.get("required", True),
+                default=p.get("default"),
+            )
+            for p in tpl_data.get("params", [])
+        ]
+        template = SQLTemplate(
+            name=tpl_data["name"],
+            display_name=tpl_data["display_name"],
+            trigger_phrases=tpl_data.get("trigger_phrases", []),
+            params=params,
+            sql=tpl_data["sql"].strip(),
+        )
+        violations = template.validate()
+        all_violations.extend(violations)
+        catalog.templates.append(template)
+
+    if all_violations:
+        msg = "SQL template validation failures:\n" + "\n".join(f"  - {v}" for v in all_violations)
+        raise ValueError(msg)
+
+    logger.info(
+        "ca.sql_templates.loaded",
+        extra={"count": len(catalog.templates), "module": data["module_id"]},
+    )
+    return catalog

--- a/ai_ready_rag/modules/community_associations/sql_templates.yaml
+++ b/ai_ready_rag/modules/community_associations/sql_templates.yaml
@@ -1,0 +1,424 @@
+# Community Associations SQL Template Catalog
+# Registered by ModuleRegistry.register_sql_templates() at startup
+# All templates use parameterized bindings (:param_name), no string interpolation
+# All templates include LIMIT :row_cap enforced by QueryRouter (default 1000)
+# Templates are READ-ONLY — no DML statements
+
+module_id: community_associations
+default_row_cap: 1000
+default_timeout_seconds: 5
+
+templates:
+
+  # ─── Primary Templates (8) ─────────────────────────────────────────────────
+
+  - name: ca_coverage_by_account_line
+    display_name: "Coverage limits and deductibles by line of business"
+    trigger_phrases:
+      - "limit"
+      - "deductible"
+      - "coverage"
+    params:
+      - name: account_id
+        type: TEXT
+        required: true
+      - name: line_of_business
+        type: TEXT
+        required: false
+        default: null
+      - name: row_cap
+        type: INTEGER
+        required: false
+        default: 1000
+    sql: |
+      SELECT
+        p.policy_number,
+        p.carrier_name,
+        p.line_of_business,
+        c.coverage_type,
+        c.limit_amount,
+        c.deductible_amount,
+        c.deductible_type,
+        p.effective_date,
+        p.expiration_date
+      FROM insurance_coverages c
+      JOIN insurance_policies p ON c.policy_id = p.id
+      WHERE p.account_id = :account_id
+        AND p.is_active = true
+        AND p.is_deleted = false
+        AND c.is_deleted = false
+        AND (:line_of_business IS NULL OR p.line_of_business = :line_of_business)
+      ORDER BY p.line_of_business, c.coverage_type
+      LIMIT :row_cap
+
+  - name: ca_carrier_lookup
+    display_name: "Carrier and policy number lookup"
+    trigger_phrases:
+      - "carrier"
+      - "insurer"
+      - "who insures"
+      - "policy number"
+    params:
+      - name: account_id
+        type: TEXT
+        required: true
+      - name: row_cap
+        type: INTEGER
+        required: false
+        default: 1000
+    sql: |
+      SELECT
+        p.policy_number,
+        p.carrier_name,
+        p.line_of_business,
+        p.effective_date,
+        p.expiration_date,
+        p.premium_amount,
+        p.broker_name
+      FROM insurance_policies p
+      WHERE p.account_id = :account_id
+        AND p.is_deleted = false
+      ORDER BY p.line_of_business, p.inception_date DESC
+      LIMIT :row_cap
+
+  - name: ca_premium_query
+    display_name: "Premium amounts by line"
+    trigger_phrases:
+      - "premium"
+      - "cost"
+      - "rate"
+      - "how much does"
+      - "total premium"
+    params:
+      - name: account_id
+        type: TEXT
+        required: true
+      - name: row_cap
+        type: INTEGER
+        required: false
+        default: 1000
+    sql: |
+      SELECT
+        p.line_of_business,
+        p.carrier_name,
+        p.policy_number,
+        p.premium_amount,
+        p.effective_date,
+        p.expiration_date
+      FROM insurance_policies p
+      WHERE p.account_id = :account_id
+        AND p.is_active = true
+        AND p.is_deleted = false
+      ORDER BY p.premium_amount DESC
+      LIMIT :row_cap
+
+  - name: ca_policy_dates
+    display_name: "Policy effective and expiration dates"
+    trigger_phrases:
+      - "expiration"
+      - "expires"
+      - "renewal"
+      - "effective"
+      - "when does"
+    params:
+      - name: account_id
+        type: TEXT
+        required: true
+      - name: row_cap
+        type: INTEGER
+        required: false
+        default: 1000
+    sql: |
+      SELECT
+        p.policy_number,
+        p.line_of_business,
+        p.carrier_name,
+        p.effective_date,
+        p.expiration_date,
+        (p.expiration_date::date - CURRENT_DATE) AS days_until_expiration,
+        p.is_active
+      FROM insurance_policies p
+      WHERE p.account_id = :account_id
+        AND p.is_deleted = false
+      ORDER BY p.expiration_date ASC
+      LIMIT :row_cap
+
+  - name: ca_claims_history
+    display_name: "Claims and loss history"
+    trigger_phrases:
+      - "claims"
+      - "losses"
+      - "loss history"
+      - "incidents"
+    params:
+      - name: account_id
+        type: TEXT
+        required: true
+      - name: cutoff_date
+        type: DATE
+        required: false
+        default: "5 years ago"
+      - name: row_cap
+        type: INTEGER
+        required: false
+        default: 1000
+    sql: |
+      SELECT
+        cl.claim_number,
+        cl.loss_date,
+        cl.claim_type,
+        cl.description,
+        cl.amount_paid,
+        cl.amount_reserved,
+        cl.status,
+        cl.closed_date,
+        p.line_of_business,
+        p.carrier_name
+      FROM insurance_claims cl
+      JOIN insurance_policies p ON cl.policy_id = p.id
+      WHERE p.account_id = :account_id
+        AND cl.loss_date >= COALESCE(:cutoff_date::date, CURRENT_DATE - INTERVAL '5 years')
+        AND cl.is_deleted = false
+      ORDER BY cl.loss_date DESC
+      LIMIT :row_cap
+
+  - name: ca_compliance_gap
+    display_name: "Insurance requirements compliance gaps"
+    trigger_phrases:
+      - "compliance"
+      - "cc&r"
+      - "requirement"
+      - "missing coverage"
+      - "gap"
+    params:
+      - name: account_id
+        type: TEXT
+        required: true
+      - name: row_cap
+        type: INTEGER
+        required: false
+        default: 1000
+    sql: |
+      SELECT
+        r.requirement_text,
+        r.coverage_line,
+        r.min_limit,
+        r.limit_type,
+        r.requirement_source,
+        r.external_standard,
+        r.section_reference,
+        r.is_met,
+        r.gap_description
+      FROM insurance_requirements r
+      WHERE r.account_id = :account_id
+        AND r.is_met = false
+        AND r.superseded_at IS NULL
+        AND r.is_deleted = false
+      ORDER BY r.coverage_line, r.min_limit DESC
+      LIMIT :row_cap
+
+  - name: ca_coverage_schedule
+    display_name: "Full coverage schedule (all lines)"
+    trigger_phrases:
+      - "coverage schedule"
+      - "all lines"
+      - "program summary"
+    params:
+      - name: account_id
+        type: TEXT
+        required: true
+      - name: row_cap
+        type: INTEGER
+        required: false
+        default: 1000
+    sql: |
+      SELECT
+        p.line_of_business,
+        p.carrier_name,
+        p.policy_number,
+        p.effective_date,
+        p.expiration_date,
+        p.premium_amount,
+        c.coverage_type,
+        c.limit_amount,
+        c.deductible_amount
+      FROM insurance_policies p
+      LEFT JOIN insurance_coverages c ON c.policy_id = p.id AND c.is_deleted = false
+      WHERE p.account_id = :account_id
+        AND p.is_active = true
+        AND p.is_deleted = false
+      ORDER BY p.line_of_business, c.coverage_type
+      LIMIT :row_cap
+
+  - name: ca_comparison_by_line
+    display_name: "Year-over-year coverage comparison"
+    trigger_phrases:
+      - "compare"
+      - "vs"
+      - "versus"
+      - "difference between"
+    params:
+      - name: account_id
+        type: TEXT
+        required: true
+      - name: row_cap
+        type: INTEGER
+        required: false
+        default: 1000
+    sql: |
+      SELECT
+        p.line_of_business,
+        p.carrier_name,
+        p.policy_number,
+        p.effective_date,
+        p.expiration_date,
+        p.premium_amount,
+        c.coverage_type,
+        c.limit_amount,
+        c.deductible_amount,
+        p.is_active
+      FROM insurance_policies p
+      LEFT JOIN insurance_coverages c ON c.policy_id = p.id AND c.is_deleted = false
+      WHERE p.account_id = :account_id
+        AND p.is_deleted = false
+      ORDER BY p.line_of_business, p.effective_date DESC, c.coverage_type
+      LIMIT :row_cap
+
+  # ─── Secondary Templates (4) ────────────────────────────────────────────────
+
+  - name: ca_reserve_status
+    display_name: "Reserve fund status (most recent study)"
+    trigger_phrases:
+      - "reserve study"
+      - "percent funded"
+      - "reserve fund"
+    params:
+      - name: account_id
+        type: TEXT
+        required: true
+      - name: row_cap
+        type: INTEGER
+        required: false
+        default: 1
+    sql: |
+      SELECT
+        rs.study_date,
+        rs.study_firm,
+        rs.percent_funded,
+        rs.fully_funded_balance,
+        rs.actual_reserve_balance,
+        rs.annual_contribution,
+        rs.replacement_cost_new,
+        rs.component_count,
+        rs.study_type,
+        rs.funding_plan
+      FROM ca_reserve_studies rs
+      WHERE rs.account_id = :account_id
+        AND rs.is_deleted = false
+      ORDER BY rs.study_date DESC
+      LIMIT :row_cap
+
+  - name: ca_requirements_by_source
+    display_name: "Insurance requirements by source document"
+    trigger_phrases:
+      - "what do the cc&rs require"
+      - "requirements by source"
+      - "fannie mae requirements"
+      - "fha requirements"
+    params:
+      - name: account_id
+        type: TEXT
+        required: true
+      - name: requirement_source
+        type: TEXT
+        required: false
+        default: null
+      - name: row_cap
+        type: INTEGER
+        required: false
+        default: 1000
+    sql: |
+      SELECT
+        r.requirement_text,
+        r.coverage_line,
+        r.min_limit,
+        r.limit_type,
+        r.requirement_source,
+        r.external_standard,
+        r.section_reference,
+        r.is_met
+      FROM insurance_requirements r
+      WHERE r.account_id = :account_id
+        AND r.superseded_at IS NULL
+        AND r.is_deleted = false
+        AND (:requirement_source IS NULL OR r.requirement_source = :requirement_source)
+      ORDER BY r.requirement_source, r.coverage_line
+      LIMIT :row_cap
+
+  - name: ca_unit_owner_status
+    display_name: "Unit owner HO-6 letter status"
+    trigger_phrases:
+      - "unit owner letters"
+      - "which units need letters"
+      - "ho-6 status"
+    params:
+      - name: account_id
+        type: TEXT
+        required: true
+      - name: row_cap
+        type: INTEGER
+        required: false
+        default: 1000
+    sql: |
+      SELECT
+        uo.unit_number,
+        uo.ho6_required,
+        uo.minimum_coverage_amount,
+        lb.batch_date AS last_letter_date,
+        lb.status AS letter_status
+      FROM ca_unit_owners uo
+      LEFT JOIN LATERAL (
+        SELECT lbi.batch_id, b.batch_date, b.status
+        FROM ca_letter_batch_items lbi
+        JOIN ca_letter_batches b ON b.id = lbi.batch_id
+        WHERE lbi.unit_owner_id = uo.id
+          AND b.is_deleted = false
+        ORDER BY b.batch_date DESC
+        LIMIT 1
+      ) lb ON true
+      WHERE uo.account_id = :account_id
+        AND uo.is_deleted = false
+      ORDER BY uo.unit_number
+      LIMIT :row_cap
+
+  - name: ca_board_resolutions
+    display_name: "Board resolutions related to insurance"
+    trigger_phrases:
+      - "board resolutions"
+      - "board approved"
+      - "board voted"
+    params:
+      - name: account_id
+        type: TEXT
+        required: true
+      - name: limit
+        type: INTEGER
+        required: false
+        default: 20
+      - name: row_cap
+        type: INTEGER
+        required: false
+        default: 1000
+    sql: |
+      SELECT
+        br.meeting_date,
+        br.resolution_type,
+        br.description,
+        br.motion_by,
+        br.vote_result,
+        br.effective_date
+      FROM ca_board_resolutions br
+      WHERE br.account_id = :account_id
+        AND br.is_deleted = false
+      ORDER BY br.meeting_date DESC
+      LIMIT LEAST(:limit, :row_cap)

--- a/ai_ready_rag/modules/community_associations/tests/test_sql_templates.py
+++ b/ai_ready_rag/modules/community_associations/tests/test_sql_templates.py
@@ -1,0 +1,97 @@
+"""Tests for CA SQL template catalog."""
+
+import pytest
+
+from ai_ready_rag.modules.community_associations.services.sql_template_catalog import (
+    load_sql_template_catalog,
+)
+
+
+@pytest.fixture(scope="module")
+def catalog():
+    return load_sql_template_catalog()
+
+
+class TestCatalogLoading:
+    def test_loads_without_error(self, catalog):
+        assert catalog is not None
+        assert catalog.module_id == "community_associations"
+
+    def test_has_12_templates(self, catalog):
+        assert len(catalog.templates) == 12
+
+    def test_all_templates_have_limit_clause(self, catalog):
+        for t in catalog.templates:
+            assert "LIMIT" in t.sql.upper(), f"Template '{t.name}' missing LIMIT"
+
+    def test_no_dml_in_any_template(self, catalog):
+        import re
+
+        dml_pattern = re.compile(
+            r"\b(INSERT|UPDATE|DELETE|DROP|ALTER|TRUNCATE)\b",
+            re.IGNORECASE,
+        )
+        for t in catalog.templates:
+            match = dml_pattern.search(t.sql)
+            assert match is None, f"Template '{t.name}' has DML: {match.group() if match else ''}"
+
+    def test_all_templates_use_parameterized_bindings(self, catalog):
+        import re
+
+        interp_pattern = re.compile(r"\{[^}]+\}|%s|%\(")
+        for t in catalog.templates:
+            assert not interp_pattern.search(t.sql), f"Template '{t.name}' has string interpolation"
+
+
+class TestTemplateLookup:
+    def test_get_by_name(self, catalog):
+        t = catalog.get("ca_coverage_by_account_line")
+        assert t is not None
+        assert t.display_name == "Coverage limits and deductibles by line of business"
+
+    def test_get_missing_returns_none(self, catalog):
+        assert catalog.get("nonexistent") is None
+
+    def test_as_dict_returns_all_sqls(self, catalog):
+        d = catalog.as_dict()
+        assert len(d) == 12
+        assert "ca_coverage_by_account_line" in d
+
+    def test_trigger_map_has_phrases(self, catalog):
+        tm = catalog.trigger_map()
+        assert "premium" in tm
+        assert tm["premium"] == "ca_premium_query"
+        assert "carrier" in tm
+        assert tm["carrier"] == "ca_carrier_lookup"
+
+
+class TestPrimaryTemplates:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "ca_coverage_by_account_line",
+            "ca_carrier_lookup",
+            "ca_premium_query",
+            "ca_policy_dates",
+            "ca_claims_history",
+            "ca_compliance_gap",
+            "ca_coverage_schedule",
+            "ca_comparison_by_line",
+        ],
+    )
+    def test_primary_template_exists(self, catalog, name):
+        assert catalog.get(name) is not None
+
+
+class TestSecondaryTemplates:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "ca_reserve_status",
+            "ca_requirements_by_source",
+            "ca_unit_owner_status",
+            "ca_board_resolutions",
+        ],
+    )
+    def test_secondary_template_exists(self, catalog, name):
+        assert catalog.get(name) is not None


### PR DESCRIPTION
## Summary

- Adds `sql_templates.yaml` with 8 primary + 4 secondary CA SQL templates (coverage, carrier, premium, policy dates, claims, compliance gap, coverage schedule, year-over-year comparison, reserve status, requirements by source, unit owner HO-6 status, board resolutions)
- Adds `services/sql_template_catalog.py`: YAML loader with DML/interpolation safety validation and trigger-phrase mapping for QueryRouter
- Adds `tests/test_sql_templates.py`: 21 tests covering catalog loading, template count, LIMIT enforcement, no-DML, parameterized binding checks, lookup by name, trigger map, and parametrized existence checks for all 12 templates

## Test plan

- [x] All 21 new tests pass: `pytest ai_ready_rag/modules/community_associations/tests/test_sql_templates.py -v`
- [x] Lint clean on new files: `ruff check services/sql_template_catalog.py tests/test_sql_templates.py`
- [x] All templates use `:param_name` bindings, no string interpolation
- [x] All templates include a `LIMIT :row_cap` clause
- [x] No DML statements in any template (word-boundary regex enforced at load time)

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)