### PR TITLE
feat: Add structured_query_confidence_threshold to Settings and seed CA SQL templates (#426)

### DIFF
--- a/ai_ready_rag/config.py
+++ b/ai_ready_rag/config.py
@@ -419,6 +419,7 @@ class Settings(BaseSettings):
     structured_query_enabled: bool | None = None  # None = use profile default
     structured_query_row_cap: int = 1000
     structured_query_timeout_seconds: int = 5
+    structured_query_confidence_threshold: float = 0.6
 
     # ---------------------------------------------------------------------------
     # Tenant / Module — Issue #374

--- a/ai_ready_rag/modules/community_associations/module.py
+++ b/ai_ready_rag/modules/community_associations/module.py
@@ -50,12 +50,18 @@ def register(registry: ModuleRegistry) -> None:
     # 2. Entity-to-table map (used by QueryRouter for SQL generation)
     registry.register_entity_map("community_associations", CA_ENTITY_TO_TABLE_MAP)
 
-    # 3. SQL templates (implemented in #365)
-    sql_templates_yaml = module_dir / "sql_templates.yaml"
-    if sql_templates_yaml.exists():
-        registry.register_sql_templates("community_associations", str(sql_templates_yaml))
-    else:
-        logger.debug("CA sql_templates.yaml not yet available — skipping template registration")
+    # 3. SQL templates — load from catalog (implemented in #365, wired in #426)
+    try:
+        from ai_ready_rag.modules.community_associations.sql_templates.catalog import (
+            TEMPLATE_CATALOG,
+        )
+
+        if TEMPLATE_CATALOG:
+            registry.register_sql_templates("community_associations", TEMPLATE_CATALOG)
+        else:
+            logger.debug("CA TEMPLATE_CATALOG is empty — skipping template registration")
+    except ImportError:
+        logger.debug("CA sql_templates catalog not yet available — skipping template registration")
 
     # 4. Compliance checker (implemented in #363)
     try:
@@ -77,6 +83,4 @@ def register(registry: ModuleRegistry) -> None:
     except ImportError:
         logger.debug("CA API router not yet implemented — skipping")
 
-    logger.info(
-        "Community Associations module registered (partial — pending #357, #363, #365, #373)"
-    )
+    logger.info("Community Associations module registered (partial — pending #357, #363, #373)")

--- a/ai_ready_rag/modules/community_associations/sql_templates/__init__.py
+++ b/ai_ready_rag/modules/community_associations/sql_templates/__init__.py
@@ -1,0 +1,1 @@
+"""SQL template catalog for the Community Associations module."""

--- a/ai_ready_rag/modules/community_associations/sql_templates/catalog.py
+++ b/ai_ready_rag/modules/community_associations/sql_templates/catalog.py
@@ -1,0 +1,52 @@
+"""Community Associations SQL template catalog.
+
+Builds TEMPLATE_CATALOG from the sql_templates.yaml file so the CA module
+register() function can load all templates into the ModuleRegistry at startup.
+
+Usage (in module.py register()):
+    from ai_ready_rag.modules.community_associations.sql_templates.catalog import TEMPLATE_CATALOG
+    registry.register_sql_templates("community_associations", TEMPLATE_CATALOG)
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+
+import yaml
+
+from ai_ready_rag.modules.registry import SQLTemplate
+
+logger = logging.getLogger(__name__)
+
+_YAML_PATH = pathlib.Path(__file__).parent.parent / "sql_templates.yaml"
+
+
+def _load_catalog() -> dict[str, SQLTemplate]:
+    """Parse sql_templates.yaml and return a dict[name, SQLTemplate]."""
+    if not _YAML_PATH.exists():
+        logger.warning("CA sql_templates.yaml not found at %s — catalog will be empty", _YAML_PATH)
+        return {}
+
+    with open(_YAML_PATH) as f:
+        data = yaml.safe_load(f)
+
+    catalog: dict[str, SQLTemplate] = {}
+    for entry in data.get("templates", []):
+        name = entry["name"]
+        sql = entry.get("sql", "").strip()
+        trigger_phrases = entry.get("trigger_phrases", [])
+        description = entry.get("display_name", "")
+        catalog[name] = SQLTemplate(
+            name=name,
+            sql=sql,
+            trigger_phrases=trigger_phrases,
+            description=description,
+        )
+
+    logger.debug("CA sql_templates catalog loaded: %d templates", len(catalog))
+    return catalog
+
+
+# Module-level singleton — loaded once at import time.
+TEMPLATE_CATALOG: dict[str, SQLTemplate] = _load_catalog()


### PR DESCRIPTION
## Summary

- Adds `structured_query_confidence_threshold: float = 0.6` to `Settings` in `config.py` — replaces the silent `getattr` fallback in `factory.get_query_router()` with a first-class field
- Creates `ai_ready_rag/modules/community_associations/sql_templates/catalog.py` which parses `sql_templates.yaml` into `dict[str, SQLTemplate]` with name, sql, trigger_phrases, and description at import time
- Updates CA `module.register()` to call `registry.register_sql_templates("community_associations", TEMPLATE_CATALOG)` so all 12 templates are loaded into the registry at startup

## Acceptance Criteria

- [x] `Settings.structured_query_confidence_threshold` field exists with default `0.6`
- [x] CA module `register()` loads SQL templates into the registry on startup
- [x] `registry.sql_templates` returns 12 template names after startup with CA module active (8 primary + 4 secondary)
- [x] Each template has at least 2 `trigger_phrases` (all have 3–5)

## Test plan

- [x] Existing `test_module_registry.py` (12 tests) — all pass
- [x] Existing `test_query_router.py` (7 tests) — all pass
- [x] Full test suite: 1575 passed, 10 skipped
- [x] Manual smoke: `TEMPLATE_CATALOG` loads 12 templates with trigger_phrases from yaml
- [x] Manual smoke: `registry.register_sql_templates("community_associations", TEMPLATE_CATALOG)` registers all 12

## Dependencies

**Depends on:** #422 (defines canonical `SQLTemplate` shape — merged)
**Blocks:** #424 (QueryRouter wiring needs templates in registry to test against)

🤖 Generated with [Claude Code](https://claude.com/claude-code)