### PR TITLE
feat: Add DocumentRenderer — PDF/PPTX generation with HTML fallback (#384)

### DIFF
--- a/ai_ready_rag/services/document_renderer.py
+++ b/ai_ready_rag/services/document_renderer.py
@@ -1,0 +1,227 @@
+"""DocumentRenderer — core PDF and PPTX generation service.
+
+Produces formatted output from structured data dicts.
+CA automation services (board presentations, renewal packets, letters)
+call this service rather than handling rendering themselves.
+
+Dependencies (optional — graceful fallback if not installed):
+  PDF: reportlab>=4.0.0
+  PPTX: python-pptx>=0.6.23
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RenderResult:
+    output_path: str
+    format: str  # "pdf" | "pptx" | "html"
+    file_size_bytes: int
+    page_count: int | None = None
+    slide_count: int | None = None
+
+
+class DocumentRenderer:
+    """Core renderer for structured document output.
+
+    Supports PDF (via reportlab) and PPTX (via python-pptx).
+    Falls back to plain HTML/text if libraries not installed.
+
+    All output is written to temp files; caller is responsible for cleanup.
+    """
+
+    def __init__(self, output_dir: str | None = None) -> None:
+        self._output_dir = output_dir or tempfile.gettempdir()
+
+    def render_pdf(self, content: dict[str, Any], filename: str = "output.pdf") -> RenderResult:
+        """Render structured content to PDF.
+
+        content dict expected keys:
+          - title: str
+          - sections: list of {"heading": str, "body": str | list[str]}
+          - metadata: dict (optional)
+        """
+        output_path = os.path.join(self._output_dir, filename)
+
+        try:
+            return self._render_pdf_reportlab(content, output_path)
+        except ImportError:
+            logger.warning("document_renderer.reportlab_not_installed", extra={"fallback": "html"})
+            return self._render_html_fallback(content, output_path.replace(".pdf", ".html"))
+
+    def _render_pdf_reportlab(self, content: dict[str, Any], output_path: str) -> RenderResult:
+        """Render PDF using reportlab."""
+        from reportlab.lib.pagesizes import letter
+        from reportlab.lib.styles import getSampleStyleSheet
+        from reportlab.lib.units import inch
+        from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer
+
+        doc = SimpleDocTemplate(output_path, pagesize=letter)
+        styles = getSampleStyleSheet()
+        story = []
+
+        # Title
+        title = content.get("title", "Document")
+        story.append(Paragraph(title, styles["Title"]))
+        story.append(Spacer(1, 0.2 * inch))
+
+        # Sections
+        for section in content.get("sections", []):
+            heading = section.get("heading", "")
+            if heading:
+                story.append(Paragraph(heading, styles["Heading2"]))
+
+            body = section.get("body", "")
+            if isinstance(body, list):
+                for item in body:
+                    story.append(Paragraph(f"• {item}", styles["Normal"]))
+            elif isinstance(body, str) and body:
+                story.append(Paragraph(body, styles["Normal"]))
+
+            story.append(Spacer(1, 0.1 * inch))
+
+        doc.build(story)
+
+        file_size = os.path.getsize(output_path)
+        logger.info("document_renderer.pdf_created", extra={"path": output_path, "size": file_size})
+        return RenderResult(
+            output_path=output_path,
+            format="pdf",
+            file_size_bytes=file_size,
+            page_count=None,  # reportlab doesn't easily expose page count
+        )
+
+    def render_pptx(self, content: dict[str, Any], filename: str = "output.pptx") -> RenderResult:
+        """Render board presentation slides to PPTX.
+
+        content dict expected from BoardPresentationPacket.to_dict():
+          - account_name: str
+          - meeting_date: str
+          - slides: list of {"type": str, "title": str, "data": dict}
+        """
+        output_path = os.path.join(self._output_dir, filename)
+
+        try:
+            return self._render_pptx_python_pptx(content, output_path)
+        except ImportError:
+            logger.warning(
+                "document_renderer.python_pptx_not_installed", extra={"fallback": "html"}
+            )
+            return self._render_html_fallback(content, output_path.replace(".pptx", ".html"))
+
+    def _render_pptx_python_pptx(self, content: dict[str, Any], output_path: str) -> RenderResult:
+        """Render PPTX using python-pptx."""
+        from pptx import Presentation
+        from pptx.util import Inches, Pt  # noqa: F401
+
+        prs = Presentation()
+
+        # Title slide
+        title_slide_layout = prs.slide_layouts[0]
+        slide = prs.slides.add_slide(title_slide_layout)
+        slide.shapes.title.text = content.get("account_name", "Insurance Review")
+        if slide.placeholders[1]:
+            slide.placeholders[1].text = content.get("meeting_date", "")
+
+        # Content slides
+        bullet_layout = prs.slide_layouts[1]
+        for slide_data in content.get("slides", []):
+            slide = prs.slides.add_slide(bullet_layout)
+            slide.shapes.title.text = slide_data.get("title", "")
+
+            # Add data as bullet points
+            data = slide_data.get("data", {})
+            body_text = self._flatten_slide_data(data)
+            if body_text and slide.placeholders[1]:
+                tf = slide.placeholders[1].text_frame
+                tf.text = ""
+                for line in body_text[:10]:  # max 10 bullets per slide
+                    p = tf.add_paragraph()
+                    p.text = line
+                    p.level = 0
+
+        prs.save(output_path)
+
+        file_size = os.path.getsize(output_path)
+        slide_count = len(prs.slides)
+        logger.info(
+            "document_renderer.pptx_created",
+            extra={"path": output_path, "slides": slide_count},
+        )
+        return RenderResult(
+            output_path=output_path,
+            format="pptx",
+            file_size_bytes=file_size,
+            slide_count=slide_count,
+        )
+
+    def _flatten_slide_data(self, data: dict[str, Any]) -> list[str]:
+        """Convert a data dict to a list of readable bullet strings."""
+        bullets = []
+        for key, value in data.items():
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        bullets.append(
+                            ", ".join(f"{k}: {v}" for k, v in item.items() if v is not None)
+                        )
+                    else:
+                        bullets.append(str(item))
+            elif isinstance(value, (int, float, str, bool)) and value is not None:
+                label = key.replace("_", " ").title()
+                if isinstance(value, float):
+                    bullets.append(
+                        f"{label}: ${value:,.2f}" if "usd" in key else f"{label}: {value:.2f}"
+                    )
+                else:
+                    bullets.append(f"{label}: {value}")
+        return bullets
+
+    def _render_html_fallback(self, content: dict[str, Any], output_path: str) -> RenderResult:
+        """Plain HTML fallback when PDF/PPTX libraries not installed."""
+        title = content.get("title") or content.get("account_name", "Document")
+        sections = content.get("sections") or content.get("slides", [])
+
+        lines = [
+            f"<html><head><title>{title}</title></head><body>",
+            f"<h1>{title}</h1>",
+        ]
+
+        for section in sections:
+            heading = section.get("heading") or section.get("title", "")
+            if heading:
+                lines.append(f"<h2>{heading}</h2>")
+            body = section.get("body") or section.get("data", {})
+            if isinstance(body, str):
+                lines.append(f"<p>{body}</p>")
+            elif isinstance(body, list):
+                lines.append("<ul>")
+                for item in body:
+                    lines.append(f"<li>{item}</li>")
+                lines.append("</ul>")
+            elif isinstance(body, dict):
+                lines.append("<ul>")
+                for k, v in body.items():
+                    lines.append(f"<li><strong>{k}</strong>: {v}</li>")
+                lines.append("</ul>")
+
+        lines.append("</body></html>")
+        html = "\n".join(lines)
+
+        Path(output_path).write_text(html, encoding="utf-8")
+        file_size = os.path.getsize(output_path)
+
+        return RenderResult(
+            output_path=output_path,
+            format="html",
+            file_size_bytes=file_size,
+        )

--- a/requirements-wsl.txt
+++ b/requirements-wsl.txt
@@ -62,6 +62,10 @@ pytest-asyncio>=0.23.0
 -e ../ingestkit/packages/ingestkit-core
 -e ../ingestkit/packages/ingestkit-excel
 
+# ============== Document Rendering ==============
+reportlab>=4.0.0
+python-pptx>=0.6.23
+
 # ============== Optional: Full Docling ==============
 # Uncomment when you need OCR, table extraction, advanced parsing
 # docling>=2.0.0

--- a/tests/test_document_renderer.py
+++ b/tests/test_document_renderer.py
@@ -1,0 +1,83 @@
+"""Tests for DocumentRenderer."""
+
+import os
+import tempfile
+
+from ai_ready_rag.services.document_renderer import DocumentRenderer, RenderResult
+
+
+class TestDocumentRenderer:
+    def setup_method(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.renderer = DocumentRenderer(output_dir=self.tmp_dir)
+
+    def teardown_method(self):
+        import shutil
+
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_import(self):
+        from ai_ready_rag.services.document_renderer import DocumentRenderer
+
+        assert DocumentRenderer is not None
+
+    def test_render_result_dataclass(self):
+        r = RenderResult(output_path="/tmp/test.pdf", format="pdf", file_size_bytes=1024)
+        assert r.format == "pdf"
+        assert r.file_size_bytes == 1024
+
+    def test_render_pdf_or_html_fallback(self):
+        content = {
+            "title": "Test Document",
+            "sections": [
+                {"heading": "Coverage Summary", "body": "Property: $5M"},
+                {"heading": "Next Steps", "body": ["Renew by March 1", "Get quotes"]},
+            ],
+        }
+        result = self.renderer.render_pdf(content, "test.pdf")
+        assert isinstance(result, RenderResult)
+        assert result.format in ("pdf", "html")
+        assert os.path.exists(result.output_path)
+        assert result.file_size_bytes > 0
+
+    def test_render_pptx_or_html_fallback(self):
+        content = {
+            "account_name": "Oak Hills HOA",
+            "meeting_date": "March 1, 2026",
+            "slides": [
+                {
+                    "type": "coverage_summary",
+                    "title": "Coverage Summary",
+                    "data": {"total_premium": 12000.0},
+                },
+                {
+                    "type": "compliance_status",
+                    "title": "Compliance",
+                    "data": {"gap_count": 0},
+                },
+            ],
+        }
+        result = self.renderer.render_pptx(content, "test.pptx")
+        assert isinstance(result, RenderResult)
+        assert result.format in ("pptx", "html")
+        assert os.path.exists(result.output_path)
+
+    def test_html_fallback_creates_valid_html(self):
+        content = {
+            "title": "Test",
+            "sections": [{"heading": "Section 1", "body": "Body text"}],
+        }
+        result = self.renderer._render_html_fallback(
+            content, os.path.join(self.tmp_dir, "test.html")
+        )
+        with open(result.output_path) as f:
+            html = f.read()
+        assert "<html>" in html
+        assert "Test" in html
+        assert "Section 1" in html
+
+    def test_flatten_slide_data(self):
+        data = {"total_premium": 12000.0, "gap_count": 2, "items": ["a", "b"]}
+        bullets = self.renderer._flatten_slide_data(data)
+        assert isinstance(bullets, list)
+        assert len(bullets) > 0


### PR DESCRIPTION
## Summary

- Adds `ai_ready_rag/services/document_renderer.py` — the core rendering service used by CA automation modules (RenewalPrepService, BoardPresentationService, UnitOwnerLetterService) to produce PDF/PPTX output
- PDF generation via `reportlab>=4.0.0`; PPTX generation via `python-pptx>=0.6.23`; graceful HTML fallback if either library is not installed
- Updated `requirements-wsl.txt` with both rendering dependencies

## Changes

### New files
- `ai_ready_rag/services/document_renderer.py` — `DocumentRenderer` class with `render_pdf()`, `render_pptx()`, `_render_html_fallback()`, and `_flatten_slide_data()` methods; `RenderResult` dataclass
- `tests/test_document_renderer.py` — 6 tests covering import, dataclass, PDF/HTML fallback render, PPTX/HTML fallback render, HTML fallback content, and slide data flattening

### Modified files
- `requirements-wsl.txt` — added `reportlab>=4.0.0` and `python-pptx>=0.6.23` under a new `Document Rendering` section

## Test plan

- [x] `pytest tests/test_document_renderer.py -v` — all 6 tests pass
- [x] `ruff check ai_ready_rag/services/document_renderer.py tests/test_document_renderer.py` — no errors
- [x] `ruff format` — files pass formatting check (pre-commit hook confirmed)
- [ ] Run full regression suite (`pytest tests/ -q`) before merge to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)