### PR TITLE
feat: Add deterministic QueryRouter — SQL-first routing with RAG fallback (#362)

### DIFF
--- a/ai_ready_rag/core/module_registry.py
+++ b/ai_ready_rag/core/module_registry.py
@@ -1,0 +1,171 @@
+"""ModuleRegistry — sole extension point between core platform and vertical modules.
+
+Architecture rule: Core never imports from modules/. Modules import from core only
+through the registry API. This file defines the 5 extension points.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from fastapi import APIRouter
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Protocols (interfaces modules must implement)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class DocumentClassifier(Protocol):
+    """A classifier that can assign a document type to a file."""
+
+    def classify(self, filename: str, content_sample: str) -> Any:
+        """Return a ClassificationResult-like object with .doc_type and .confidence."""
+        ...
+
+
+@runtime_checkable
+class ComplianceChecker(Protocol):
+    """A checker that injects compliance constraints into prompts or validates results."""
+
+    def check(self, context: dict[str, Any]) -> Any:
+        """Return a ComplianceReport-like object."""
+        ...
+
+
+@dataclass
+class SQLTemplate:
+    """A registered SQL template with its parameter contract."""
+
+    name: str
+    sql: str
+    trigger_phrases: list[str] = field(default_factory=list)
+    description: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class ModuleRegistry:
+    """Singleton registry for vertical module extension points.
+
+    Modules call register() at startup to contribute:
+    - Document classifiers
+    - Entity alias maps
+    - SQL query templates
+    - Compliance checkers
+    - FastAPI sub-routers
+    """
+
+    _instance: ModuleRegistry | None = None
+
+    def __init__(self) -> None:
+        self._classifiers: list[DocumentClassifier] = []
+        self._entity_maps: dict[str, str] = {}  # canonical_name → table/column hint
+        self._sql_templates: dict[str, SQLTemplate] = {}  # template_name → SQLTemplate
+        self._compliance_checkers: list[ComplianceChecker] = []
+        self._routers: list[tuple[APIRouter, str]] = []  # (router, prefix)
+        self._registered_modules: list[str] = []
+
+    @classmethod
+    def get_instance(cls) -> ModuleRegistry:
+        """Return the process-wide singleton."""
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset singleton — for testing only."""
+        cls._instance = None
+
+    # ------------------------------------------------------------------
+    # Extension point 1: Document classifiers
+    # ------------------------------------------------------------------
+
+    def register_document_classifiers(self, classifiers: list[DocumentClassifier]) -> None:
+        """Register one or more document classifiers contributed by a module."""
+        self._classifiers.extend(classifiers)
+        logger.debug("registry.classifiers.added", extra={"count": len(classifiers)})
+
+    @property
+    def document_classifiers(self) -> list[DocumentClassifier]:
+        return list(self._classifiers)
+
+    # ------------------------------------------------------------------
+    # Extension point 2: Entity alias map
+    # ------------------------------------------------------------------
+
+    def register_entity_map(self, entity_map: dict[str, str]) -> None:
+        """Merge entity_map into the registry. Later registrations win on key collision."""
+        self._entity_maps.update(entity_map)
+        logger.debug("registry.entity_map.merged", extra={"keys": len(entity_map)})
+
+    @property
+    def entity_map(self) -> dict[str, str]:
+        return dict(self._entity_maps)
+
+    # ------------------------------------------------------------------
+    # Extension point 3: SQL templates
+    # ------------------------------------------------------------------
+
+    def register_sql_templates(self, templates: dict[str, SQLTemplate]) -> None:
+        """Register SQL templates. Later registrations win on name collision."""
+        self._sql_templates.update(templates)
+        logger.debug("registry.sql_templates.merged", extra={"keys": len(templates)})
+
+    @property
+    def sql_templates(self) -> dict[str, SQLTemplate]:
+        return dict(self._sql_templates)
+
+    # ------------------------------------------------------------------
+    # Extension point 4: Compliance checkers
+    # ------------------------------------------------------------------
+
+    def register_compliance_checker(self, checker: ComplianceChecker) -> None:
+        """Register a compliance checker."""
+        self._compliance_checkers.append(checker)
+        logger.debug("registry.compliance_checker.added")
+
+    @property
+    def compliance_checkers(self) -> list[ComplianceChecker]:
+        return list(self._compliance_checkers)
+
+    # ------------------------------------------------------------------
+    # Extension point 5: API routers
+    # ------------------------------------------------------------------
+
+    def register_api_router(self, router: APIRouter, prefix: str) -> None:
+        """Register a FastAPI router with its URL prefix."""
+        self._routers.append((router, prefix))
+        logger.debug("registry.router.added", extra={"prefix": prefix})
+
+    @property
+    def api_routers(self) -> list[tuple[APIRouter, str]]:
+        return list(self._routers)
+
+    # ------------------------------------------------------------------
+    # Module lifecycle
+    # ------------------------------------------------------------------
+
+    def register_module(self, module_id: str) -> None:
+        """Record that a module has been registered (for health/status endpoints)."""
+        if module_id not in self._registered_modules:
+            self._registered_modules.append(module_id)
+            logger.info("registry.module.registered", extra={"module_id": module_id})
+
+    @property
+    def registered_modules(self) -> list[str]:
+        return list(self._registered_modules)
+
+
+def get_registry() -> ModuleRegistry:
+    """FastAPI dependency: returns the process-wide ModuleRegistry."""
+    return ModuleRegistry.get_instance()

--- a/ai_ready_rag/services/factory.py
+++ b/ai_ready_rag/services/factory.py
@@ -16,6 +16,7 @@ from ai_ready_rag.services.settings_service import get_model_setting
 if TYPE_CHECKING:
     from ai_ready_rag.services.processing_service import ProcessingOptions
     from ai_ready_rag.services.protocols import ChunkerProtocol, VectorServiceProtocol
+    from ai_ready_rag.services.query_router import QueryRouter
 
 logger = logging.getLogger(__name__)
 
@@ -156,3 +157,18 @@ def get_chunker(
         )
     else:
         raise ValueError(f"Unknown chunker_backend: {backend}")
+
+
+def get_query_router() -> QueryRouter:
+    """Factory that returns a QueryRouter configured from application settings.
+
+    Returns:
+        QueryRouter instance with sql_confidence_threshold from settings
+        (defaults to 0.6 if setting is not present).
+    """
+    from ai_ready_rag.config import get_settings
+    from ai_ready_rag.services.query_router import QueryRouter
+
+    settings = get_settings()
+    sql_threshold = getattr(settings, "structured_query_confidence_threshold", 0.6)
+    return QueryRouter(sql_confidence_threshold=sql_threshold)

--- a/ai_ready_rag/services/query_router.py
+++ b/ai_ready_rag/services/query_router.py
@@ -1,0 +1,152 @@
+"""Deterministic QueryRouter — rule-based SQL-first query routing.
+
+No LLM call is made during routing. Routing decisions are:
+1. SQL-first: if entity extraction + trigger phrases + confidence >= threshold -> structured query
+2. RAG fallback: all other queries -> vector search
+
+Modules contribute SQL templates and trigger phrases via ModuleRegistry.register_sql_templates().
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+
+class RouteType(str, Enum):
+    SQL = "sql"
+    RAG = "rag"
+    REVIEW = "review"  # routed to human review (confidence below floor)
+
+
+@dataclass
+class RoutingDecision:
+    route: RouteType
+    template_name: str | None = None  # set when route == SQL
+    confidence: float = 0.0
+    matched_phrases: list[str] = field(default_factory=list)
+    reason: str = ""
+
+
+class QueryRouter:
+    """Deterministic query router.
+
+    Routing logic (in order):
+    1. Extract trigger phrases from query text
+    2. Find matching SQL templates in registry
+    3. Score match confidence
+    4. If confidence >= sql_threshold -> SQL route
+    5. Otherwise -> RAG route
+    6. If confidence below review_floor AND structured_query_enabled -> REVIEW route
+
+    This is intentionally simple and auditable. No LLM, no ambiguity.
+    """
+
+    def __init__(
+        self,
+        sql_confidence_threshold: float = 0.6,
+        review_floor: float = 0.0,  # disabled by default
+    ) -> None:
+        self._sql_threshold = sql_confidence_threshold
+        self._review_floor = review_floor
+        self._registry = None
+
+    def _get_registry(self):
+        if self._registry is None:
+            from ai_ready_rag.core.module_registry import ModuleRegistry
+
+            self._registry = ModuleRegistry.get_instance()
+        return self._registry
+
+    def route(self, query: str, structured_query_enabled: bool = False) -> RoutingDecision:
+        """Route a query to SQL or RAG based on deterministic rules."""
+        if not structured_query_enabled:
+            return RoutingDecision(
+                route=RouteType.RAG,
+                confidence=0.0,
+                reason="structured_query_disabled",
+            )
+
+        registry = self._get_registry()
+        templates = registry.sql_templates
+
+        if not templates:
+            return RoutingDecision(
+                route=RouteType.RAG,
+                confidence=0.0,
+                reason="no_sql_templates_registered",
+            )
+
+        best_template: str | None = None
+        best_confidence: float = 0.0
+        best_phrases: list[str] = []
+
+        query_lower = query.lower()
+
+        for name, template in templates.items():
+            matched = []
+            for phrase in template.trigger_phrases:
+                # Word-boundary match (case-insensitive)
+                if re.search(r"\b" + re.escape(phrase.lower()) + r"\b", query_lower):
+                    matched.append(phrase)
+
+            if not matched:
+                continue
+
+            # Confidence: ratio of matched phrases to total trigger phrases, capped at 1.0
+            total = max(len(template.trigger_phrases), 1)
+            confidence = min(len(matched) / total, 1.0)
+
+            # Bonus for multiple phrase matches
+            if len(matched) >= 2:
+                confidence = min(confidence + 0.1, 1.0)
+
+            if confidence > best_confidence:
+                best_confidence = confidence
+                best_template = name
+                best_phrases = matched
+
+        if best_template is None:
+            return RoutingDecision(
+                route=RouteType.RAG,
+                confidence=0.0,
+                reason="no_trigger_match",
+            )
+
+        if best_confidence >= self._sql_threshold:
+            logger.info(
+                "router.sql_route",
+                extra={
+                    "template": best_template,
+                    "confidence": best_confidence,
+                    "matched_phrases": best_phrases,
+                },
+            )
+            return RoutingDecision(
+                route=RouteType.SQL,
+                template_name=best_template,
+                confidence=best_confidence,
+                matched_phrases=best_phrases,
+                reason="trigger_match",
+            )
+
+        # Below SQL threshold but above review floor
+        if self._review_floor > 0 and best_confidence >= self._review_floor:
+            return RoutingDecision(
+                route=RouteType.REVIEW,
+                template_name=best_template,
+                confidence=best_confidence,
+                matched_phrases=best_phrases,
+                reason="below_sql_threshold_above_review_floor",
+            )
+
+        return RoutingDecision(
+            route=RouteType.RAG,
+            confidence=best_confidence,
+            matched_phrases=best_phrases,
+            reason="below_sql_threshold",
+        )

--- a/tests/test_query_router.py
+++ b/tests/test_query_router.py
@@ -1,0 +1,108 @@
+"""Tests for the deterministic QueryRouter."""
+
+import pytest
+
+from ai_ready_rag.core.module_registry import ModuleRegistry, SQLTemplate
+from ai_ready_rag.services.query_router import QueryRouter, RouteType
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    ModuleRegistry.reset()
+    yield
+    ModuleRegistry.reset()
+
+
+@pytest.fixture
+def router_with_templates():
+    registry = ModuleRegistry.get_instance()
+    registry.register_sql_templates(
+        {
+            "ca_coverage_by_line": SQLTemplate(
+                name="ca_coverage_by_line",
+                sql="SELECT * FROM insurance_coverages WHERE account_id = :account_id LIMIT :row_cap",
+                trigger_phrases=[
+                    "coverage",
+                    "insurance limit",
+                    "coverage line",
+                    "what is the coverage",
+                ],
+                description="Look up coverage by line of business",
+            ),
+            "ca_carrier_lookup": SQLTemplate(
+                name="ca_carrier_lookup",
+                sql="SELECT * FROM insurance_accounts WHERE account_name = :account_name LIMIT :row_cap",
+                trigger_phrases=["carrier", "insurer", "who insures", "insurance company"],
+                description="Look up carrier by account name",
+            ),
+        }
+    )
+    return QueryRouter(sql_confidence_threshold=0.5)
+
+
+class TestQueryRouterDisabled:
+    def test_rag_when_disabled(self, router_with_templates):
+        decision = router_with_templates.route(
+            "what is the coverage limit?", structured_query_enabled=False
+        )
+        assert decision.route == RouteType.RAG
+        assert decision.reason == "structured_query_disabled"
+
+
+class TestQueryRouterNoTemplates:
+    def test_rag_when_no_templates(self):
+        router = QueryRouter()
+        decision = router.route("what is the coverage?", structured_query_enabled=True)
+        assert decision.route == RouteType.RAG
+        assert decision.reason == "no_sql_templates_registered"
+
+
+class TestQueryRouterRouting:
+    def test_sql_route_on_trigger_match(self, router_with_templates):
+        decision = router_with_templates.route(
+            "what is the coverage limit for the property?",
+            structured_query_enabled=True,
+        )
+        assert decision.route == RouteType.SQL
+        assert decision.template_name == "ca_coverage_by_line"
+        assert "coverage" in decision.matched_phrases
+
+    def test_rag_route_on_no_match(self, router_with_templates):
+        decision = router_with_templates.route(
+            "summarize the board meeting minutes",
+            structured_query_enabled=True,
+        )
+        assert decision.route == RouteType.RAG
+        assert decision.reason in ("no_trigger_match", "below_sql_threshold")
+
+    def test_picks_best_template_on_multi_match(self, router_with_templates):
+        decision = router_with_templates.route(
+            "what is the coverage and who is the carrier?",
+            structured_query_enabled=True,
+        )
+        # Should route to SQL — multiple templates match but one wins
+        assert decision.route == RouteType.SQL
+
+    def test_confidence_above_threshold_routes_sql(self, router_with_templates):
+        decision = router_with_templates.route(
+            "what is the coverage line?",
+            structured_query_enabled=True,
+        )
+        assert decision.route == RouteType.SQL
+        assert decision.confidence >= 0.5
+
+    def test_review_route_when_floor_set(self):
+        registry = ModuleRegistry.get_instance()
+        registry.register_sql_templates(
+            {
+                "test_tmpl": SQLTemplate(
+                    name="test_tmpl",
+                    sql="SELECT 1 LIMIT :row_cap",
+                    trigger_phrases=["coverage", "policy", "limit", "carrier", "insurer"],
+                ),
+            }
+        )
+        router = QueryRouter(sql_confidence_threshold=0.9, review_floor=0.1)
+        decision = router.route("what is the coverage?", structured_query_enabled=True)
+        # Single phrase match -> confidence ~0.2 -> below 0.9 threshold, above 0.1 floor
+        assert decision.route == RouteType.REVIEW


### PR DESCRIPTION
## Summary

- Implements `ModuleRegistry` singleton (`ai_ready_rag/core/module_registry.py`) as the sole extension point between core and vertical modules — modules register `SQLTemplate` objects with trigger phrases via `register_sql_templates()`
- Implements `QueryRouter` (`ai_ready_rag/services/query_router.py`) with fully deterministic, no-LLM routing: word-boundary phrase matching against registered SQL templates, confidence scoring, SQL/RAG/REVIEW route types
- Adds `get_query_router()` factory in `ai_ready_rag/services/factory.py` that reads `structured_query_confidence_threshold` from settings (defaults to `0.6`)
- 7 passing unit tests covering all routing paths

## Routing logic

1. If `structured_query_enabled=False` → always RAG (reason: `structured_query_disabled`)
2. If no SQL templates registered → RAG (reason: `no_sql_templates_registered`)
3. Scan all registered templates; for each, count trigger phrase word-boundary matches
4. Confidence = matched / total phrases (bonus +0.1 if ≥ 2 phrases matched, capped at 1.0)
5. Best-scoring template wins; if confidence ≥ `sql_threshold` → SQL route
6. If `review_floor > 0` and confidence ≥ floor → REVIEW route
7. Otherwise → RAG fallback

## Test plan

- [x] `pytest tests/test_query_router.py -v` — all 7 tests pass
- [x] `ruff check ai_ready_rag tests && ruff format ai_ready_rag tests` — clean
- [x] Pre-existing test errors (`duplicate column name: forms_template_id`) are environment/schema issues unrelated to this PR; utility unit tests pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)