### PR TITLE
feat: Add ClaudeEnrichmentService — two-call synopsis + entity extraction pipeline (#358)

### DIFF
--- a/ai_ready_rag/services/enrichment_service.py
+++ b/ai_ready_rag/services/enrichment_service.py
@@ -1,0 +1,294 @@
+"""ClaudeEnrichmentService — two-call document enrichment pipeline.
+
+Call 1 (Synopsis): claude-sonnet-4-6 with prompt caching
+  - Input: full document text (up to 200k tokens)
+  - Output: structured synopsis stored in enrichment_synopses
+
+Call 2 (Entities): claude-haiku-4-5-20251001 per chunk batch
+  - Input: synopsis + chunk batch
+  - Output: typed entities stored in enrichment_entities
+
+No-op on sqlite profile — Ollama/RAG path is unaffected.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SYNOPSIS_SYSTEM_PROMPT = """You are a document analyst specializing in insurance and property management documents.
+Extract a structured synopsis from the document. Return valid JSON with:
+{
+  "document_type": "<string>",
+  "key_entities": [{"type": "<string>", "value": "<string>", "confidence": <0.0-1.0>}],
+  "summary": "<string, 2-3 sentences>",
+  "coverage_lines": ["<string>"],
+  "date_references": ["<string>"],
+  "amounts": [{"label": "<string>", "amount": <number>, "currency": "USD"}]
+}
+Return ONLY valid JSON. No explanation."""
+
+ENTITY_EXTRACTION_PROMPT = """Given this document synopsis and chunk batch, extract typed entities.
+Return a JSON array:
+[{"entity_type": "<string>", "value": "<string>", "canonical_value": "<string or null>", "confidence": <0.0-1.0>, "chunk_index": <int>}]
+Entity types: insurance_carrier, coverage_line, coverage_limit, deductible, policy_number, effective_date, expiration_date, account_name, association_name
+Return ONLY valid JSON array. No explanation."""
+
+
+@dataclass
+class SynopsisResult:
+    synopsis_text: str
+    model_id: str
+    token_cost: int
+    cost_usd: float
+    raw_json: dict[str, Any]
+
+
+@dataclass
+class EntityResult:
+    entity_type: str
+    value: str
+    canonical_value: str | None
+    confidence: float
+    source_chunk_index: int | None
+
+
+class ClaudeEnrichmentService:
+    """Two-call enrichment pipeline using Claude API.
+
+    Gracefully degrades to no-op on SQLite / laptop dev profile.
+    """
+
+    def __init__(self, settings: Any, db_session: Any = None) -> None:
+        self._settings = settings
+        self._db = db_session
+        self._client = None
+
+    def _is_enabled(self) -> bool:
+        """Return True only when Claude enrichment is explicitly enabled."""
+        enabled = getattr(self._settings, "claude_enrichment_enabled", None)
+        api_key = getattr(self._settings, "claude_api_key", None)
+        database_backend = getattr(self._settings, "database_backend", "sqlite")
+        if database_backend == "sqlite":
+            return False
+        return bool(enabled and api_key)
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            try:
+                import anthropic
+
+                api_key = getattr(self._settings, "claude_api_key", None)
+                self._client = anthropic.Anthropic(api_key=api_key)
+            except ImportError as err:
+                raise RuntimeError(
+                    "anthropic package not installed. Add anthropic>=0.40.0 to requirements-wsl.txt"
+                ) from err
+        return self._client
+
+    async def enrich_document(
+        self,
+        document_id: str,
+        document_text: str,
+        chunks: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Run the full two-call enrichment pipeline for a document.
+
+        Returns enrichment result dict. No-op (returns empty dict) if not enabled.
+        """
+        if not self._is_enabled():
+            logger.debug(
+                "enrichment.skipped",
+                extra={"document_id": document_id, "reason": "not_enabled_or_sqlite"},
+            )
+            return {}
+
+        try:
+            synopsis = await self._call_synopsis(document_id, document_text)
+            entities = await self._call_entity_extraction(document_id, synopsis, chunks)
+
+            result = {
+                "document_id": document_id,
+                "synopsis": synopsis,
+                "entities": entities,
+                "enrichment_model": synopsis.model_id,
+                "token_cost": synopsis.token_cost,
+                "cost_usd": synopsis.cost_usd,
+            }
+
+            if self._db is not None:
+                await self._persist(document_id, synopsis, entities)
+
+            logger.info(
+                "enrichment.completed",
+                extra={
+                    "document_id": document_id,
+                    "entities_count": len(entities),
+                    "cost_usd": synopsis.cost_usd,
+                },
+            )
+            return result
+        except Exception as exc:
+            logger.error(
+                "enrichment.failed",
+                extra={"document_id": document_id, "error": str(exc)},
+            )
+            raise
+
+    async def _call_synopsis(self, document_id: str, document_text: str) -> SynopsisResult:
+        """Call claude-sonnet-4-6 for document synopsis with prompt caching."""
+        import json
+
+        client = self._get_client()
+        model = getattr(self._settings, "claude_enrichment_model", "claude-sonnet-4-6")
+        timeout = getattr(self._settings, "claude_enrichment_timeout", 60)
+
+        # Truncate to ~100k chars to stay within token limits
+        text = document_text[:100_000]
+
+        message = client.messages.create(
+            model=model,
+            max_tokens=2048,
+            system=[
+                {
+                    "type": "text",
+                    "text": SYNOPSIS_SYSTEM_PROMPT,
+                    "cache_control": {"type": "ephemeral"},  # prompt caching
+                }
+            ],
+            messages=[{"role": "user", "content": f"Document text:\n\n{text}"}],
+            timeout=timeout,
+        )
+
+        content = message.content[0].text if message.content else "{}"
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError:
+            parsed = {"raw": content}
+
+        input_tokens = getattr(message.usage, "input_tokens", 0)
+        output_tokens = getattr(message.usage, "output_tokens", 0)
+        token_cost = input_tokens + output_tokens
+        # Approximate cost: sonnet-4-6 input ~$3/1M, output ~$15/1M
+        cost_usd = (input_tokens * 3.0 + output_tokens * 15.0) / 1_000_000
+
+        return SynopsisResult(
+            synopsis_text=content,
+            model_id=model,
+            token_cost=token_cost,
+            cost_usd=cost_usd,
+            raw_json=parsed,
+        )
+
+    async def _call_entity_extraction(
+        self,
+        document_id: str,
+        synopsis: SynopsisResult,
+        chunks: list[dict[str, Any]],
+    ) -> list[EntityResult]:
+        """Call claude-haiku for entity extraction on chunk batches."""
+        import json
+
+        client = self._get_client()
+        simple_model = getattr(
+            self._settings,
+            "claude_query_model_simple",
+            "claude-haiku-4-5-20251001",
+        )
+        batch_size = getattr(self._settings, "claude_enrichment_batch_size", 8)
+
+        all_entities: list[EntityResult] = []
+
+        for batch_start in range(0, len(chunks), batch_size):
+            batch = chunks[batch_start : batch_start + batch_size]
+            batch_text = "\n---\n".join(
+                f"[Chunk {batch_start + i}] {c.get('text', c.get('content', ''))[:500]}"
+                for i, c in enumerate(batch)
+            )
+
+            prompt = f"Synopsis:\n{synopsis.synopsis_text[:1000]}\n\nChunks:\n{batch_text}"
+
+            message = client.messages.create(
+                model=simple_model,
+                max_tokens=1024,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": ENTITY_EXTRACTION_PROMPT + "\n\n" + prompt,
+                    }
+                ],
+            )
+
+            content = message.content[0].text if message.content else "[]"
+            try:
+                items = json.loads(content)
+                if not isinstance(items, list):
+                    items = []
+            except json.JSONDecodeError:
+                items = []
+
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                all_entities.append(
+                    EntityResult(
+                        entity_type=str(item.get("entity_type", "unknown")),
+                        value=str(item.get("value", "")),
+                        canonical_value=item.get("canonical_value"),
+                        confidence=float(item.get("confidence", 0.5)),
+                        source_chunk_index=item.get("chunk_index"),
+                    )
+                )
+
+        return all_entities
+
+    async def _persist(
+        self,
+        document_id: str,
+        synopsis: SynopsisResult,
+        entities: list[EntityResult],
+    ) -> None:
+        """Persist synopsis and entities to the database."""
+        try:
+            from ai_ready_rag.db.models.base import generate_uuid
+            from ai_ready_rag.db.models.enrichment import (
+                EnrichmentEntity,
+                EnrichmentSynopsis,
+            )
+
+            synopsis_id = generate_uuid()
+            synopsis_obj = EnrichmentSynopsis(
+                id=synopsis_id,
+                document_id=document_id,
+                synopsis_text=synopsis.synopsis_text,
+                model_id=synopsis.model_id,
+                token_cost=synopsis.token_cost,
+                cost_usd=synopsis.cost_usd,
+            )
+            self._db.add(synopsis_obj)
+
+            for entity in entities:
+                self._db.add(
+                    EnrichmentEntity(
+                        id=generate_uuid(),
+                        synopsis_id=synopsis_id,
+                        entity_type=entity.entity_type,
+                        value=entity.value,
+                        canonical_value=entity.canonical_value,
+                        confidence=entity.confidence,
+                        source_chunk_index=entity.source_chunk_index,
+                    )
+                )
+
+            self._db.commit()
+        except Exception as exc:
+            logger.error(
+                "enrichment.persist.failed",
+                extra={"document_id": document_id, "error": str(exc)},
+            )
+            if self._db:
+                self._db.rollback()
+            raise

--- a/requirements-wsl.txt
+++ b/requirements-wsl.txt
@@ -24,6 +24,9 @@ langchain>=0.3.0
 langchain-community>=0.3.0
 langchain-ollama>=0.2.0
 
+# ============== Claude / Anthropic API ==============
+anthropic>=0.40.0
+
 # ============== Evaluation Framework ==============
 ragas>=0.4.0,<0.5.0
 openai>=1.0.0,<2.0.0

--- a/tests/test_enrichment_service.py
+++ b/tests/test_enrichment_service.py
@@ -1,0 +1,238 @@
+"""Tests for ClaudeEnrichmentService."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestClaudeEnrichmentServiceUnit:
+    def test_import(self):
+        from ai_ready_rag.services.enrichment_service import ClaudeEnrichmentService
+
+        assert ClaudeEnrichmentService is not None
+
+    def test_disabled_on_sqlite(self):
+        from ai_ready_rag.services.enrichment_service import ClaudeEnrichmentService
+
+        settings = MagicMock()
+        settings.claude_enrichment_enabled = True
+        settings.claude_api_key = "sk-ant-test"
+        settings.database_backend = "sqlite"
+        svc = ClaudeEnrichmentService(settings)
+        assert svc._is_enabled() is False
+
+    def test_disabled_when_no_api_key(self):
+        from ai_ready_rag.services.enrichment_service import ClaudeEnrichmentService
+
+        settings = MagicMock()
+        settings.claude_enrichment_enabled = True
+        settings.claude_api_key = None
+        settings.database_backend = "postgresql"
+        svc = ClaudeEnrichmentService(settings)
+        assert svc._is_enabled() is False
+
+    def test_disabled_when_flag_off(self):
+        from ai_ready_rag.services.enrichment_service import ClaudeEnrichmentService
+
+        settings = MagicMock()
+        settings.claude_enrichment_enabled = False
+        settings.claude_api_key = "sk-ant-test"
+        settings.database_backend = "postgresql"
+        svc = ClaudeEnrichmentService(settings)
+        assert svc._is_enabled() is False
+
+    def test_enabled_on_postgresql_with_key(self):
+        from ai_ready_rag.services.enrichment_service import ClaudeEnrichmentService
+
+        settings = MagicMock()
+        settings.claude_enrichment_enabled = True
+        settings.claude_api_key = "sk-ant-test"
+        settings.database_backend = "postgresql"
+        svc = ClaudeEnrichmentService(settings)
+        assert svc._is_enabled() is True
+
+    @pytest.mark.asyncio
+    async def test_enrich_noop_when_disabled(self):
+        from ai_ready_rag.services.enrichment_service import ClaudeEnrichmentService
+
+        settings = MagicMock()
+        settings.claude_enrichment_enabled = False
+        settings.database_backend = "sqlite"
+        svc = ClaudeEnrichmentService(settings)
+        result = await svc.enrich_document("doc1", "text", [])
+        assert result == {}
+
+    def test_synopsis_result_dataclass(self):
+        from ai_ready_rag.services.enrichment_service import SynopsisResult
+
+        r = SynopsisResult(
+            synopsis_text="test",
+            model_id="model",
+            token_cost=100,
+            cost_usd=0.001,
+            raw_json={},
+        )
+        assert r.synopsis_text == "test"
+
+    def test_entity_result_dataclass(self):
+        from ai_ready_rag.services.enrichment_service import EntityResult
+
+        e = EntityResult(
+            entity_type="carrier",
+            value="State Farm",
+            canonical_value=None,
+            confidence=0.9,
+            source_chunk_index=0,
+        )
+        assert e.entity_type == "carrier"
+
+    def test_get_client_raises_when_anthropic_not_installed(self):
+        from ai_ready_rag.services.enrichment_service import ClaudeEnrichmentService
+
+        settings = MagicMock()
+        settings.claude_api_key = "sk-ant-test"
+        svc = ClaudeEnrichmentService(settings)
+
+        with patch.dict("sys.modules", {"anthropic": None}):
+            with pytest.raises(RuntimeError, match="anthropic package not installed"):
+                svc._get_client()
+
+    @pytest.mark.asyncio
+    async def test_enrich_noop_returns_empty_dict_on_sqlite_even_with_key(self):
+        """SQLite backend always returns empty dict regardless of other settings."""
+        from ai_ready_rag.services.enrichment_service import ClaudeEnrichmentService
+
+        settings = MagicMock()
+        settings.claude_enrichment_enabled = True
+        settings.claude_api_key = "sk-ant-real-key"
+        settings.database_backend = "sqlite"
+        svc = ClaudeEnrichmentService(settings)
+        result = await svc.enrich_document("doc-id", "some text", [{"text": "chunk"}])
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_enrich_document_calls_synopsis_and_entities_when_enabled(self):
+        """Full pipeline is called when enabled (mocked API)."""
+        from ai_ready_rag.services.enrichment_service import (
+            ClaudeEnrichmentService,
+            EntityResult,
+            SynopsisResult,
+        )
+
+        settings = MagicMock()
+        settings.claude_enrichment_enabled = True
+        settings.claude_api_key = "sk-ant-test"
+        settings.database_backend = "postgresql"
+
+        svc = ClaudeEnrichmentService(settings)
+
+        mock_synopsis = SynopsisResult(
+            synopsis_text='{"document_type": "policy"}',
+            model_id="claude-sonnet-4-6",
+            token_cost=500,
+            cost_usd=0.005,
+            raw_json={"document_type": "policy"},
+        )
+        mock_entities = [
+            EntityResult(
+                entity_type="insurance_carrier",
+                value="Acme Insurance",
+                canonical_value=None,
+                confidence=0.95,
+                source_chunk_index=0,
+            )
+        ]
+
+        svc._call_synopsis = AsyncMock(return_value=mock_synopsis)
+        svc._call_entity_extraction = AsyncMock(return_value=mock_entities)
+
+        result = await svc.enrich_document("doc-123", "document text", [])
+
+        assert result["document_id"] == "doc-123"
+        assert result["enrichment_model"] == "claude-sonnet-4-6"
+        assert result["token_cost"] == 500
+        assert result["cost_usd"] == 0.005
+        assert result["synopsis"] is mock_synopsis
+        assert result["entities"] is mock_entities
+
+        svc._call_synopsis.assert_called_once_with("doc-123", "document text")
+        svc._call_entity_extraction.assert_called_once_with("doc-123", mock_synopsis, [])
+
+    @pytest.mark.asyncio
+    async def test_enrich_document_persists_when_db_provided(self):
+        """Persist is called when db_session is provided."""
+        from ai_ready_rag.services.enrichment_service import (
+            ClaudeEnrichmentService,
+            EntityResult,
+            SynopsisResult,
+        )
+
+        settings = MagicMock()
+        settings.claude_enrichment_enabled = True
+        settings.claude_api_key = "sk-ant-test"
+        settings.database_backend = "postgresql"
+
+        mock_db = MagicMock()
+        svc = ClaudeEnrichmentService(settings, db_session=mock_db)
+
+        mock_synopsis = SynopsisResult(
+            synopsis_text="{}",
+            model_id="claude-sonnet-4-6",
+            token_cost=100,
+            cost_usd=0.001,
+            raw_json={},
+        )
+        mock_entities: list[EntityResult] = []
+
+        svc._call_synopsis = AsyncMock(return_value=mock_synopsis)
+        svc._call_entity_extraction = AsyncMock(return_value=mock_entities)
+        svc._persist = AsyncMock()
+
+        await svc.enrich_document("doc-456", "text", [])
+
+        svc._persist.assert_called_once_with("doc-456", mock_synopsis, mock_entities)
+
+    @pytest.mark.asyncio
+    async def test_enrich_document_propagates_exceptions(self):
+        """Exceptions from synopsis call bubble up to caller."""
+        from ai_ready_rag.services.enrichment_service import ClaudeEnrichmentService
+
+        settings = MagicMock()
+        settings.claude_enrichment_enabled = True
+        settings.claude_api_key = "sk-ant-test"
+        settings.database_backend = "postgresql"
+
+        svc = ClaudeEnrichmentService(settings)
+        svc._call_synopsis = AsyncMock(side_effect=RuntimeError("API timeout"))
+
+        with pytest.raises(RuntimeError, match="API timeout"):
+            await svc.enrich_document("doc-789", "text", [])
+
+    def test_entity_result_fields(self):
+        from ai_ready_rag.services.enrichment_service import EntityResult
+
+        e = EntityResult(
+            entity_type="policy_number",
+            value="POL-12345",
+            canonical_value="POL-12345",
+            confidence=1.0,
+            source_chunk_index=3,
+        )
+        assert e.value == "POL-12345"
+        assert e.canonical_value == "POL-12345"
+        assert e.confidence == 1.0
+        assert e.source_chunk_index == 3
+
+    def test_synopsis_result_fields(self):
+        from ai_ready_rag.services.enrichment_service import SynopsisResult
+
+        r = SynopsisResult(
+            synopsis_text='{"summary": "test doc"}',
+            model_id="claude-sonnet-4-6",
+            token_cost=1234,
+            cost_usd=0.012,
+            raw_json={"summary": "test doc"},
+        )
+        assert r.model_id == "claude-sonnet-4-6"
+        assert r.token_cost == 1234
+        assert r.raw_json == {"summary": "test doc"}


### PR DESCRIPTION
## Summary

- Implements `ClaudeEnrichmentService` in `ai_ready_rag/services/enrichment_service.py` with a two-call Claude API pipeline
- Call 1 (Synopsis): `claude-sonnet-4-6` with system-prompt caching → structured synopsis with document type, key entities, summary, coverage lines, dates, and amounts
- Call 2 (Entities): `claude-haiku-4-5-20251001` per chunk batch → typed entities (insurance_carrier, coverage_line, policy_number, etc.)
- No-op on SQLite profile (`database_backend == "sqlite"`) — the Ollama/RAG path is completely unaffected
- Adds `anthropic>=0.40.0` to `requirements-wsl.txt`
- `_persist()` method writes to `enrichment_synopses` / `enrichment_entities` tables (deferred import — gracefully fails until PR #398 enrichment models land)

## Test plan

- [x] `pytest tests/test_enrichment_service.py -v` — 15 unit tests, all passing
- [x] `pytest tests/ -q` — regression check confirms no new failures introduced
- [x] `ruff check` and `ruff format` — all clean, pre-commit hooks passed
- [x] Verified `_is_enabled()` returns `False` for sqlite backend regardless of other settings
- [x] Verified `enrich_document()` returns `{}` immediately when disabled (no API calls)
- [x] Verified exceptions from Claude API calls propagate to the caller

## Notes

- `EnrichmentSynopsis` / `EnrichmentEntity` models are imported lazily inside `_persist()` — this prevents import errors until PR #398 (enrichment DB models) is merged
- `anthropic` client is also lazily imported inside `_get_client()` — raises a clear `RuntimeError` with install instructions if the package is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)