### PR TITLE
feat: Add React tenant config loading — branding and feature flags at startup (#376)

### DIFF
--- a/frontend/src/api/tenant.ts
+++ b/frontend/src/api/tenant.ts
@@ -1,0 +1,77 @@
+/**
+ * Tenant configuration API client.
+ * Fetches tenant config from GET /api/tenant/config
+ */
+
+export interface AIModelConfig {
+  enrichment_model: string;
+  query_model_simple: string;
+  query_model_complex: string;
+}
+
+export interface FeatureFlags {
+  ca_enabled: boolean;
+  ca_auto_renewal: boolean;
+  ca_unit_owner_letters: boolean;
+  ca_board_presentations: boolean;
+  structured_query_enabled: boolean;
+  claude_enrichment_enabled: boolean;
+}
+
+export interface BrandingConfig {
+  primary_color: string;
+  logo_url: string | null;
+  product_name: string;
+}
+
+export interface TenantConfig {
+  tenant_id: string;
+  display_name: string;
+  active_modules: string[];
+  feature_flags: FeatureFlags;
+  ai_models: AIModelConfig;
+  branding: BrandingConfig;
+}
+
+const DEFAULT_TENANT_CONFIG: TenantConfig = {
+  tenant_id: 'default',
+  display_name: '',
+  active_modules: ['core'],
+  feature_flags: {
+    ca_enabled: false,
+    ca_auto_renewal: false,
+    ca_unit_owner_letters: false,
+    ca_board_presentations: false,
+    structured_query_enabled: false,
+    claude_enrichment_enabled: false,
+  },
+  ai_models: {
+    enrichment_model: 'claude-sonnet-4-6',
+    query_model_simple: 'claude-haiku-4-5-20251001',
+    query_model_complex: 'claude-sonnet-4-6',
+  },
+  branding: {
+    primary_color: '#1a73e8',
+    logo_url: null,
+    product_name: 'VaultIQ',
+  },
+};
+
+export async function fetchTenantConfig(token: string): Promise<TenantConfig> {
+  const baseUrl = import.meta.env.VITE_API_URL || '';
+  const response = await fetch(`${baseUrl}/api/tenant/config`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    console.warn('Failed to load tenant config, using defaults', response.status);
+    return DEFAULT_TENANT_CONFIG;
+  }
+
+  return response.json();
+}
+
+export { DEFAULT_TENANT_CONFIG };

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { apiClient } from '../api/client';
 import type { User } from '../types';
+import { useTenantStore } from './tenantStore';
 
 interface AuthState {
   token: string | null;
@@ -35,6 +36,8 @@ export const useAuthStore = create<AuthState>()(
             isAuthenticated: true,
             isLoading: false,
           });
+          // Load tenant config after successful login
+          void useTenantStore.getState().loadConfig(access_token);
         } catch (error) {
           set({
             error: error instanceof Error ? error.message : 'Login failed',
@@ -63,6 +66,8 @@ export const useAuthStore = create<AuthState>()(
         try {
           const user = await apiClient.get<User>('/api/auth/me');
           set({ user, isAuthenticated: true });
+          // Load tenant config after session restore
+          void useTenantStore.getState().loadConfig(token);
         } catch {
           set({ token: null, user: null, isAuthenticated: false });
         }

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -2,3 +2,4 @@ export { useAuthStore } from './authStore';
 export { useUIStore } from './uiStore';
 export { useChatStore } from './chatStore';
 export { useDocumentsStore } from './documentsStore';
+export { useTenantStore, useTenantConfig } from './tenantStore';

--- a/frontend/src/stores/tenantStore.ts
+++ b/frontend/src/stores/tenantStore.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand';
+import { TenantConfig, DEFAULT_TENANT_CONFIG, fetchTenantConfig } from '../api/tenant';
+
+interface TenantState {
+  config: TenantConfig;
+  isLoaded: boolean;
+  isLoading: boolean;
+  error: string | null;
+  loadConfig: (token: string) => Promise<void>;
+  hasFeature: (flag: keyof TenantConfig['feature_flags']) => boolean;
+}
+
+export const useTenantStore = create<TenantState>((set, get) => ({
+  config: DEFAULT_TENANT_CONFIG,
+  isLoaded: false,
+  isLoading: false,
+  error: null,
+
+  loadConfig: async (token: string) => {
+    set({ isLoading: true, error: null });
+    try {
+      const config = await fetchTenantConfig(token);
+      set({ config, isLoaded: true, isLoading: false });
+
+      // Apply CSS custom properties for branding
+      if (config.branding?.primary_color) {
+        document.documentElement.style.setProperty(
+          '--color-primary',
+          config.branding.primary_color
+        );
+      }
+      if (config.branding?.product_name) {
+        document.title = config.branding.product_name;
+      }
+    } catch (err) {
+      set({
+        config: DEFAULT_TENANT_CONFIG,
+        isLoaded: true,
+        isLoading: false,
+        error: String(err),
+      });
+    }
+  },
+
+  hasFeature: (flag) => {
+    return get().config.feature_flags[flag] === true;
+  },
+}));
+
+export function useTenantConfig() {
+  return useTenantStore();
+}


### PR DESCRIPTION
## Summary

- Adds `frontend/src/api/tenant.ts` with full TypeScript interfaces (`TenantConfig`, `FeatureFlags`, `BrandingConfig`, `AIModelConfig`), safe `DEFAULT_TENANT_CONFIG` fallback, and `fetchTenantConfig(token)` that gracefully returns defaults on non-200 responses
- Adds `frontend/src/stores/tenantStore.ts` as a zustand store (`useTenantStore`) with `loadConfig(token)`, `hasFeature(flag)`, and a convenience `useTenantConfig()` hook — matching the existing zustand `create<State>()` pattern used across the codebase
- Wires `loadConfig()` into `authStore` at two points: after a successful `login()` and inside `checkAuth()` (session restore on page reload with a persisted token)
- On config load, applies `--color-primary` as a CSS custom property on `:root` and sets `document.title` from `branding.product_name`
- Exports `useTenantStore` and `useTenantConfig` from `stores/index.ts`

## Test plan

- [ ] Login flow: after `login()` succeeds, confirm `useTenantStore.getState().isLoaded === true` and `config` reflects server response (or defaults on 404/500)
- [ ] Page reload: with a valid persisted token, confirm `checkAuth()` triggers `loadConfig()` so branding is applied without re-logging in
- [ ] Fallback: when `/api/tenant/config` returns non-200, confirm `DEFAULT_TENANT_CONFIG` is used and no uncaught error is thrown
- [ ] Branding: confirm `document.documentElement.style.getPropertyValue('--color-primary')` reflects the loaded `primary_color`
- [ ] `hasFeature('ca_enabled')` returns `false` with defaults; returns `true` when the server returns `ca_enabled: true`
- [ ] TypeScript: `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)