### PR TITLE
feat: Add ClaudeCliEnrichmentBackend — use claude -p subprocess (#435)

### DIFF
--- a/.env.dev-full
+++ b/.env.dev-full
@@ -27,6 +27,9 @@ DEPLOYMENT_TIER=standard
 STRUCTURED_QUERY_ENABLED=true
 CLAUDE_ENRICHMENT_ENABLED=false   # Set to true after providing ANTHROPIC_API_KEY
 
+# ── Claude backend (cli = use claude -p subprocess; api = Anthropic HTTP API)
+CLAUDE_BACKEND=cli
+
 # ── Claude API (fill in when ready) ──────────────────────────────────────────
 # ANTHROPIC_API_KEY=sk-ant-...
 

--- a/ai_ready_rag/config.py
+++ b/ai_ready_rag/config.py
@@ -395,6 +395,8 @@ class Settings(BaseSettings):
     claude_enrichment_max_retries: int = 3
     claude_enrichment_timeout: int = 60
     claude_enrichment_cost_limit_usd: float = 10.0  # daily cap
+    # Enrichment backend: "api" = Anthropic HTTP API, "cli" = claude -p subprocess (#435)
+    claude_backend: Literal["api", "cli"] = "api"
 
     # ---------------------------------------------------------------------------
     # Claude Query (Standard tier primary) — Issue #374

--- a/ai_ready_rag/services/enrichment_cli_backend.py
+++ b/ai_ready_rag/services/enrichment_cli_backend.py
@@ -1,0 +1,130 @@
+"""ClaudeCliEnrichmentBackend — call claude -p subprocess instead of Anthropic HTTP API.
+
+Allows full enrichment pipeline testing using an existing Claude Code login session
+with no API key required.
+
+Usage: set CLAUDE_BACKEND=cli (and CLAUDE_ENRICHMENT_ENABLED=true)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+
+from ai_ready_rag.services.enrichment_service import (
+    ENTITY_EXTRACTION_PROMPT,
+    SYNOPSIS_SYSTEM_PROMPT,
+)
+
+logger = logging.getLogger(__name__)
+
+_SUBPROCESS_TIMEOUT = 120  # seconds
+
+
+def _strip_markdown_fences(text: str) -> str:
+    """Remove leading/trailing markdown code fences from text.
+
+    Handles:
+    - ```json\\n...\\n```
+    - ```\\n...\\n```
+    """
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        # Remove opening fence (```json or ```)
+        first_newline = stripped.find("\n")
+        if first_newline != -1:
+            stripped = stripped[first_newline + 1 :]
+        # Remove closing fence
+        if stripped.endswith("```"):
+            stripped = stripped[: stripped.rfind("```")].rstrip()
+    return stripped
+
+
+class ClaudeCliEnrichmentBackend:
+    """Enrichment backend that shells out to the claude CLI.
+
+    Both methods are synchronous (subprocess is blocking). Callers in
+    ClaudeEnrichmentService wrap them with asyncio.to_thread.
+    """
+
+    def call_synopsis(self, document_text: str, tenant_id: str = "default") -> str:
+        """Call claude -p with the synopsis prompt and return stdout.
+
+        Args:
+            document_text: Full document text (truncated to 100k chars internally).
+            tenant_id: Tenant identifier (unused by subprocess backend, kept for interface parity).
+
+        Returns:
+            Synopsis text string (stdout from claude -p, stripped).
+
+        Raises:
+            RuntimeError: If subprocess exits with non-zero code or times out.
+        """
+        text = document_text[:100_000]
+        prompt = f"{SYNOPSIS_SYSTEM_PROMPT}\n\nDocument text:\n\n{text}"
+
+        logger.debug("enrichment_cli.synopsis.start", extra={"tenant_id": tenant_id})
+        result = subprocess.run(  # noqa: S603
+            ["claude", "-p", prompt],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"claude -p exited with code {result.returncode}: {result.stderr.strip()}"
+            )
+
+        synopsis = result.stdout.strip()
+        logger.debug(
+            "enrichment_cli.synopsis.done",
+            extra={"tenant_id": tenant_id, "chars": len(synopsis)},
+        )
+        return synopsis
+
+    def call_entity_extraction(self, synopsis: str, chunk_text: str) -> list[dict]:
+        """Call claude -p for entity extraction and parse JSON from stdout.
+
+        Args:
+            synopsis: Document synopsis text (truncated to 1000 chars internally).
+            chunk_text: Concatenated chunk text to extract entities from.
+
+        Returns:
+            List of entity dicts parsed from stdout. Returns [] on parse errors.
+
+        Raises:
+            RuntimeError: If subprocess exits with non-zero code or times out.
+        """
+        prompt = (
+            f"{ENTITY_EXTRACTION_PROMPT}\n\nSynopsis:\n{synopsis[:1000]}\n\nChunks:\n{chunk_text}"
+        )
+
+        logger.debug("enrichment_cli.entity_extraction.start")
+        result = subprocess.run(  # noqa: S603
+            ["claude", "-p", prompt],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"claude -p exited with code {result.returncode}: {result.stderr.strip()}"
+            )
+
+        raw = _strip_markdown_fences(result.stdout)
+        try:
+            items = json.loads(raw)
+            if not isinstance(items, list):
+                logger.warning("enrichment_cli.entity_extraction.non_list_response")
+                return []
+            # Filter out non-dict items defensively
+            return [item for item in items if isinstance(item, dict)]
+        except json.JSONDecodeError:
+            logger.warning(
+                "enrichment_cli.entity_extraction.json_parse_error",
+                extra={"raw_preview": raw[:200]},
+            )
+            return []

--- a/ai_ready_rag/services/enrichment_service.py
+++ b/ai_ready_rag/services/enrichment_service.py
@@ -13,12 +13,16 @@ No-op on sqlite profile — Ollama/RAG path is unaffected.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ai_ready_rag.services.cost_tracker import CostTracker
 from ai_ready_rag.tenant.resolver import PromptResolver
+
+if TYPE_CHECKING:
+    from ai_ready_rag.services.enrichment_cli_backend import ClaudeCliEnrichmentBackend
 
 logger = logging.getLogger(__name__)
 
@@ -82,19 +86,33 @@ class ClaudeEnrichmentService:
         self._synopsis_prompt = resolver.resolve("enrichment_synopsis") or SYNOPSIS_SYSTEM_PROMPT
         self._entity_prompt = resolver.resolve("enrichment_entities") or ENTITY_EXTRACTION_PROMPT
 
+        # Wire in CLI backend when CLAUDE_BACKEND=cli
+        self._cli_backend: ClaudeCliEnrichmentBackend | None = None
+        if getattr(settings, "claude_backend", "api") == "cli":
+            from ai_ready_rag.services.enrichment_cli_backend import ClaudeCliEnrichmentBackend
+
+            self._cli_backend = ClaudeCliEnrichmentBackend()
+
     def _is_enabled(self) -> bool:
         """Return True only when Claude enrichment is explicitly enabled.
 
         When tenant_config is provided, TenantConfig.feature_flags.claude_enrichment_enabled
         takes precedence over Settings.claude_enrichment_enabled. A TenantConfig flag of False
         disables enrichment even if Settings has it True.
+
+        When claude_backend == "cli", the API key check is skipped (CLI uses the local
+        Claude Code session instead of ANTHROPIC_API_KEY).
         """
-        api_key = getattr(self._settings, "claude_api_key", None)
         database_backend = getattr(self._settings, "database_backend", "sqlite")
         if database_backend == "sqlite":
             return False
-        if not api_key:
-            return False
+
+        claude_backend = getattr(self._settings, "claude_backend", "api")
+        if claude_backend != "cli":
+            # API backend requires an API key
+            api_key = getattr(self._settings, "claude_api_key", None)
+            if not api_key:
+                return False
 
         # Check TenantConfig feature flag first (overrides global settings)
         if self._tenant_config is not None:
@@ -210,9 +228,31 @@ class ClaudeEnrichmentService:
         return getattr(self._settings, "claude_enrichment_model", "claude-sonnet-4-6")
 
     async def _call_synopsis(self, document_id: str, document_text: str) -> SynopsisResult:
-        """Call claude-sonnet-4-6 for document synopsis with prompt caching."""
+        """Call Claude for document synopsis.
+
+        Delegates to the CLI backend when claude_backend == "cli", otherwise
+        uses the Anthropic HTTP API with prompt caching.
+        """
         import json
 
+        # --- CLI backend path ---
+        if self._cli_backend is not None:
+            content = await asyncio.to_thread(
+                self._cli_backend.call_synopsis, document_text, "default"
+            )
+            try:
+                parsed = json.loads(content)
+            except json.JSONDecodeError:
+                parsed = {"raw": content}
+            return SynopsisResult(
+                synopsis_text=content,
+                model_id="claude-cli",
+                token_cost=0,
+                cost_usd=0.0,
+                raw_json=parsed,
+            )
+
+        # --- API backend path (unchanged) ---
         client = self._get_client()
         model = self._get_enrichment_model()
         timeout = getattr(self._settings, "claude_enrichment_timeout", 60)
@@ -260,17 +300,14 @@ class ClaudeEnrichmentService:
         synopsis: SynopsisResult,
         chunks: list[dict[str, Any]],
     ) -> list[EntityResult]:
-        """Call claude-haiku for entity extraction on chunk batches."""
+        """Call Claude for entity extraction on chunk batches.
+
+        Delegates to the CLI backend when claude_backend == "cli", otherwise
+        uses the Anthropic HTTP API (haiku model, batched).
+        """
         import json
 
-        client = self._get_client()
-        simple_model = getattr(
-            self._settings,
-            "claude_query_model_simple",
-            "claude-haiku-4-5-20251001",
-        )
         batch_size = getattr(self._settings, "claude_enrichment_batch_size", 8)
-
         all_entities: list[EntityResult] = []
 
         for batch_start in range(0, len(chunks), batch_size):
@@ -280,26 +317,39 @@ class ClaudeEnrichmentService:
                 for i, c in enumerate(batch)
             )
 
-            prompt = f"Synopsis:\n{synopsis.synopsis_text[:1000]}\n\nChunks:\n{batch_text}"
-
-            message = client.messages.create(
-                model=simple_model,
-                max_tokens=1024,
-                messages=[
-                    {
-                        "role": "user",
-                        "content": self._entity_prompt + "\n\n" + prompt,
-                    }
-                ],
-            )
-
-            content = message.content[0].text if message.content else "[]"
-            try:
-                items = json.loads(content)
-                if not isinstance(items, list):
+            # --- CLI backend path ---
+            if self._cli_backend is not None:
+                items = await asyncio.to_thread(
+                    self._cli_backend.call_entity_extraction,
+                    synopsis.synopsis_text,
+                    batch_text,
+                )
+            else:
+                # --- API backend path (unchanged) ---
+                client = self._get_client()
+                simple_model = getattr(
+                    self._settings,
+                    "claude_query_model_simple",
+                    "claude-haiku-4-5-20251001",
+                )
+                prompt = f"Synopsis:\n{synopsis.synopsis_text[:1000]}\n\nChunks:\n{batch_text}"
+                message = client.messages.create(
+                    model=simple_model,
+                    max_tokens=1024,
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": self._entity_prompt + "\n\n" + prompt,
+                        }
+                    ],
+                )
+                content = message.content[0].text if message.content else "[]"
+                try:
+                    items = json.loads(content)
+                    if not isinstance(items, list):
+                        items = []
+                except json.JSONDecodeError:
                     items = []
-            except json.JSONDecodeError:
-                items = []
 
             for item in items:
                 if not isinstance(item, dict):

--- a/tenant-instances/tenant.dev-default.json
+++ b/tenant-instances/tenant.dev-default.json
@@ -3,7 +3,7 @@
   "tenant_name": "VaultIQ Dev",
   "feature_flags": {
     "ca_enabled": true,
-    "claude_enrichment_enabled": false,
+    "claude_enrichment_enabled": true,
     "structured_query_enabled": true,
     "claude_query_enabled": false
   },

--- a/tests/test_enrichment_cli_backend.py
+++ b/tests/test_enrichment_cli_backend.py
@@ -1,0 +1,249 @@
+"""Tests for ClaudeCliEnrichmentBackend and CLI-mode wiring in ClaudeEnrichmentService.
+
+All tests mock subprocess.run — no actual claude binary required.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_proc(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    """Return a mock CompletedProcess-like object."""
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = stdout
+    proc.stderr = stderr
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# TestClaudeCliEnrichmentBackendSynopsis
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCliEnrichmentBackendSynopsis:
+    def test_call_synopsis_returns_stdout(self):
+        from ai_ready_rag.services.enrichment_cli_backend import ClaudeCliEnrichmentBackend
+
+        backend = ClaudeCliEnrichmentBackend()
+        with patch("subprocess.run", return_value=_make_proc(0, "synopsis text")) as mock_run:
+            result = backend.call_synopsis("doc text", "default")
+        assert result == "synopsis text"
+        mock_run.assert_called_once()
+
+    def test_call_synopsis_raises_on_nonzero_exit(self):
+        from ai_ready_rag.services.enrichment_cli_backend import ClaudeCliEnrichmentBackend
+
+        backend = ClaudeCliEnrichmentBackend()
+        with patch("subprocess.run", return_value=_make_proc(1, "", "bad error")):
+            with pytest.raises(RuntimeError, match="bad error"):
+                backend.call_synopsis("doc text", "default")
+
+    def test_call_synopsis_passes_timeout_120(self):
+        from ai_ready_rag.services.enrichment_cli_backend import ClaudeCliEnrichmentBackend
+
+        backend = ClaudeCliEnrichmentBackend()
+        with patch("subprocess.run", return_value=_make_proc(0, "ok")) as mock_run:
+            backend.call_synopsis("doc text", "default")
+        _, kwargs = mock_run.call_args
+        assert kwargs.get("timeout") == 120
+
+    def test_call_synopsis_strips_leading_trailing_whitespace(self):
+        from ai_ready_rag.services.enrichment_cli_backend import ClaudeCliEnrichmentBackend
+
+        backend = ClaudeCliEnrichmentBackend()
+        with patch("subprocess.run", return_value=_make_proc(0, "\n  synopsis text  \n")):
+            result = backend.call_synopsis("doc text", "default")
+        assert result == "synopsis text"
+
+    def test_call_synopsis_includes_exit_code_in_error(self):
+        from ai_ready_rag.services.enrichment_cli_backend import ClaudeCliEnrichmentBackend
+
+        backend = ClaudeCliEnrichmentBackend()
+        with patch("subprocess.run", return_value=_make_proc(2, "", "some err")):
+            with pytest.raises(RuntimeError, match="exited with code 2"):
+                backend.call_synopsis("doc", "default")
+
+
+# ---------------------------------------------------------------------------
+# TestClaudeCliEnrichmentBackendEntityExtraction
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCliEnrichmentBackendEntityExtraction:
+    def test_call_entity_extraction_parses_valid_json_array(self):
+        from ai_ready_rag.services.enrichment_cli_backend import ClaudeCliEnrichmentBackend
+
+        backend = ClaudeCliEnrichmentBackend()
+        json_out = '[{"entity_type":"carrier","value":"Acme","confidence":0.9,"chunk_index":0}]'
+        with patch("subprocess.run", return_value=_make_proc(0, json_out)):
+            result = backend.call_entity_extraction("synopsis", "chunk text")
+        assert len(result) == 1
+        assert result[0]["entity_type"] == "carrier"
+        assert result[0]["value"] == "Acme"
+
+    def test_call_entity_extraction_strips_json_fences(self):
+        from ai_ready_rag.services.enrichment_cli_backend import ClaudeCliEnrichmentBackend
+
+        backend = ClaudeCliEnrichmentBackend()
+        fenced = '```json\n[{"entity_type":"x","value":"y"}]\n```'
+        with patch("subprocess.run", return_value=_make_proc(0, fenced)):
+            result = backend.call_entity_extraction("synopsis", "chunk")
+        assert len(result) == 1
+        assert result[0]["value"] == "y"
+
+    def test_call_entity_extraction_strips_plain_fences(self):
+        from ai_ready_rag.services.enrichment_cli_backend import ClaudeCliEnrichmentBackend
+
+        backend = ClaudeCliEnrichmentBackend()
+        fenced = "```\n[]\n```"
+        with patch("subprocess.run", return_value=_make_proc(0, fenced)):
+            result = backend.call_entity_extraction("synopsis", "chunk")
+        assert result == []
+
+    def test_call_entity_extraction_returns_empty_on_bad_json(self):
+        from ai_ready_rag.services.enrichment_cli_backend import ClaudeCliEnrichmentBackend
+
+        backend = ClaudeCliEnrichmentBackend()
+        with patch("subprocess.run", return_value=_make_proc(0, "not valid json")):
+            result = backend.call_entity_extraction("synopsis", "chunk")
+        assert result == []
+
+    def test_call_entity_extraction_raises_on_nonzero_exit(self):
+        from ai_ready_rag.services.enrichment_cli_backend import ClaudeCliEnrichmentBackend
+
+        backend = ClaudeCliEnrichmentBackend()
+        with patch("subprocess.run", return_value=_make_proc(1, "", "subprocess err")):
+            with pytest.raises(RuntimeError, match="subprocess err"):
+                backend.call_entity_extraction("synopsis", "chunk")
+
+    def test_call_entity_extraction_ignores_non_dict_items(self):
+        from ai_ready_rag.services.enrichment_cli_backend import ClaudeCliEnrichmentBackend
+
+        backend = ClaudeCliEnrichmentBackend()
+        mixed = '[42, "string", {"entity_type":"x","value":"y"}]'
+        with patch("subprocess.run", return_value=_make_proc(0, mixed)):
+            result = backend.call_entity_extraction("synopsis", "chunk")
+        assert len(result) == 1
+        assert result[0]["entity_type"] == "x"
+
+    def test_call_entity_extraction_returns_empty_on_non_list_json(self):
+        from ai_ready_rag.services.enrichment_cli_backend import ClaudeCliEnrichmentBackend
+
+        backend = ClaudeCliEnrichmentBackend()
+        with patch("subprocess.run", return_value=_make_proc(0, '{"key": "value"}')):
+            result = backend.call_entity_extraction("synopsis", "chunk")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# TestClaudeEnrichmentServiceCliMode
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeEnrichmentServiceCliMode:
+    def _make_settings(
+        self,
+        *,
+        claude_backend: str = "api",
+        database_backend: str = "postgresql",
+        claude_enrichment_enabled: bool = True,
+        claude_api_key: str | None = None,
+    ) -> MagicMock:
+        settings = MagicMock()
+        settings.claude_backend = claude_backend
+        settings.database_backend = database_backend
+        settings.claude_enrichment_enabled = claude_enrichment_enabled
+        settings.claude_api_key = claude_api_key
+        return settings
+
+    def test_is_enabled_cli_backend_no_api_key(self):
+        """CLI backend allows enrichment without an API key."""
+        from ai_ready_rag.services.enrichment_service import ClaudeEnrichmentService
+
+        settings = self._make_settings(claude_backend="cli", claude_api_key=None)
+        svc = ClaudeEnrichmentService(settings)
+        assert svc._is_enabled() is True
+
+    def test_is_enabled_cli_backend_sqlite_still_disabled(self):
+        """SQLite backend always disables enrichment regardless of claude_backend."""
+        from ai_ready_rag.services.enrichment_service import ClaudeEnrichmentService
+
+        settings = self._make_settings(claude_backend="cli", database_backend="sqlite")
+        svc = ClaudeEnrichmentService(settings)
+        assert svc._is_enabled() is False
+
+    def test_cli_backend_instantiated_when_setting_is_cli(self):
+        """_cli_backend is set when claude_backend == 'cli'."""
+        from ai_ready_rag.services.enrichment_cli_backend import ClaudeCliEnrichmentBackend
+        from ai_ready_rag.services.enrichment_service import ClaudeEnrichmentService
+
+        settings = self._make_settings(claude_backend="cli")
+        svc = ClaudeEnrichmentService(settings)
+        assert svc._cli_backend is not None
+        assert isinstance(svc._cli_backend, ClaudeCliEnrichmentBackend)
+
+    def test_api_backend_not_instantiated_when_setting_is_api(self):
+        """_cli_backend is None when claude_backend == 'api' (default)."""
+        from ai_ready_rag.services.enrichment_service import ClaudeEnrichmentService
+
+        settings = self._make_settings(claude_backend="api", claude_api_key="sk-ant-test")
+        svc = ClaudeEnrichmentService(settings)
+        assert svc._cli_backend is None
+
+    def test_api_backend_default_still_requires_api_key(self):
+        """Default api backend still requires api_key for _is_enabled()."""
+        from ai_ready_rag.services.enrichment_service import ClaudeEnrichmentService
+
+        settings = self._make_settings(claude_backend="api", claude_api_key=None)
+        svc = ClaudeEnrichmentService(settings)
+        assert svc._is_enabled() is False
+
+    @pytest.mark.asyncio
+    async def test_enrich_document_uses_cli_backend_when_configured(self):
+        """Full pipeline calls subprocess when claude_backend == 'cli'."""
+        from unittest.mock import AsyncMock
+
+        from ai_ready_rag.services.enrichment_service import (
+            ClaudeEnrichmentService,
+            EntityResult,
+            SynopsisResult,
+        )
+
+        settings = self._make_settings(claude_backend="cli")
+        svc = ClaudeEnrichmentService(settings)
+
+        # Patch the _call_synopsis / _call_entity_extraction instead of subprocess
+        # to keep this test at the service boundary
+        mock_synopsis = SynopsisResult(
+            synopsis_text='{"document_type":"policy"}',
+            model_id="claude-cli",
+            token_cost=0,
+            cost_usd=0.0,
+            raw_json={"document_type": "policy"},
+        )
+        mock_entities = [
+            EntityResult(
+                entity_type="carrier",
+                value="Acme",
+                canonical_value=None,
+                confidence=0.9,
+                source_chunk_index=0,
+            )
+        ]
+
+        svc._call_synopsis = AsyncMock(return_value=mock_synopsis)
+        svc._call_entity_extraction = AsyncMock(return_value=mock_entities)
+
+        result = await svc.enrich_document("doc-cli-1", "document text", [])
+
+        assert result["document_id"] == "doc-cli-1"
+        assert result["enrichment_model"] == "claude-cli"
+        assert result["cost_usd"] == 0.0
+        svc._call_synopsis.assert_called_once()
+        svc._call_entity_extraction.assert_called_once()


### PR DESCRIPTION
## Summary

- Adds `ClaudeCliEnrichmentBackend` in `ai_ready_rag/services/enrichment_cli_backend.py` that shells out to `claude -p` subprocess instead of calling the Anthropic HTTP API
- Wires the CLI backend into `ClaudeEnrichmentService` via new `claude_backend: Literal["api", "cli"]` setting (default: `"api"` so existing behaviour is unchanged)
- Updates `_is_enabled()` to skip the API key check when `claude_backend == "cli"` (CLI backend uses an existing Claude Code login session)
- Adds `CLAUDE_BACKEND=cli` to `.env.dev-full` and enables `claude_enrichment_enabled` in `tenant.dev-default.json` for dev testing

## Test plan

- [x] 18 new unit tests in `tests/test_enrichment_cli_backend.py` — all mock `subprocess.run`, no real `claude` binary needed
- [x] Tests cover: happy path, non-zero exit → RuntimeError with stderr, timeout=120 passed, markdown fence stripping, bad JSON → `[]`, non-dict items filtered
- [x] CLI-mode wiring tests: `_cli_backend` set when `claude_backend=="cli"`, `None` when `"api"`; `_is_enabled()` allows CLI backend without API key, still blocks on sqlite
- [x] Full regression suite: `pytest tests/ -q` → **1607 passed, 10 skipped** (no regressions)
- [x] `ruff check` + `ruff format` clean (pre-commit hooks pass)

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)