### PR TITLE
feat: Add core data model — enrichment models and document enrichment columns (#366)

### DIFF
--- a/ai_ready_rag/db/database.py
+++ b/ai_ready_rag/db/database.py
@@ -173,6 +173,58 @@ _TRACKED_MIGRATIONS = [
             "ALTER TABLE documents ADD COLUMN source_path VARCHAR",
         ],
     ),
+    (
+        "enrichment_v1_tables",
+        [
+            """CREATE TABLE IF NOT EXISTS enrichment_synopses (
+                id VARCHAR PRIMARY KEY,
+                document_id VARCHAR NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+                synopsis_text TEXT NOT NULL,
+                model_id VARCHAR NOT NULL,
+                prompt_version VARCHAR,
+                token_cost INTEGER,
+                cost_usd REAL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )""",
+            "CREATE INDEX IF NOT EXISTS ix_enrichment_synopses_document_id ON enrichment_synopses(document_id)",
+            """CREATE TABLE IF NOT EXISTS enrichment_entities (
+                id VARCHAR PRIMARY KEY,
+                synopsis_id VARCHAR NOT NULL REFERENCES enrichment_synopses(id) ON DELETE CASCADE,
+                entity_type VARCHAR NOT NULL,
+                value VARCHAR NOT NULL,
+                canonical_value VARCHAR,
+                confidence REAL,
+                source_chunk_index INTEGER,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )""",
+            "CREATE INDEX IF NOT EXISTS ix_enrichment_entities_synopsis_id ON enrichment_entities(synopsis_id)",
+            """CREATE TABLE IF NOT EXISTS review_items (
+                id VARCHAR PRIMARY KEY,
+                query_id VARCHAR,
+                answer_text TEXT,
+                confidence REAL,
+                reason VARCHAR,
+                status VARCHAR DEFAULT 'pending',
+                resolved_at DATETIME,
+                resolved_by VARCHAR REFERENCES users(id) ON DELETE SET NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )""",
+            "CREATE INDEX IF NOT EXISTS ix_review_items_query_id ON review_items(query_id)",
+        ],
+    ),
+    (
+        "enrichment_v1_document_columns",
+        [
+            "ALTER TABLE documents ADD COLUMN synopsis_id VARCHAR REFERENCES enrichment_synopses(id) ON DELETE SET NULL",
+            "ALTER TABLE documents ADD COLUMN enrichment_status VARCHAR",
+            "ALTER TABLE documents ADD COLUMN enrichment_model VARCHAR",
+            "ALTER TABLE documents ADD COLUMN enrichment_version VARCHAR",
+            "ALTER TABLE documents ADD COLUMN enrichment_tokens_used INTEGER",
+            "ALTER TABLE documents ADD COLUMN enrichment_cost_usd REAL",
+            "ALTER TABLE documents ADD COLUMN enrichment_completed_at DATETIME",
+            "ALTER TABLE documents ADD COLUMN document_role VARCHAR",
+        ],
+    ),
 ]
 
 

--- a/ai_ready_rag/db/models/__init__.py
+++ b/ai_ready_rag/db/models/__init__.py
@@ -20,6 +20,7 @@ from ai_ready_rag.db.models.cache import (
 )
 from ai_ready_rag.db.models.chat import ChatMessage, ChatSession
 from ai_ready_rag.db.models.document import Document
+from ai_ready_rag.db.models.enrichment import EnrichmentEntity, EnrichmentSynopsis, ReviewItem
 from ai_ready_rag.db.models.evaluation import (
     DatasetSample,
     EvaluationDataset,
@@ -62,4 +63,7 @@ __all__ = [
     "EvaluationRun",
     "EvaluationSample",
     "LiveEvaluationScore",
+    "EnrichmentSynopsis",
+    "EnrichmentEntity",
+    "ReviewItem",
 ]

--- a/ai_ready_rag/db/models/document.py
+++ b/ai_ready_rag/db/models/document.py
@@ -52,4 +52,25 @@ class Document(Base):
     auto_tag_source = Column(Text, nullable=True)  # JSON provenance
     source_path = Column(String, nullable=True)  # Original folder path from upload
 
+    # Enrichment columns — Issue #366
+    synopsis_id = Column(
+        String,
+        ForeignKey("enrichment_synopses.id", ondelete="SET NULL", use_alter=True),
+        nullable=True,
+    )
+    enrichment_status = Column(String, nullable=True)  # null | pending | completed | failed
+    enrichment_model = Column(String, nullable=True)
+    enrichment_version = Column(String, nullable=True)
+    enrichment_tokens_used = Column(Integer, nullable=True)
+    enrichment_cost_usd = Column(Float, nullable=True)
+    enrichment_completed_at = Column(DateTime, nullable=True)
+    document_role = Column(String, nullable=True)  # e.g. "governing_doc", "insurance_policy"
+
     tags = relationship("Tag", secondary=document_tags, back_populates="documents")
+
+    # Relationship — the "active" synopsis linked to this document
+    synopsis = relationship(
+        "EnrichmentSynopsis",
+        foreign_keys=[synopsis_id],
+        primaryjoin="Document.synopsis_id == EnrichmentSynopsis.id",
+    )

--- a/ai_ready_rag/db/models/enrichment.py
+++ b/ai_ready_rag/db/models/enrichment.py
@@ -1,0 +1,69 @@
+"""Enrichment models — synopsis, entity, and review queue tables."""
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+
+from ai_ready_rag.db.database import Base
+from ai_ready_rag.db.models.base import generate_uuid
+
+
+class EnrichmentSynopsis(Base):
+    __tablename__ = "enrichment_synopses"
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    document_id = Column(
+        String, ForeignKey("documents.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    synopsis_text = Column(Text, nullable=False)
+    model_id = Column(String, nullable=False)  # e.g. "claude-sonnet-4-6"
+    prompt_version = Column(String, nullable=True)  # semver of the prompt template
+    token_cost = Column(Integer, nullable=True)  # input + output tokens
+    cost_usd = Column(Float, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    # Relationships
+    entities = relationship(
+        "EnrichmentEntity", back_populates="synopsis", cascade="all, delete-orphan"
+    )
+    document = relationship(
+        "Document",
+        foreign_keys=[document_id],
+        primaryjoin="EnrichmentSynopsis.document_id == Document.id",
+        viewonly=True,
+    )
+
+
+class EnrichmentEntity(Base):
+    __tablename__ = "enrichment_entities"
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    synopsis_id = Column(
+        String,
+        ForeignKey("enrichment_synopses.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    entity_type = Column(String, nullable=False)  # e.g. "insurance_carrier", "coverage_line"
+    value = Column(String, nullable=False)  # raw extracted value
+    canonical_value = Column(String, nullable=True)  # normalized via alias resolution
+    confidence = Column(Float, nullable=True)  # 0.0–1.0
+    source_chunk_index = Column(Integer, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    synopsis = relationship("EnrichmentSynopsis", back_populates="entities")
+
+
+class ReviewItem(Base):
+    __tablename__ = "review_items"
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    query_id = Column(String, nullable=True, index=True)  # chat message ID if applicable
+    answer_text = Column(Text, nullable=True)
+    confidence = Column(Float, nullable=True)
+    reason = Column(String, nullable=True)  # why it was routed to review
+    status = Column(String, default="pending")  # pending | approved | rejected
+    resolved_at = Column(DateTime, nullable=True)
+    resolved_by = Column(String, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/tests/test_enrichment_models.py
+++ b/tests/test_enrichment_models.py
@@ -1,0 +1,399 @@
+"""Tests for enrichment models — EnrichmentSynopsis, EnrichmentEntity, ReviewItem."""
+
+import pytest
+
+from ai_ready_rag.db.models.document import Document
+from ai_ready_rag.db.models.enrichment import EnrichmentEntity, EnrichmentSynopsis, ReviewItem
+
+
+class TestEnrichmentSynopsis:
+    """Tests for the EnrichmentSynopsis model."""
+
+    def test_synopsis_can_be_created_and_queried(self, db, admin_user):
+        """EnrichmentSynopsis can be inserted and retrieved from the database."""
+        doc = Document(
+            filename="test.pdf",
+            original_filename="test.pdf",
+            file_path="/tmp/test.pdf",
+            file_type="pdf",
+            file_size=1024,
+            uploaded_by=admin_user.id,
+        )
+        db.add(doc)
+        db.flush()
+
+        synopsis = EnrichmentSynopsis(
+            document_id=doc.id,
+            synopsis_text="This is a test synopsis describing the document.",
+            model_id="claude-sonnet-4-6",
+            prompt_version="1.0.0",
+            token_cost=250,
+            cost_usd=0.001,
+        )
+        db.add(synopsis)
+        db.flush()
+        db.refresh(synopsis)
+
+        result = db.query(EnrichmentSynopsis).filter_by(id=synopsis.id).first()
+        assert result is not None
+        assert result.document_id == doc.id
+        assert result.synopsis_text == "This is a test synopsis describing the document."
+        assert result.model_id == "claude-sonnet-4-6"
+        assert result.prompt_version == "1.0.0"
+        assert result.token_cost == 250
+        assert result.cost_usd == pytest.approx(0.001)
+        assert result.created_at is not None
+
+    def test_synopsis_optional_fields_are_nullable(self, db, admin_user):
+        """prompt_version, token_cost, and cost_usd are all nullable."""
+        doc = Document(
+            filename="minimal.pdf",
+            original_filename="minimal.pdf",
+            file_path="/tmp/minimal.pdf",
+            file_type="pdf",
+            file_size=512,
+            uploaded_by=admin_user.id,
+        )
+        db.add(doc)
+        db.flush()
+
+        synopsis = EnrichmentSynopsis(
+            document_id=doc.id,
+            synopsis_text="Minimal synopsis.",
+            model_id="claude-sonnet-4-6",
+        )
+        db.add(synopsis)
+        db.flush()
+        db.refresh(synopsis)
+
+        assert synopsis.prompt_version is None
+        assert synopsis.token_cost is None
+        assert synopsis.cost_usd is None
+
+    def test_synopsis_fk_references_document(self, db, admin_user):
+        """EnrichmentSynopsis.document_id is a FK to documents with ondelete=CASCADE."""
+        fk_cols = {
+            fk.column.table.name: fk.ondelete for fk in EnrichmentSynopsis.__table__.foreign_keys
+        }
+        assert "documents" in fk_cols, "Expected FK to 'documents' table"
+        assert fk_cols["documents"] == "CASCADE", "Expected ondelete=CASCADE"
+
+
+class TestEnrichmentEntity:
+    """Tests for the EnrichmentEntity model."""
+
+    def test_entity_links_to_synopsis(self, db, admin_user):
+        """EnrichmentEntity is correctly linked to its parent EnrichmentSynopsis."""
+        doc = Document(
+            filename="entity_test.pdf",
+            original_filename="entity_test.pdf",
+            file_path="/tmp/entity_test.pdf",
+            file_type="pdf",
+            file_size=1024,
+            uploaded_by=admin_user.id,
+        )
+        db.add(doc)
+        db.flush()
+
+        synopsis = EnrichmentSynopsis(
+            document_id=doc.id,
+            synopsis_text="Synopsis with entities.",
+            model_id="claude-sonnet-4-6",
+        )
+        db.add(synopsis)
+        db.flush()
+
+        entity = EnrichmentEntity(
+            synopsis_id=synopsis.id,
+            entity_type="insurance_carrier",
+            value="Acme Insurance Co.",
+            canonical_value="Acme Insurance",
+            confidence=0.95,
+            source_chunk_index=3,
+        )
+        db.add(entity)
+        db.flush()
+        db.refresh(entity)
+
+        result = db.query(EnrichmentEntity).filter_by(id=entity.id).first()
+        assert result is not None
+        assert result.synopsis_id == synopsis.id
+        assert result.entity_type == "insurance_carrier"
+        assert result.value == "Acme Insurance Co."
+        assert result.canonical_value == "Acme Insurance"
+        assert result.confidence == pytest.approx(0.95)
+        assert result.source_chunk_index == 3
+        assert result.created_at is not None
+
+    def test_entity_optional_fields_are_nullable(self, db, admin_user):
+        """canonical_value, confidence, and source_chunk_index are all nullable."""
+        doc = Document(
+            filename="minimal_entity.pdf",
+            original_filename="minimal_entity.pdf",
+            file_path="/tmp/minimal_entity.pdf",
+            file_type="pdf",
+            file_size=512,
+            uploaded_by=admin_user.id,
+        )
+        db.add(doc)
+        db.flush()
+
+        synopsis = EnrichmentSynopsis(
+            document_id=doc.id,
+            synopsis_text="Synopsis for minimal entity.",
+            model_id="claude-sonnet-4-6",
+        )
+        db.add(synopsis)
+        db.flush()
+
+        entity = EnrichmentEntity(
+            synopsis_id=synopsis.id,
+            entity_type="coverage_line",
+            value="General Liability",
+        )
+        db.add(entity)
+        db.flush()
+        db.refresh(entity)
+
+        assert entity.canonical_value is None
+        assert entity.confidence is None
+        assert entity.source_chunk_index is None
+
+    def test_multiple_entities_per_synopsis(self, db, admin_user):
+        """Multiple EnrichmentEntity rows can be linked to one synopsis."""
+        doc = Document(
+            filename="multi_entity.pdf",
+            original_filename="multi_entity.pdf",
+            file_path="/tmp/multi_entity.pdf",
+            file_type="pdf",
+            file_size=1024,
+            uploaded_by=admin_user.id,
+        )
+        db.add(doc)
+        db.flush()
+
+        synopsis = EnrichmentSynopsis(
+            document_id=doc.id,
+            synopsis_text="Synopsis with multiple entities.",
+            model_id="claude-sonnet-4-6",
+        )
+        db.add(synopsis)
+        db.flush()
+
+        entities = [
+            EnrichmentEntity(
+                synopsis_id=synopsis.id, entity_type="insurance_carrier", value="Carrier A"
+            ),
+            EnrichmentEntity(
+                synopsis_id=synopsis.id, entity_type="coverage_line", value="Property"
+            ),
+            EnrichmentEntity(
+                synopsis_id=synopsis.id, entity_type="coverage_line", value="Liability"
+            ),
+        ]
+        for e in entities:
+            db.add(e)
+        db.flush()
+
+        db.refresh(synopsis)
+        assert len(synopsis.entities) == 3
+
+    def test_entity_cascade_deleted_with_synopsis(self, db, admin_user):
+        """Deleting an EnrichmentSynopsis cascades and removes its entities."""
+        doc = Document(
+            filename="entity_cascade.pdf",
+            original_filename="entity_cascade.pdf",
+            file_path="/tmp/entity_cascade.pdf",
+            file_type="pdf",
+            file_size=1024,
+            uploaded_by=admin_user.id,
+        )
+        db.add(doc)
+        db.flush()
+
+        synopsis = EnrichmentSynopsis(
+            document_id=doc.id,
+            synopsis_text="Synopsis to cascade.",
+            model_id="claude-sonnet-4-6",
+        )
+        db.add(synopsis)
+        db.flush()
+
+        entity = EnrichmentEntity(
+            synopsis_id=synopsis.id,
+            entity_type="insurance_carrier",
+            value="To be deleted",
+        )
+        db.add(entity)
+        db.flush()
+        entity_id = entity.id
+
+        db.delete(synopsis)
+        db.flush()
+
+        result = db.query(EnrichmentEntity).filter_by(id=entity_id).first()
+        assert result is None
+
+
+class TestReviewItem:
+    """Tests for the ReviewItem model."""
+
+    def test_review_item_can_be_created(self, db):
+        """ReviewItem can be inserted and retrieved from the database."""
+        item = ReviewItem(
+            query_id="msg-abc-123",
+            answer_text="The policy limit is $1M per occurrence.",
+            confidence=0.42,
+            reason="confidence_below_threshold",
+            status="pending",
+        )
+        db.add(item)
+        db.flush()
+        db.refresh(item)
+
+        result = db.query(ReviewItem).filter_by(id=item.id).first()
+        assert result is not None
+        assert result.query_id == "msg-abc-123"
+        assert result.answer_text == "The policy limit is $1M per occurrence."
+        assert result.confidence == pytest.approx(0.42)
+        assert result.reason == "confidence_below_threshold"
+        assert result.status == "pending"
+        assert result.resolved_at is None
+        assert result.resolved_by is None
+        assert result.created_at is not None
+
+    def test_review_item_default_status_is_pending(self, db):
+        """ReviewItem.status defaults to 'pending' when not specified."""
+        item = ReviewItem(
+            answer_text="An unanswered question.",
+        )
+        db.add(item)
+        db.flush()
+        db.refresh(item)
+
+        assert item.status == "pending"
+
+    def test_review_item_all_fields_nullable_except_id_and_status(self, db):
+        """All fields except id, status, and created_at are nullable."""
+        item = ReviewItem()
+        db.add(item)
+        db.flush()
+        db.refresh(item)
+
+        assert item.id is not None
+        assert item.status == "pending"
+        assert item.created_at is not None
+        assert item.query_id is None
+        assert item.answer_text is None
+        assert item.confidence is None
+        assert item.reason is None
+        assert item.resolved_at is None
+        assert item.resolved_by is None
+
+    def test_review_item_can_be_resolved_by_user(self, db, admin_user):
+        """ReviewItem can reference a user via resolved_by FK."""
+        from datetime import datetime
+
+        item = ReviewItem(
+            query_id="msg-resolve-test",
+            answer_text="Approved answer.",
+            confidence=0.9,
+            status="approved",
+            resolved_by=admin_user.id,
+            resolved_at=datetime.utcnow(),
+        )
+        db.add(item)
+        db.flush()
+        db.refresh(item)
+
+        assert item.resolved_by == admin_user.id
+        assert item.resolved_at is not None
+        assert item.status == "approved"
+
+
+class TestDocumentEnrichmentColumns:
+    """Tests for enrichment columns added to the Document model."""
+
+    def test_document_enrichment_status_is_nullable(self, db, admin_user):
+        """Document.enrichment_status defaults to None."""
+        doc = Document(
+            filename="enrichment_col_test.pdf",
+            original_filename="enrichment_col_test.pdf",
+            file_path="/tmp/enrichment_col_test.pdf",
+            file_type="pdf",
+            file_size=1024,
+            uploaded_by=admin_user.id,
+        )
+        db.add(doc)
+        db.flush()
+        db.refresh(doc)
+
+        assert doc.enrichment_status is None
+        assert doc.enrichment_model is None
+        assert doc.enrichment_version is None
+        assert doc.enrichment_tokens_used is None
+        assert doc.enrichment_cost_usd is None
+        assert doc.enrichment_completed_at is None
+        assert doc.document_role is None
+        assert doc.synopsis_id is None
+
+    def test_document_enrichment_columns_can_be_set(self, db, admin_user):
+        """Document enrichment columns can be written and read back."""
+        from datetime import datetime
+
+        doc = Document(
+            filename="enriched_doc.pdf",
+            original_filename="enriched_doc.pdf",
+            file_path="/tmp/enriched_doc.pdf",
+            file_type="pdf",
+            file_size=2048,
+            uploaded_by=admin_user.id,
+            enrichment_status="completed",
+            enrichment_model="claude-sonnet-4-6",
+            enrichment_version="1.0.0",
+            enrichment_tokens_used=500,
+            enrichment_cost_usd=0.002,
+            enrichment_completed_at=datetime.utcnow(),
+            document_role="insurance_policy",
+        )
+        db.add(doc)
+        db.flush()
+        db.refresh(doc)
+
+        assert doc.enrichment_status == "completed"
+        assert doc.enrichment_model == "claude-sonnet-4-6"
+        assert doc.enrichment_version == "1.0.0"
+        assert doc.enrichment_tokens_used == 500
+        assert doc.enrichment_cost_usd == pytest.approx(0.002)
+        assert doc.enrichment_completed_at is not None
+        assert doc.document_role == "insurance_policy"
+
+    def test_document_synopsis_relationship(self, db, admin_user):
+        """Document.synopsis relationship resolves via synopsis_id FK."""
+        doc = Document(
+            filename="synopsis_rel.pdf",
+            original_filename="synopsis_rel.pdf",
+            file_path="/tmp/synopsis_rel.pdf",
+            file_type="pdf",
+            file_size=1024,
+            uploaded_by=admin_user.id,
+        )
+        db.add(doc)
+        db.flush()
+
+        synopsis = EnrichmentSynopsis(
+            document_id=doc.id,
+            synopsis_text="Linked synopsis.",
+            model_id="claude-sonnet-4-6",
+        )
+        db.add(synopsis)
+        db.flush()
+
+        # Link the synopsis back to the document via the synopsis_id FK
+        doc.synopsis_id = synopsis.id
+        db.flush()
+        db.refresh(doc)
+
+        assert doc.synopsis_id == synopsis.id
+        assert doc.synopsis is not None
+        assert doc.synopsis.synopsis_text == "Linked synopsis."


### PR DESCRIPTION
## Summary

- **`db/models/enrichment.py`** (new): `EnrichmentSynopsis`, `EnrichmentEntity`, and `ReviewItem` SQLAlchemy models for the Claude enrichment pipeline
- **`db/models/document.py`**: 8 new nullable enrichment columns (`synopsis_id`, `enrichment_status`, `enrichment_model`, `enrichment_version`, `enrichment_tokens_used`, `enrichment_cost_usd`, `enrichment_completed_at`, `document_role`) plus `Document.synopsis` relationship
- **`db/models/__init__.py`**: Exports `EnrichmentSynopsis`, `EnrichmentEntity`, `ReviewItem`
- **`db/database.py`**: SQLite tracked migrations for enrichment tables and document enrichment columns
- **`tests/test_enrichment_models.py`**: 14 integration tests (all pass)

## Notes

- No Alembic migration created — covered by #353
- All new `Document` columns are nullable — no impact on existing tests
- `ReviewItem` is defined in `enrichment.py` (single module for all three models)
- SQLite circular FK warning (documents ↔ enrichment_synopses) is expected and benign

## Test plan

- [x] `pytest tests/test_enrichment_models.py -v` — 14 passed
- [x] `ruff check` — all checks passed
- [x] `ruff format` — all files formatted

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)