### PR TITLE
feat: Full-feature dev environment for local testing

### DIFF
--- a/.env.dev-full
+++ b/.env.dev-full
@@ -1,0 +1,42 @@
+# Full-feature dev environment — postgres + docling + pgvector + CA module
+# Usage: source .env.dev-full  OR  set -a && source .env.dev-full && set +a
+#
+# Requires: docker compose -f docker-compose.dev.yml up -d
+
+# ── Profile ──────────────────────────────────────────────────────────────────
+ENV_PROFILE=laptop
+
+# ── Database (postgres via docker-compose.dev.yml) ───────────────────────────
+DATABASE_URL=postgresql://vaultiq:devpassword@localhost:5432/vaultiq
+DATABASE_BACKEND=postgresql
+
+# ── Vector store ─────────────────────────────────────────────────────────────
+VECTOR_BACKEND=pgvector
+
+# ── Document processing ───────────────────────────────────────────────────────
+CHUNKER_BACKEND=docling
+ENABLE_OCR=false
+
+# ── LLM ──────────────────────────────────────────────────────────────────────
+OLLAMA_BASE_URL=http://localhost:11434
+CHAT_MODEL=qwen3:8b
+EMBEDDING_MODEL=nomic-embed-text
+
+# ── Feature flags (profile overrides) ────────────────────────────────────────
+DEPLOYMENT_TIER=standard
+STRUCTURED_QUERY_ENABLED=true
+CLAUDE_ENRICHMENT_ENABLED=false   # Set to true after providing ANTHROPIC_API_KEY
+
+# ── Claude API (fill in when ready) ──────────────────────────────────────────
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# ── Auth ──────────────────────────────────────────────────────────────────────
+JWT_SECRET_KEY=dev-secret-key-change-in-production
+
+# ── PII encryption (CA module — ca_unit_owners table) ────────────────────────
+# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# Leave unset to skip PII column encryption in dev.
+# VAULTIQ_ENCRYPTION_KEY=
+
+# ── Tenant ────────────────────────────────────────────────────────────────────
+TENANT_ID=default

--- a/alembic/versions/004_ca_module_tables.py
+++ b/alembic/versions/004_ca_module_tables.py
@@ -1,0 +1,121 @@
+"""Create Community Associations module tables.
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-02-28
+
+Creates:
+- insurance_accounts     — HOA / condo property accounts
+- insurance_policies     — Insurance policies linked to an account
+- insurance_coverages    — Individual coverage lines for a policy
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "004"
+down_revision: str | None = "003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "insurance_accounts",
+        sa.Column("id", sa.String, primary_key=True),
+        sa.Column("account_name", sa.String, nullable=False),
+        sa.Column("account_type", sa.String, nullable=True),
+        sa.Column("property_address", sa.String, nullable=True),
+        sa.Column("city", sa.String, nullable=True),
+        sa.Column("state", sa.String, nullable=True),
+        sa.Column("zip_code", sa.String, nullable=True),
+        sa.Column("units_residential", sa.Integer, nullable=True),
+        sa.Column("units_commercial", sa.Integer, nullable=True),
+        sa.Column("year_built", sa.Integer, nullable=True),
+        sa.Column("source_document_id", sa.String, nullable=True),
+        sa.Column("extraction_confidence", sa.Float, nullable=True),
+        sa.Column("custom_fields", sa.Text, nullable=True),
+        sa.Column("tenant_id", sa.String, nullable=False),
+        sa.Column("valid_from", sa.DateTime, nullable=True),
+        sa.Column("valid_to", sa.DateTime, nullable=True),
+        sa.Column("is_deleted", sa.Boolean, default=False),
+        sa.Column("deleted_at", sa.DateTime, nullable=True),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime, server_default=sa.func.now()),
+    )
+    op.create_index("ix_insurance_accounts_tenant_id", "insurance_accounts", ["tenant_id"])
+    op.create_index("ix_insurance_accounts_account_name", "insurance_accounts", ["account_name"])
+
+    op.create_table(
+        "insurance_policies",
+        sa.Column("id", sa.String, primary_key=True),
+        sa.Column(
+            "account_id",
+            sa.String,
+            sa.ForeignKey("insurance_accounts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("policy_number", sa.String, nullable=True),
+        sa.Column("carrier_name", sa.String, nullable=True),
+        sa.Column("broker_name", sa.String, nullable=True),
+        sa.Column("line_of_business", sa.String, nullable=False),
+        sa.Column("policy_status", sa.String, server_default="active"),
+        sa.Column("inception_date", sa.DateTime, nullable=True),
+        sa.Column("effective_date", sa.DateTime, nullable=True),
+        sa.Column("expiration_date", sa.DateTime, nullable=True),
+        sa.Column("premium_amount", sa.Float, nullable=True),
+        sa.Column("source_document_id", sa.String, nullable=True),
+        sa.Column("idempotency_key", sa.String, nullable=True, unique=True),
+        sa.Column("is_active", sa.Boolean, default=True),
+        sa.Column("tenant_id", sa.String, nullable=False),
+        sa.Column("valid_from", sa.DateTime, nullable=True),
+        sa.Column("valid_to", sa.DateTime, nullable=True),
+        sa.Column("is_deleted", sa.Boolean, default=False),
+        sa.Column("deleted_at", sa.DateTime, nullable=True),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime, server_default=sa.func.now()),
+    )
+    op.create_index("ix_insurance_policies_account_id", "insurance_policies", ["account_id"])
+    op.create_index("ix_insurance_policies_tenant_id", "insurance_policies", ["tenant_id"])
+
+    op.create_table(
+        "insurance_coverages",
+        sa.Column("id", sa.String, primary_key=True),
+        sa.Column(
+            "policy_id",
+            sa.String,
+            sa.ForeignKey("insurance_policies.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "account_id",
+            sa.String,
+            sa.ForeignKey("insurance_accounts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("coverage_type", sa.String, nullable=False),
+        sa.Column("limit_amount", sa.Float, nullable=True),
+        sa.Column("deductible_amount", sa.Float, nullable=True),
+        sa.Column("deductible_type", sa.String, nullable=True),
+        sa.Column("sublimit_type", sa.String, nullable=True),
+        sa.Column("sublimit_amount", sa.Float, nullable=True),
+        sa.Column("notes", sa.Text, nullable=True),
+        sa.Column("tenant_id", sa.String, nullable=False),
+        sa.Column("is_deleted", sa.Boolean, default=False),
+        sa.Column("deleted_at", sa.DateTime, nullable=True),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+    )
+    op.create_index("ix_insurance_coverages_policy_id", "insurance_coverages", ["policy_id"])
+    op.create_index("ix_insurance_coverages_account_id", "insurance_coverages", ["account_id"])
+    op.create_index("ix_insurance_coverages_tenant_id", "insurance_coverages", ["tenant_id"])
+    op.create_index(
+        "ix_insurance_coverages_coverage_type", "insurance_coverages", ["coverage_type"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("insurance_coverages")
+    op.drop_table("insurance_policies")
+    op.drop_table("insurance_accounts")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,43 @@
+# Dev-only Docker Compose — starts infrastructure dependencies only.
+# The app runs natively via uvicorn (not in Docker) for fast iteration.
+#
+# Usage:
+#   docker compose -f docker-compose.dev.yml up -d
+#   source .env.dev-full && alembic upgrade head
+#   source .env.dev-full && python -m uvicorn ai_ready_rag.main:app --host 0.0.0.0 --port 8502
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: vaultiq-dev-postgres
+    restart: unless-stopped
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_DB=vaultiq
+      - POSTGRES_USER=vaultiq
+      - POSTGRES_PASSWORD=devpassword
+    volumes:
+      - dev_postgres_data:/var/lib/postgresql/data
+      - ./scripts/init-pgvector.sql:/docker-entrypoint-initdb.d/init-pgvector.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U vaultiq -d vaultiq"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
+  redis:
+    image: redis:7-alpine
+    container_name: vaultiq-dev-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  dev_postgres_data:

--- a/scripts/start-dev-full.sh
+++ b/scripts/start-dev-full.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# start-dev-full.sh — Full-feature dev environment startup
+# Starts postgres+redis via Docker, runs Alembic migrations, then launches the app.
+#
+# Usage:
+#   bash scripts/start-dev-full.sh
+#   bash scripts/start-dev-full.sh --reset   # drop & recreate postgres volume
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_DIR"
+
+# ── Parse args ────────────────────────────────────────────────────────────────
+RESET=false
+for arg in "$@"; do
+  case $arg in
+    --reset) RESET=true ;;
+  esac
+done
+
+# ── Load env ──────────────────────────────────────────────────────────────────
+if [ ! -f ".env.dev-full" ]; then
+  echo "ERROR: .env.dev-full not found. Run from project root."
+  exit 1
+fi
+set -a && source .env.dev-full && set +a
+echo "✓ Loaded .env.dev-full"
+
+# ── Docker infrastructure ─────────────────────────────────────────────────────
+if [ "$RESET" = true ]; then
+  echo "⚠  Resetting postgres volume..."
+  docker compose -f docker-compose.dev.yml down -v 2>/dev/null || true
+fi
+
+echo "▶ Starting postgres + redis..."
+docker compose -f docker-compose.dev.yml up -d
+
+echo "⏳ Waiting for postgres to be healthy..."
+ATTEMPTS=0
+until docker exec vaultiq-dev-postgres pg_isready -U vaultiq -d vaultiq -q 2>/dev/null; do
+  ATTEMPTS=$((ATTEMPTS+1))
+  if [ "$ATTEMPTS" -ge 30 ]; then
+    echo "ERROR: postgres did not become healthy in time."
+    exit 1
+  fi
+  sleep 1
+done
+echo "✓ Postgres ready"
+
+# ── Activate venv ─────────────────────────────────────────────────────────────
+if [ -f ".venv/bin/activate" ]; then
+  source .venv/bin/activate
+  echo "✓ Virtual environment activated"
+fi
+
+# ── Tenant config ─────────────────────────────────────────────────────────────
+TENANT_DIR="tenant-instances/default"
+TENANT_TEMPLATE="tenant-instances/tenant.dev-default.json"
+if [ ! -f "$TENANT_DIR/tenant.json" ]; then
+  mkdir -p "$TENANT_DIR"
+  cp "$TENANT_TEMPLATE" "$TENANT_DIR/tenant.json"
+  echo "✓ Created $TENANT_DIR/tenant.json from template"
+fi
+
+# ── Alembic migrations ────────────────────────────────────────────────────────
+echo "▶ Running Alembic migrations..."
+alembic upgrade head
+echo "✓ Migrations complete"
+
+# ── Launch app ────────────────────────────────────────────────────────────────
+echo ""
+echo "═══════════════════════════════════════════════════"
+echo "  VaultIQ Dev — Full Feature Mode"
+echo "  Backend:  http://localhost:8502"
+echo "  Swagger:  http://localhost:8502/api/docs"
+echo "  Postgres: localhost:5432 (vaultiq/devpassword)"
+echo "  CA module: ENABLED (tenant-instances/default/tenant.json)"
+echo "  Claude:   DISABLED (set ANTHROPIC_API_KEY to enable)"
+echo "═══════════════════════════════════════════════════"
+echo ""
+
+python -m uvicorn ai_ready_rag.main:app --host 0.0.0.0 --port 8502 --reload

--- a/tenant-instances/tenant.dev-default.json
+++ b/tenant-instances/tenant.dev-default.json
@@ -1,0 +1,19 @@
+{
+  "tenant_id": "default",
+  "tenant_name": "VaultIQ Dev",
+  "feature_flags": {
+    "ca_enabled": true,
+    "claude_enrichment_enabled": false,
+    "structured_query_enabled": true,
+    "claude_query_enabled": false
+  },
+  "ai_models": {
+    "enrichment_model": "claude-haiku-4-5-20251001",
+    "query_model": "claude-sonnet-4-6",
+    "synopsis_model": "claude-sonnet-4-6"
+  },
+  "cost_controls": {
+    "daily_enrichment_cap_usd": 5.0,
+    "monthly_enrichment_cap_usd": 50.0
+  }
+}


### PR DESCRIPTION
## Summary

- **`docker-compose.dev.yml`** — starts postgres+pgvector and redis only; app runs natively for \`--reload\` iteration
- **\`.env.dev-full\`** — activates postgres, docling, pgvector, structured query routing; \`ANTHROPIC_API_KEY\` left unset until user provides it
- **\`tenant-instances/tenant.dev-default.json\`** — \`ca_enabled=true\`, \`structured_query_enabled=true\`
- **\`scripts/start-dev-full.sh\`** — single-command startup: docker deps → alembic migrations → uvicorn
- **\`alembic/versions/004_ca_module_tables.py\`** — creates \`insurance_accounts\`, \`insurance_policies\`, \`insurance_coverages\` tables (CA models used a separate \`CABase\` invisible to Alembic)

## Usage

\`\`\`bash
bash scripts/start-dev-full.sh
# App at http://localhost:8502 | Swagger at http://localhost:8502/api/docs
# First run: --reset flag drops and recreates the postgres volume
\`\`\`

## To enable Claude enrichment (after providing API key)
\`\`\`bash
# In .env.dev-full:
ANTHROPIC_API_KEY=sk-ant-...
CLAUDE_ENRICHMENT_ENABLED=true

# In tenant-instances/default/tenant.json:
"claude_enrichment_enabled": true
\`\`\`

## Test plan
- [ ] docker compose up starts cleanly
- [ ] alembic upgrade head runs all 4 migrations
- [ ] App starts, /api/health returns OK
- [ ] Document upload + ingestion via Docling works
- [ ] Chat query routes through QueryRouter then RAG fallback
- [ ] GET /api/ca/accounts returns 200 (ca_enabled=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)