### PR TITLE
feat: Wire QueryRouter into RAGService — SQL-first deterministic routing (#424)

### DIFF
--- a/ai_ready_rag/api/chat.py
+++ b/ai_ready_rag/api/chat.py
@@ -567,6 +567,7 @@ async def send_message(
             settings,
             vector_service=request.app.state.vector_service,
             default_model=chat_model,
+            query_router=getattr(request.app.state, "query_router", None),
         )
         response = await rag_service.generate(rag_request, db)
 

--- a/ai_ready_rag/main.py
+++ b/ai_ready_rag/main.py
@@ -255,10 +255,17 @@ async def lifespan(app: FastAPI):
     finally:
         db.close()
 
+    # Initialize QueryRouter singleton (SQL-first deterministic routing)
+    from ai_ready_rag.services.factory import get_query_router
+
+    query_router = get_query_router()
+    app.state.query_router = query_router
+    logger.info("QueryRouter initialized (SQL-first routing)")
+
     # Initialize and start DB-based WarmingWorker
     from ai_ready_rag.services.rag_service import RAGService
 
-    rag_service = RAGService(settings, vector_service=vector_service)
+    rag_service = RAGService(settings, vector_service=vector_service, query_router=query_router)
     warming_worker = WarmingWorker(rag_service, settings)
     await warming_worker.start()
 

--- a/ai_ready_rag/services/rag_service.py
+++ b/ai_ready_rag/services/rag_service.py
@@ -41,6 +41,7 @@ from ai_ready_rag.services.vector_service import SearchResult
 
 if TYPE_CHECKING:
     from ai_ready_rag.services.protocols import VectorServiceProtocol
+    from ai_ready_rag.services.query_router import QueryRouter, RoutingDecision
 
 logger = logging.getLogger(__name__)
 
@@ -211,7 +212,7 @@ class RAGResponse:
     context_tokens_used: int
     generation_time_ms: float
     grounded: bool  # True iff len(citations) > 0
-    routing_decision: Literal["RETRIEVE", "DIRECT"] | None = None  # Query routing result
+    routing_decision: Literal["RETRIEVE", "DIRECT", "SQL"] | None = None  # Query routing result
 
 
 @dataclass
@@ -936,6 +937,7 @@ class RAGService:
         vector_service: VectorServiceProtocol | None = None,
         cache_service: CacheService | None = None,
         default_model: str | None = None,
+        query_router: QueryRouter | None = None,
     ):
         """Initialize RAG service.
 
@@ -944,6 +946,7 @@ class RAGService:
             vector_service: VectorService instance (uses factory if None for backward compat)
             cache_service: CacheService instance (lazy-created if None)
             default_model: Optional default model override
+            query_router: Optional QueryRouter for SQL-first deterministic routing
         """
         self.settings = settings
         self._vector_service = vector_service
@@ -958,6 +961,8 @@ class RAGService:
         self._cache_service: CacheService | None = cache_service
         # Live evaluation queue (injected post-construction from main.py)
         self._live_eval_queue = None
+        # SQL-first query router (optional — disabled if None)
+        self.query_router: QueryRouter | None = query_router
         # Forms query service (lazy — only if forms DB exists)
         self._forms_query_service = None
         forms_db = getattr(settings, "forms_db_path", None)
@@ -1950,6 +1955,89 @@ class RAGService:
             routing_decision=routing_decision,
         )
 
+    async def _execute_sql_route(
+        self,
+        decision: RoutingDecision,
+        query: str,
+        db: Session,
+        elapsed_ms: float,
+    ) -> RAGResponse:
+        """Execute a SQL-routed structured query and return a formatted RAGResponse.
+
+        Args:
+            decision: Routing decision containing template_name and confidence
+            query: Original user query string
+            db: Database session for executing SQL
+            elapsed_ms: Elapsed time so far (for total latency in response)
+
+        Returns:
+            RAGResponse with SQL-derived answer and routing_decision="SQL"
+        """
+        from sqlalchemy import text as sa_text
+
+        from ai_ready_rag.modules.registry import get_registry
+
+        template_name = decision.template_name
+        registry = get_registry()
+        sql_template = registry.get_sql_template_object(template_name)
+
+        if sql_template is None:
+            # Template disappeared between routing and execution — fall through gracefully
+            logger.warning(
+                "sql_route.template_missing",
+                extra={"template": template_name},
+            )
+            return self._insufficient_context_response(self.default_model, elapsed_ms, "SQL")
+
+        row_cap = getattr(self.settings, "structured_query_row_cap", 100)
+        try:
+            result = db.execute(sa_text(sql_template.sql), {"row_cap": row_cap})
+            rows = result.fetchall()
+            columns = list(result.keys())
+        except Exception as exc:
+            logger.warning(
+                "sql_route.execution_error",
+                extra={"template": template_name, "error": str(exc)},
+            )
+            return self._insufficient_context_response(self.default_model, elapsed_ms, "SQL")
+
+        # Format rows as a human-readable table
+        if not rows:
+            answer = "No matching records found in the database for your query."
+        else:
+            header = " | ".join(columns)
+            separator = "-" * len(header)
+            body_lines = [" | ".join(str(cell) for cell in row) for row in rows[:row_cap]]
+            answer = f"{header}\n{separator}\n" + "\n".join(body_lines)
+
+        logger.info(
+            "sql_route.success",
+            extra={
+                "template": template_name,
+                "rows_returned": len(rows),
+                "confidence": decision.confidence,
+            },
+        )
+
+        return RAGResponse(
+            answer=answer,
+            confidence=ConfidenceScore(
+                overall=100,
+                retrieval_score=decision.confidence,
+                coverage_score=1.0,
+                llm_score=100,
+            ),
+            citations=[],
+            action="CITE",
+            route_to=None,
+            model_used="sql",
+            context_chunks_used=0,
+            context_tokens_used=0,
+            generation_time_ms=elapsed_ms,
+            grounded=True,
+            routing_decision="SQL",
+        )
+
     async def generate(self, request: RAGRequest, db: Session) -> RAGResponse:
         """Generate RAG response for a query.
 
@@ -2051,6 +2139,19 @@ class RAGService:
                     return self._cache_entry_to_response(cached, elapsed_ms)
             except Exception as e:
                 logger.warning(f"Cache lookup failed, proceeding without cache: {e}")
+
+        # 1.4 SQL-first routing (structured queries only — no LLM involved)
+        structured_query_enabled = bool(getattr(self.settings, "structured_query_enabled", False))
+        if self.query_router and structured_query_enabled:
+            from ai_ready_rag.services.query_router import RouteType
+
+            sql_decision = self.query_router.route(
+                query=request.query,
+                structured_query_enabled=True,
+            )
+            if sql_decision.route == RouteType.SQL and sql_decision.template_name:
+                elapsed_ms = (time.perf_counter() - start_time) * 1000
+                return await self._execute_sql_route(sql_decision, request.query, db, elapsed_ms)
 
         # 1.5 Run query router (if retrieve_and_direct mode enabled)
         routing_decision: str | None = None

--- a/tests/test_query_router_integration.py
+++ b/tests/test_query_router_integration.py
@@ -1,0 +1,471 @@
+"""Tests for QueryRouter integration with RAGService.
+
+Tests two acceptance criteria from issue #424:
+1. Unit test: mock registry with one template, assert SQL route taken for matching query
+2. Integration test: assert non-matching query still reaches _run_rag_pipeline
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ai_ready_rag.config import Settings
+from ai_ready_rag.modules.registry import ModuleRegistry, SQLTemplate
+from ai_ready_rag.services.cache_service import CacheService
+from ai_ready_rag.services.query_router import QueryRouter
+from ai_ready_rag.services.rag_service import RAGRequest, RAGService
+from ai_ready_rag.services.vector_service import VectorService
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    """Reset registry singleton between tests."""
+    ModuleRegistry.reset()
+    yield
+    ModuleRegistry.reset()
+
+
+@pytest.fixture
+def mock_settings():
+    """Mock Settings with structured_query_enabled=True."""
+    settings = MagicMock(spec=Settings)
+    settings.ollama_base_url = "http://localhost:11434"
+    settings.chat_model = "llama3.2"
+    settings.rag_temperature = 0.1
+    settings.rag_timeout_seconds = 30
+    settings.rag_confidence_threshold = 60
+    settings.rag_admin_email = "admin@test.com"
+    settings.rag_max_context_tokens = 3000
+    settings.rag_max_history_tokens = 1000
+    settings.rag_max_response_tokens = 1024
+    settings.rag_system_prompt_tokens = 500
+    settings.rag_min_similarity_score = 0.3
+    settings.rag_max_chunks_per_doc = 5
+    settings.rag_total_context_chunks = 8
+    settings.rag_dedup_candidates_cap = 15
+    settings.rag_chunk_overlap_threshold = 0.9
+    settings.rag_enable_query_expansion = False
+    settings.rag_enable_hallucination_check = False
+    settings.forms_db_path = None
+    # Key: structured queries enabled
+    settings.structured_query_enabled = True
+    settings.structured_query_row_cap = 100
+    return settings
+
+
+@pytest.fixture
+def mock_settings_disabled(mock_settings):
+    """Mock Settings with structured_query_enabled=False."""
+    mock_settings.structured_query_enabled = False
+    return mock_settings
+
+
+@pytest.fixture
+def disabled_cache():
+    """A CacheService stub with enabled=False so the cache path is skipped."""
+    cache = MagicMock(spec=CacheService)
+    cache.enabled = False
+    return cache
+
+
+@pytest.fixture
+def router_with_coverage_template():
+    """QueryRouter with a single coverage lookup SQL template registered."""
+    registry = ModuleRegistry.get_instance()
+    registry.register_sql_templates(
+        "test_module",
+        {
+            "coverage_lookup": SQLTemplate(
+                name="coverage_lookup",
+                sql="SELECT name, limit FROM coverages LIMIT :row_cap",
+                trigger_phrases=["coverage", "insurance limit", "what is the coverage"],
+                description="Look up coverage limits",
+            ),
+        },
+    )
+    return QueryRouter(sql_confidence_threshold=0.3)
+
+
+@pytest.fixture
+def mock_db():
+    """Mock database session."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_vector_service():
+    """Mock VectorService."""
+    vs = AsyncMock(spec=VectorService)
+    vs.search = AsyncMock(return_value=[])
+    return vs
+
+
+# =============================================================================
+# Tests: SQL route taken on matching query
+# =============================================================================
+
+
+class TestSQLRouteOnMatch:
+    """Unit test: mock registry with one template, assert SQL route taken for matching query."""
+
+    @pytest.mark.asyncio
+    async def test_sql_route_taken_for_matching_query(
+        self,
+        mock_settings,
+        router_with_coverage_template,
+        mock_db,
+        mock_vector_service,
+        disabled_cache,
+    ):
+        """A query matching a registered SQL template's trigger_phrases returns SQL-derived answer."""
+        # Arrange: mock the DB execution to return sample rows
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [("General Liability", 1000000)]
+        mock_result.keys.return_value = ["name", "limit"]
+        mock_db.execute.return_value = mock_result
+
+        rag_service = RAGService(
+            mock_settings,
+            vector_service=mock_vector_service,
+            cache_service=disabled_cache,
+            query_router=router_with_coverage_template,
+        )
+
+        with (
+            patch(
+                "ai_ready_rag.services.rag_service.check_curated_qa",
+                return_value=None,
+            ),
+            patch(
+                "ai_ready_rag.services.settings_service.SettingsService",
+                autospec=True,
+            ) as MockSettingsService,
+            patch(
+                "ai_ready_rag.services.rag_service.RAGService.validate_model",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "ai_ready_rag.modules.registry.get_registry",
+                return_value=ModuleRegistry.get_instance(),
+            ),
+        ):
+            MockSettingsService.return_value.get.return_value = "retrieve_only"
+
+            request = RAGRequest(
+                query="what is the coverage limit for property?",
+                user_tags=["hr"],
+            )
+            response = await rag_service.generate(request, mock_db)
+
+        # Assert SQL-route taken
+        assert response.routing_decision == "SQL"
+        assert response.model_used == "sql"
+        assert response.action == "CITE"
+        assert response.grounded is True
+        # Answer should contain column headers or row data
+        assert "name" in response.answer or "General Liability" in response.answer
+
+    @pytest.mark.asyncio
+    async def test_sql_route_metadata_records_sql_routing(
+        self,
+        mock_settings,
+        router_with_coverage_template,
+        mock_db,
+        mock_vector_service,
+        disabled_cache,
+    ):
+        """routing_decision is 'SQL' when SQL route is taken."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [("GL", 500000)]
+        mock_result.keys.return_value = ["type", "limit"]
+        mock_db.execute.return_value = mock_result
+
+        rag_service = RAGService(
+            mock_settings,
+            vector_service=mock_vector_service,
+            cache_service=disabled_cache,
+            query_router=router_with_coverage_template,
+        )
+
+        with (
+            patch("ai_ready_rag.services.rag_service.check_curated_qa", return_value=None),
+            patch(
+                "ai_ready_rag.services.settings_service.SettingsService", autospec=True
+            ) as MockSvc,
+            patch(
+                "ai_ready_rag.services.rag_service.RAGService.validate_model",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "ai_ready_rag.modules.registry.get_registry",
+                return_value=ModuleRegistry.get_instance(),
+            ),
+        ):
+            MockSvc.return_value.get.return_value = "retrieve_only"
+
+            request = RAGRequest(
+                query="what is the coverage line?",
+                user_tags=None,
+            )
+            response = await rag_service.generate(request, mock_db)
+
+        assert response.routing_decision == "SQL"
+
+    @pytest.mark.asyncio
+    async def test_row_cap_respected(
+        self,
+        mock_settings,
+        router_with_coverage_template,
+        mock_db,
+        mock_vector_service,
+        disabled_cache,
+    ):
+        """Row cap (structured_query_row_cap) is passed as :row_cap param to SQL execution."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_result.keys.return_value = ["name", "limit"]
+        mock_db.execute.return_value = mock_result
+
+        mock_settings.structured_query_row_cap = 42
+
+        rag_service = RAGService(
+            mock_settings,
+            vector_service=mock_vector_service,
+            cache_service=disabled_cache,
+            query_router=router_with_coverage_template,
+        )
+
+        with (
+            patch("ai_ready_rag.services.rag_service.check_curated_qa", return_value=None),
+            patch(
+                "ai_ready_rag.services.settings_service.SettingsService", autospec=True
+            ) as MockSvc,
+            patch(
+                "ai_ready_rag.services.rag_service.RAGService.validate_model",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "ai_ready_rag.modules.registry.get_registry",
+                return_value=ModuleRegistry.get_instance(),
+            ),
+        ):
+            MockSvc.return_value.get.return_value = "retrieve_only"
+
+            request = RAGRequest(
+                query="what is the coverage limit?",
+                user_tags=[],
+            )
+            await rag_service.generate(request, mock_db)
+
+        # Verify db.execute was called with row_cap=42 in params
+        mock_db.execute.assert_called_once()
+        call_args = mock_db.execute.call_args
+        # Second positional argument is the params dict
+        params = call_args[0][1]
+        assert params.get("row_cap") == 42
+
+
+# =============================================================================
+# Tests: Non-matching query still reaches _run_rag_pipeline
+# =============================================================================
+
+
+class TestRAGFallbackOnNonMatch:
+    """Integration test: non-matching query still reaches _run_rag_pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_non_matching_query_goes_to_rag(
+        self,
+        mock_settings,
+        router_with_coverage_template,
+        mock_db,
+        mock_vector_service,
+        disabled_cache,
+    ):
+        """A query not matching any SQL template continues through _run_rag_pipeline."""
+        rag_service = RAGService(
+            mock_settings,
+            vector_service=mock_vector_service,
+            cache_service=disabled_cache,
+            query_router=router_with_coverage_template,
+        )
+
+        with (
+            patch("ai_ready_rag.services.rag_service.check_curated_qa", return_value=None),
+            patch(
+                "ai_ready_rag.services.settings_service.SettingsService", autospec=True
+            ) as MockSvc,
+            patch(
+                "ai_ready_rag.services.rag_service.RAGService.validate_model",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                rag_service,
+                "_run_rag_pipeline",
+                new_callable=AsyncMock,
+            ) as mock_pipeline,
+        ):
+            MockSvc.return_value.get.return_value = "retrieve_only"
+
+            # Mock _run_rag_pipeline to return a minimal valid response
+            from ai_ready_rag.services.rag_service import ConfidenceScore, RAGResponse
+
+            mock_pipeline.return_value = (
+                RAGResponse(
+                    answer="Board meeting notes...",
+                    confidence=ConfidenceScore(
+                        overall=80, retrieval_score=0.8, coverage_score=0.7, llm_score=80
+                    ),
+                    citations=[],
+                    action="CITE",
+                    route_to=None,
+                    model_used="llama3.2",
+                    context_chunks_used=2,
+                    context_tokens_used=300,
+                    generation_time_ms=100.0,
+                    grounded=False,
+                    routing_decision="RETRIEVE",
+                ),
+                [],
+            )
+
+            request = RAGRequest(
+                query="summarize the board meeting minutes from December",
+                user_tags=["hr"],
+            )
+            response = await rag_service.generate(request, mock_db)
+
+        # Assert _run_rag_pipeline was called (SQL route NOT taken)
+        mock_pipeline.assert_called_once()
+        assert response.routing_decision == "RETRIEVE"
+
+    @pytest.mark.asyncio
+    async def test_disabled_flag_bypasses_sql_router(
+        self,
+        mock_settings_disabled,
+        router_with_coverage_template,
+        mock_db,
+        mock_vector_service,
+        disabled_cache,
+    ):
+        """When structured_query_enabled=False, all queries go to _run_rag_pipeline."""
+        rag_service = RAGService(
+            mock_settings_disabled,
+            vector_service=mock_vector_service,
+            cache_service=disabled_cache,
+            query_router=router_with_coverage_template,
+        )
+
+        with (
+            patch("ai_ready_rag.services.rag_service.check_curated_qa", return_value=None),
+            patch(
+                "ai_ready_rag.services.settings_service.SettingsService", autospec=True
+            ) as MockSvc,
+            patch(
+                "ai_ready_rag.services.rag_service.RAGService.validate_model",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                rag_service,
+                "_run_rag_pipeline",
+                new_callable=AsyncMock,
+            ) as mock_pipeline,
+        ):
+            MockSvc.return_value.get.return_value = "retrieve_only"
+
+            from ai_ready_rag.services.rag_service import ConfidenceScore, RAGResponse
+
+            mock_pipeline.return_value = (
+                RAGResponse(
+                    answer="Coverage is $1M.",
+                    confidence=ConfidenceScore(
+                        overall=80, retrieval_score=0.8, coverage_score=0.7, llm_score=80
+                    ),
+                    citations=[],
+                    action="CITE",
+                    route_to=None,
+                    model_used="llama3.2",
+                    context_chunks_used=1,
+                    context_tokens_used=100,
+                    generation_time_ms=50.0,
+                    grounded=False,
+                    routing_decision="RETRIEVE",
+                ),
+                [],
+            )
+
+            request = RAGRequest(
+                query="what is the coverage limit?",
+                user_tags=["insurance"],
+            )
+            await rag_service.generate(request, mock_db)
+
+        # _run_rag_pipeline should be called even though query matches trigger phrases
+        mock_pipeline.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_query_router_goes_to_rag(
+        self,
+        mock_settings,
+        mock_db,
+        mock_vector_service,
+        disabled_cache,
+    ):
+        """When query_router=None, all queries go to _run_rag_pipeline."""
+        # RAGService without a query_router
+        rag_service = RAGService(
+            mock_settings,
+            vector_service=mock_vector_service,
+            cache_service=disabled_cache,
+            query_router=None,  # Explicit None
+        )
+
+        with (
+            patch("ai_ready_rag.services.rag_service.check_curated_qa", return_value=None),
+            patch(
+                "ai_ready_rag.services.settings_service.SettingsService", autospec=True
+            ) as MockSvc,
+            patch(
+                "ai_ready_rag.services.rag_service.RAGService.validate_model",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                rag_service,
+                "_run_rag_pipeline",
+                new_callable=AsyncMock,
+            ) as mock_pipeline,
+        ):
+            MockSvc.return_value.get.return_value = "retrieve_only"
+
+            from ai_ready_rag.services.rag_service import ConfidenceScore, RAGResponse
+
+            mock_pipeline.return_value = (
+                RAGResponse(
+                    answer="No router, goes to RAG.",
+                    confidence=ConfidenceScore(
+                        overall=70, retrieval_score=0.7, coverage_score=0.6, llm_score=70
+                    ),
+                    citations=[],
+                    action="CITE",
+                    route_to=None,
+                    model_used="llama3.2",
+                    context_chunks_used=1,
+                    context_tokens_used=100,
+                    generation_time_ms=80.0,
+                    grounded=False,
+                    routing_decision="RETRIEVE",
+                ),
+                [],
+            )
+
+            request = RAGRequest(
+                query="what is the coverage limit?",
+                user_tags=[],
+            )
+            await rag_service.generate(request, mock_db)
+
+        mock_pipeline.assert_called_once()


### PR DESCRIPTION
## Summary

- Wires the fully-implemented `QueryRouter` into `RAGService.generate()` so that structured queries matching a registered SQL template are answered from the database instead of going through the Ollama RAG pipeline
- Adds `RAGService._execute_sql_route()` to fetch the SQL template, execute against SQLite with `row_cap` guard, format results as a tabular answer, and return a `RAGResponse` with `routing_decision="SQL"`
- Instantiates `QueryRouter` as a singleton in `main.py` lifespan and injects it via `app.state` into `RAGService` in `api/chat.py`

## Changes

**`ai_ready_rag/services/rag_service.py`**
- `RAGService.__init__`: adds `query_router: QueryRouter | None = None` parameter
- `RAGResponse.routing_decision`: extends `Literal` to include `"SQL"`
- New method `_execute_sql_route()`: executes SQL template, formats tabular response
- `generate()`: inserts SQL-first routing check (step 1.4) after cache lookup, before existing LLM router

**`ai_ready_rag/main.py`**
- Instantiates `QueryRouter` via `get_query_router()` during lifespan, stores on `app.state.query_router`
- Passes `query_router` to `RAGService` used by `WarmingWorker`

**`ai_ready_rag/api/chat.py`**
- Passes `request.app.state.query_router` into per-request `RAGService` construction

**`tests/test_query_router_integration.py`** (new file — 6 tests)
- SQL route taken for matching trigger phrase
- `routing_decision="SQL"` recorded in response
- `structured_query_row_cap` passed as `:row_cap` to SQL execution
- Non-matching query falls through to `_run_rag_pipeline`
- `structured_query_enabled=False` bypasses SQL router entirely
- `query_router=None` falls through to `_run_rag_pipeline`

## Test plan

- [x] All 6 new tests pass (`pytest tests/test_query_router_integration.py -v`)
- [x] Full test suite passes (1577 tests, 0 failures)
- [x] `ruff check` and `ruff format` pass on all changed files
- [x] Prerequisite #422 (registry mismatch fix) is CLOSED

## Acceptance Criteria

- [x] Query matching registered SQL template returns SQL-derived answer
- [x] `ChatMessage` metadata records `routing_decision="SQL"`
- [x] Non-matching query continues through existing Ollama RAG pipeline unchanged
- [x] `settings.structured_query_enabled=False` disables routing — all queries go to RAG
- [x] Row cap is respected (`structured_query_row_cap`)
- [x] Unit test: mock registry with one template, assert SQL route taken
- [x] Integration test: assert non-matching query reaches `_run_rag_pipeline`

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)