### PR TITLE
fix: Resolve ModuleRegistry dual-singleton mismatch (#422)

### DIFF
--- a/ai_ready_rag/core/module_registry.py
+++ b/ai_ready_rag/core/module_registry.py
@@ -1,171 +1,38 @@
-"""ModuleRegistry — sole extension point between core platform and vertical modules.
+"""ModuleRegistry — re-export shim (DEPRECATED).
 
-Architecture rule: Core never imports from modules/. Modules import from core only
-through the registry API. This file defines the 5 extension points.
+Previously this module held a separate ModuleRegistry class with a class-level
+singleton (_instance), while ai_ready_rag.modules.registry held a different
+singleton (_registry, module-level global). The two never shared state, so
+QueryRouter (which imported from here) always saw an empty template set even
+after vertical modules registered templates via modules.registry at startup.
+
+All implementation is now consolidated in ai_ready_rag.modules.registry.
+This file is kept as a thin re-export shim to avoid breaking any existing
+imports. New code should import directly from ai_ready_rag.modules.registry.
+
+Fixed by: issue #422
 """
 
-from __future__ import annotations
-
-import logging
-from dataclasses import dataclass, field
-from typing import Any, Protocol, runtime_checkable
-
-from fastapi import APIRouter
-
-logger = logging.getLogger(__name__)
-
-
 # ---------------------------------------------------------------------------
-# Protocols (interfaces modules must implement)
+# Re-export everything from the canonical registry module
 # ---------------------------------------------------------------------------
 
+from ai_ready_rag.modules.registry import (  # noqa: F401
+    ComplianceChecker,
+    ModuleManifest,
+    ModuleRegistry,
+    SQLTemplate,
+    _validate_sql_template,
+    get_registry,
+    init_registry,
+)
 
-@runtime_checkable
-class DocumentClassifier(Protocol):
-    """A classifier that can assign a document type to a file."""
-
-    def classify(self, filename: str, content_sample: str) -> Any:
-        """Return a ClassificationResult-like object with .doc_type and .confidence."""
-        ...
-
-
-@runtime_checkable
-class ComplianceChecker(Protocol):
-    """A checker that injects compliance constraints into prompts or validates results."""
-
-    def check(self, context: dict[str, Any]) -> Any:
-        """Return a ComplianceReport-like object."""
-        ...
-
-
-@dataclass
-class SQLTemplate:
-    """A registered SQL template with its parameter contract."""
-
-    name: str
-    sql: str
-    trigger_phrases: list[str] = field(default_factory=list)
-    description: str = ""
-
-
-# ---------------------------------------------------------------------------
-# Registry
-# ---------------------------------------------------------------------------
-
-
-class ModuleRegistry:
-    """Singleton registry for vertical module extension points.
-
-    Modules call register() at startup to contribute:
-    - Document classifiers
-    - Entity alias maps
-    - SQL query templates
-    - Compliance checkers
-    - FastAPI sub-routers
-    """
-
-    _instance: ModuleRegistry | None = None
-
-    def __init__(self) -> None:
-        self._classifiers: list[DocumentClassifier] = []
-        self._entity_maps: dict[str, str] = {}  # canonical_name → table/column hint
-        self._sql_templates: dict[str, SQLTemplate] = {}  # template_name → SQLTemplate
-        self._compliance_checkers: list[ComplianceChecker] = []
-        self._routers: list[tuple[APIRouter, str]] = []  # (router, prefix)
-        self._registered_modules: list[str] = []
-
-    @classmethod
-    def get_instance(cls) -> ModuleRegistry:
-        """Return the process-wide singleton."""
-        if cls._instance is None:
-            cls._instance = cls()
-        return cls._instance
-
-    @classmethod
-    def reset(cls) -> None:
-        """Reset singleton — for testing only."""
-        cls._instance = None
-
-    # ------------------------------------------------------------------
-    # Extension point 1: Document classifiers
-    # ------------------------------------------------------------------
-
-    def register_document_classifiers(self, classifiers: list[DocumentClassifier]) -> None:
-        """Register one or more document classifiers contributed by a module."""
-        self._classifiers.extend(classifiers)
-        logger.debug("registry.classifiers.added", extra={"count": len(classifiers)})
-
-    @property
-    def document_classifiers(self) -> list[DocumentClassifier]:
-        return list(self._classifiers)
-
-    # ------------------------------------------------------------------
-    # Extension point 2: Entity alias map
-    # ------------------------------------------------------------------
-
-    def register_entity_map(self, entity_map: dict[str, str]) -> None:
-        """Merge entity_map into the registry. Later registrations win on key collision."""
-        self._entity_maps.update(entity_map)
-        logger.debug("registry.entity_map.merged", extra={"keys": len(entity_map)})
-
-    @property
-    def entity_map(self) -> dict[str, str]:
-        return dict(self._entity_maps)
-
-    # ------------------------------------------------------------------
-    # Extension point 3: SQL templates
-    # ------------------------------------------------------------------
-
-    def register_sql_templates(self, templates: dict[str, SQLTemplate]) -> None:
-        """Register SQL templates. Later registrations win on name collision."""
-        self._sql_templates.update(templates)
-        logger.debug("registry.sql_templates.merged", extra={"keys": len(templates)})
-
-    @property
-    def sql_templates(self) -> dict[str, SQLTemplate]:
-        return dict(self._sql_templates)
-
-    # ------------------------------------------------------------------
-    # Extension point 4: Compliance checkers
-    # ------------------------------------------------------------------
-
-    def register_compliance_checker(self, checker: ComplianceChecker) -> None:
-        """Register a compliance checker."""
-        self._compliance_checkers.append(checker)
-        logger.debug("registry.compliance_checker.added")
-
-    @property
-    def compliance_checkers(self) -> list[ComplianceChecker]:
-        return list(self._compliance_checkers)
-
-    # ------------------------------------------------------------------
-    # Extension point 5: API routers
-    # ------------------------------------------------------------------
-
-    def register_api_router(self, router: APIRouter, prefix: str) -> None:
-        """Register a FastAPI router with its URL prefix."""
-        self._routers.append((router, prefix))
-        logger.debug("registry.router.added", extra={"prefix": prefix})
-
-    @property
-    def api_routers(self) -> list[tuple[APIRouter, str]]:
-        return list(self._routers)
-
-    # ------------------------------------------------------------------
-    # Module lifecycle
-    # ------------------------------------------------------------------
-
-    def register_module(self, module_id: str) -> None:
-        """Record that a module has been registered (for health/status endpoints)."""
-        if module_id not in self._registered_modules:
-            self._registered_modules.append(module_id)
-            logger.info("registry.module.registered", extra={"module_id": module_id})
-
-    @property
-    def registered_modules(self) -> list[str]:
-        return list(self._registered_modules)
-
-
-def get_registry() -> ModuleRegistry:
-    """FastAPI dependency: returns the process-wide ModuleRegistry."""
-    return ModuleRegistry.get_instance()
+__all__ = [
+    "ComplianceChecker",
+    "ModuleManifest",
+    "ModuleRegistry",
+    "SQLTemplate",
+    "_validate_sql_template",
+    "get_registry",
+    "init_registry",
+]

--- a/ai_ready_rag/modules/registry.py
+++ b/ai_ready_rag/modules/registry.py
@@ -26,6 +26,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+# ─── SQL template dataclass ──────────────────────────────────────────────────
+
+
+@dataclass
+class SQLTemplate:
+    """A registered SQL template with its parameter contract and routing metadata."""
+
+    name: str
+    sql: str
+    trigger_phrases: list[str] = field(default_factory=list)
+    description: str = ""
+
+
 # ─── SQL template safety guards ─────────────────────────────────────────────
 
 _DML_PATTERN = re.compile(
@@ -92,11 +106,31 @@ class ModuleRegistry:
     def __init__(self) -> None:
         self._classifiers: dict[str, Any] = {}  # module_name → classifier config/path
         self._entity_maps: dict[str, dict[str, str]] = {}  # module_name → {entity: table.col}
-        self._sql_templates: dict[str, str] = {}  # template_name → sql
+        self._sql_templates: dict[str, SQLTemplate] = {}  # template_name → SQLTemplate
         self._compliance_checkers: dict[str, ComplianceChecker] = {}
         self._api_routers: list[tuple[str, APIRouter, str]] = []  # (module_name, router, prefix)
         self._active_modules: list[str] = ["core"]
         self._manifests: dict[str, ModuleManifest] = {}
+
+    # ── Class-level singleton helpers (mirrors core.module_registry API) ──
+
+    @classmethod
+    def get_instance(cls) -> ModuleRegistry:
+        """Return the process-wide singleton, initializing it if needed.
+
+        Convenience alias for init_registry() / get_registry() for code that
+        previously used core.module_registry.ModuleRegistry.get_instance().
+        """
+        global _registry
+        if _registry is None:
+            _registry = cls()
+        return _registry
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset the singleton — for testing only."""
+        global _registry
+        _registry = None
 
     # ── Registration methods (called by modules at startup) ────────────────
 
@@ -124,13 +158,18 @@ class ModuleRegistry:
             extra={"module_name": module_name, "count": len(entity_map)},
         )
 
-    def register_sql_templates(self, module_name: str, templates: dict[str, str] | str) -> None:
+    def register_sql_templates(
+        self, module_name: str, templates: dict[str, SQLTemplate | str] | str
+    ) -> None:
         """Register parameterized SQL templates.
 
         Args:
             module_name: Unique module identifier.
-            templates: Dict of {template_name: sql_string} OR path to sql_templates.yaml.
-                       All templates are validated for safety (no DML, must have LIMIT).
+            templates: One of:
+                - Dict of {template_name: SQLTemplate} — preferred, full metadata
+                - Dict of {template_name: sql_string} — backward-compat; auto-wrapped
+                - Path to sql_templates.yaml — loaded and auto-wrapped
+                All templates are validated for safety (no DML, must have LIMIT).
 
         Raises:
             ValueError: If any template fails safety validation.
@@ -143,9 +182,15 @@ class ModuleRegistry:
                 data = yaml.safe_load(f)
             templates = {t["name"]: t["sql"].strip() for t in data.get("templates", [])}
 
-        for name, sql in templates.items():
-            _validate_sql_template(name, sql)
-            self._sql_templates[name] = sql
+        for name, tmpl in templates.items():
+            if isinstance(tmpl, SQLTemplate):
+                _validate_sql_template(name, tmpl.sql)
+                self._sql_templates[name] = tmpl
+            else:
+                # Backward compat: plain SQL string — auto-wrap into SQLTemplate
+                sql = tmpl
+                _validate_sql_template(name, sql)
+                self._sql_templates[name] = SQLTemplate(name=name, sql=sql, trigger_phrases=[])
 
         logger.info(
             "registry.sql_templates.registered",
@@ -194,12 +239,22 @@ class ModuleRegistry:
             merged.update(entity_map)
         return merged
 
-    def get_sql_templates(self) -> dict[str, str]:
-        """Return all registered SQL templates across all modules."""
+    @property
+    def sql_templates(self) -> dict[str, SQLTemplate]:
+        """Return all registered SQL templates as SQLTemplate objects (used by QueryRouter)."""
         return dict(self._sql_templates)
 
+    def get_sql_templates(self) -> dict[str, str]:
+        """Return all registered SQL templates as {name: sql} strings (backward-compat)."""
+        return {name: tmpl.sql for name, tmpl in self._sql_templates.items()}
+
     def get_sql_template(self, name: str) -> str | None:
-        """Return a single SQL template by name."""
+        """Return a single SQL template SQL string by name, or None."""
+        tmpl = self._sql_templates.get(name)
+        return tmpl.sql if tmpl is not None else None
+
+    def get_sql_template_object(self, name: str) -> SQLTemplate | None:
+        """Return a single SQLTemplate object by name, or None."""
         return self._sql_templates.get(name)
 
     def get_compliance_checker(self, module_name: str) -> ComplianceChecker | None:

--- a/ai_ready_rag/services/query_router.py
+++ b/ai_ready_rag/services/query_router.py
@@ -57,8 +57,11 @@ class QueryRouter:
 
     def _get_registry(self):
         if self._registry is None:
-            from ai_ready_rag.core.module_registry import ModuleRegistry
+            from ai_ready_rag.modules.registry import ModuleRegistry
 
+            # Use get_instance() so the router always shares the same singleton
+            # as main.py and module startup code, even when called before
+            # init_registry() (e.g. in tests — returns an empty registry).
             self._registry = ModuleRegistry.get_instance()
         return self._registry
 

--- a/tests/test_query_router.py
+++ b/tests/test_query_router.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ai_ready_rag.core.module_registry import ModuleRegistry, SQLTemplate
+from ai_ready_rag.modules.registry import ModuleRegistry, SQLTemplate
 from ai_ready_rag.services.query_router import QueryRouter, RouteType
 
 
@@ -17,6 +17,7 @@ def reset_registry():
 def router_with_templates():
     registry = ModuleRegistry.get_instance()
     registry.register_sql_templates(
+        "test_module",
         {
             "ca_coverage_by_line": SQLTemplate(
                 name="ca_coverage_by_line",
@@ -35,7 +36,7 @@ def router_with_templates():
                 trigger_phrases=["carrier", "insurer", "who insures", "insurance company"],
                 description="Look up carrier by account name",
             ),
-        }
+        },
     )
     return QueryRouter(sql_confidence_threshold=0.5)
 
@@ -94,13 +95,14 @@ class TestQueryRouterRouting:
     def test_review_route_when_floor_set(self):
         registry = ModuleRegistry.get_instance()
         registry.register_sql_templates(
+            "test_module",
             {
                 "test_tmpl": SQLTemplate(
                     name="test_tmpl",
                     sql="SELECT 1 LIMIT :row_cap",
                     trigger_phrases=["coverage", "policy", "limit", "carrier", "insurer"],
                 ),
-            }
+            },
         )
         router = QueryRouter(sql_confidence_threshold=0.9, review_floor=0.1)
         decision = router.route("what is the coverage?", structured_query_enabled=True)


### PR DESCRIPTION
## Summary

- **Root cause**: Two separate `ModuleRegistry` classes with disjoint singleton state — `core/module_registry.py` (class-level `_instance`) and `modules/registry.py` (module-level `_registry` global) — never shared state. `QueryRouter` imported from `core`, while `main.py` lifespan and all vertical modules registered templates via `modules/registry`. Templates were invisible to the router at runtime, causing it to always fall back to RAG with reason `no_sql_templates_registered`.
- **Secondary issue**: `modules/registry.py` stored SQL templates as `dict[str, str]` (plain strings), while `QueryRouter` expected `SQLTemplate` objects with `.trigger_phrases`. This would have caused `AttributeError` even if the singleton mismatch were fixed independently.

## Changes

- **`ai_ready_rag/modules/registry.py`**: Added `SQLTemplate` dataclass (with `trigger_phrases: list[str]` and `description: str`); changed `_sql_templates` internal type to `dict[str, SQLTemplate]`; updated `register_sql_templates()` to accept `dict[str, SQLTemplate | str]` with backward-compat auto-wrapping of plain strings; added `sql_templates` property returning `dict[str, SQLTemplate]` for `QueryRouter`; added `get_instance()` and `reset()` class methods for test isolation and legacy callers.
- **`ai_ready_rag/services/query_router.py`**: Changed `_get_registry()` from importing `core.module_registry.ModuleRegistry.get_instance()` to importing `modules.registry.ModuleRegistry.get_instance()` — QueryRouter now reads from the same singleton that modules populate at startup.
- **`ai_ready_rag/core/module_registry.py`**: Replaced full implementation with a thin re-export shim that forwards all imports to `modules.registry`. All existing import paths continue to work unchanged.
- **`tests/test_query_router.py`**: Updated imports to `modules.registry`; added `module_name` positional arg to `register_sql_templates()` calls to match the consolidated API.

## Test plan

- [x] `pytest tests/test_query_router.py tests/test_module_registry.py -v` — all 19 tests pass
- [x] `pytest tests/ -q` — 1571 passed, 10 skipped, 0 failures
- [x] `ruff check` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)