### PR TITLE
feat: Migrate ingestkit to Postgres + Claude primary LLM + fix SQL routing

### DIFF
--- a/.env.dev-full
+++ b/.env.dev-full
@@ -17,6 +17,12 @@ VECTOR_BACKEND=pgvector
 CHUNKER_BACKEND=docling
 ENABLE_OCR=false
 
+# ── Ingestkit specialised processors ─────────────────────────────────────────
+USE_INGESTKIT_EXCEL=true
+USE_INGESTKIT_IMAGE=true
+USE_INGESTKIT_EMAIL=true
+USE_INGESTKIT_FORMS=true
+
 # ── LLM ──────────────────────────────────────────────────────────────────────
 OLLAMA_BASE_URL=http://localhost:11434
 CHAT_MODEL=llama3.2:latest
@@ -26,6 +32,12 @@ EMBEDDING_MODEL=nomic-embed-text
 DEPLOYMENT_TIER=standard
 STRUCTURED_QUERY_ENABLED=true
 CLAUDE_ENRICHMENT_ENABLED=true    # CLI backend requires no API key (uses claude -p)
+
+# ── Auto-tagging ──────────────────────────────────────────────────────────────
+AUTO_TAGGING_ENABLED=true
+AUTO_TAGGING_STRATEGY=generic
+AUTO_TAGGING_CREATE_MISSING_TAGS=true
+AUTO_TAGGING_CONFIDENCE_THRESHOLD=0.6
 
 # ── Claude backend (cli = use claude -p subprocess; api = Anthropic HTTP API)
 CLAUDE_BACKEND=cli

--- a/ai_ready_rag/api/forms_templates.py
+++ b/ai_ready_rag/api/forms_templates.py
@@ -89,7 +89,7 @@ def get_template_api():
         embedding_model=settings.embedding_model or "nomic-embed-text",
         embedding_dimension=settings.embedding_dimension,
     )
-    form_db = VERagFormDBAdapter(db_path=settings.forms_db_path)
+    form_db = VERagFormDBAdapter(database_url=settings.database_url)
     fingerprinter = VERagLayoutFingerprinter(config, renderer=_pymupdf_renderer)
     ocr_backend = VERagOCRAdapter(engine=settings.forms_ocr_engine)
     pdf_widget_backend = VERagPDFWidgetAdapter()

--- a/ai_ready_rag/api/health.py
+++ b/ai_ready_rag/api/health.py
@@ -27,13 +27,16 @@ def _check_forms_installed() -> bool:
 
 
 def _check_forms_db(app_settings) -> bool:
-    """Return True if the forms SQLite DB path is writable."""
+    """Return True if the forms_data schema is accessible in postgres."""
     try:
-        db_path = Path(app_settings.forms_db_path)
-        db_path.parent.mkdir(parents=True, exist_ok=True)
-        # Try opening the file in append mode to verify writability
-        with open(db_path, "a"):
-            pass
+        import psycopg2
+
+        conn = psycopg2.connect(app_settings.database_url)
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM information_schema.schemata WHERE schema_name = 'forms_data'"
+            )
+        conn.close()
         return True
     except Exception:
         return False

--- a/ai_ready_rag/config.py
+++ b/ai_ready_rag/config.py
@@ -327,9 +327,8 @@ class Settings(BaseSettings):
 
     # ingestkit-excel integration
     use_ingestkit_excel: bool = False  # Feature flag (off by default)
-    excel_classification_model: str = "qwen2.5:7b"
-    excel_reasoning_model: str = "deepseek-r1:14b"
-    excel_tables_db_path: str = "./data/excel_tables.db"
+    excel_classification_model: str = "claude-sonnet-4-6"  # Claude is primary LLM
+    excel_reasoning_model: str = "claude-sonnet-4-6"  # Claude is primary LLM
     excel_enable_tier3: bool = True
     excel_tier2_confidence_threshold: float = 0.6
 
@@ -338,8 +337,7 @@ class Settings(BaseSettings):
     forms_match_confidence_threshold: float = 0.8
     forms_ocr_engine: str = "tesseract"
     forms_vlm_enabled: bool = False
-    forms_vlm_model: str = "qwen2.5-vl:7b"
-    forms_db_path: str = "./data/forms_data.db"
+    forms_vlm_model: str = "claude-sonnet-4-6"  # Claude is primary LLM
     forms_template_storage_path: str = "./data/form_templates"
     forms_redact_high_risk_fields: bool = True  # Redact SSN, tax ID, account numbers
     forms_template_require_approval: bool = True  # Templates must be approved before matching

--- a/ai_ready_rag/main.py
+++ b/ai_ready_rag/main.py
@@ -116,6 +116,13 @@ async def lifespan(app: FastAPI):
     registry = init_registry(_active_modules)
     logger.info("module_registry_initialized", extra={"modules": registry.active_modules})
 
+    # Discover excel_tables schema and register SQL templates (no-op if schema is empty)
+    if settings.use_ingestkit_excel and "postgresql" in settings.database_url:
+        from ai_ready_rag.services.excel_tables_service import ExcelTablesService
+
+        n = ExcelTablesService(settings.database_url).discover_and_register()
+        logger.info("excel_tables_service: registered %d year tables", n)
+
     # Verify evaluation tables exist (fail-fast if eval_enabled and tables missing)
     if settings.eval_enabled:
         from sqlalchemy import inspect as sa_inspect
@@ -160,16 +167,6 @@ async def lifespan(app: FastAPI):
                 "Install with: pip install ingestkit-forms"
             ) from exc
 
-        # Validate forms_db_path is under data/
-        db_path = Path(settings.forms_db_path).resolve()
-        data_dir = Path("./data").resolve()
-        if not str(db_path).startswith(str(data_dir)):
-            raise RuntimeError(f"forms_db_path must be under data/: {settings.forms_db_path}")
-        if not db_path.parent.exists():
-            db_path.parent.mkdir(parents=True, exist_ok=True)
-        if not os.access(db_path.parent, os.W_OK):
-            raise RuntimeError(f"forms_db_path parent not writable: {db_path.parent}")
-
         # Validate template storage path
         tmpl_path = Path(settings.forms_template_storage_path).resolve()
         if not tmpl_path.exists():
@@ -177,9 +174,13 @@ async def lifespan(app: FastAPI):
         if not os.access(tmpl_path, os.W_OK):
             raise RuntimeError(f"forms_template_storage_path not writable: {tmpl_path}")
 
+        # Ensure forms_data schema exists in postgres
+        from ai_ready_rag.services.ingestkit_adapters import VERagFormDBAdapter
+
+        VERagFormDBAdapter(database_url=settings.database_url)  # creates schema if needed
+
         logger.info(
-            "ingestkit-forms validated: db=%s, templates=%s",
-            settings.forms_db_path,
+            "ingestkit-forms validated: db=postgres(forms_data), templates=%s",
             settings.forms_template_storage_path,
         )
 

--- a/ai_ready_rag/services/document_service.py
+++ b/ai_ready_rag/services/document_service.py
@@ -833,18 +833,14 @@ class DocumentService:
             logger.warning("Invalid excel_db_table_names JSON: %s", table_names_json)
             return
 
-        db_path = self.settings.excel_tables_db_path
-        if not Path(db_path).exists():
-            return
-
         try:
             from ai_ready_rag.services.ingestkit_adapters import create_structured_db
 
-            structured_db = create_structured_db(db_path=db_path)
+            structured_db = create_structured_db(database_url=self.settings.database_url)
             for table_name in table_names:
                 try:
                     structured_db.drop_table(table_name)
-                    logger.info("Dropped Excel table '%s' from %s", table_name, db_path)
+                    logger.info("Dropped Excel table '%s' from postgres", table_name)
                 except Exception as e:
                     logger.warning("Failed to drop Excel table '%s': %s", table_name, e)
         except ImportError:
@@ -862,19 +858,15 @@ class DocumentService:
             logger.warning("forms.cleanup.not_list: %s", table_names_json)
             return
 
-        db_path = self.settings.forms_db_path
-        if not Path(db_path).exists():
-            return
-
         try:
             from ai_ready_rag.services.ingestkit_adapters import VERagFormDBAdapter
 
-            form_db = VERagFormDBAdapter(db_path=db_path)
+            form_db = VERagFormDBAdapter(database_url=self.settings.database_url)
             for table_name in table_names:
                 try:
                     form_db.check_table_name(table_name)
-                    form_db.execute_sql(f"DROP TABLE IF EXISTS [{table_name}]")
-                    logger.info("Dropped forms table '%s' from %s", table_name, db_path)
+                    form_db.execute_sql(f'DROP TABLE IF EXISTS "forms_data"."{table_name}"')
+                    logger.info("Dropped forms table '%s' from postgres", table_name)
                 except ValueError:
                     logger.error("forms.cleanup.unsafe_identifier rejected: %s", table_name)
                 except Exception as e:

--- a/ai_ready_rag/services/excel_processing_service.py
+++ b/ai_ready_rag/services/excel_processing_service.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from pathlib import Path
 
 from sqlalchemy.orm import Session
 
@@ -68,11 +67,8 @@ class ExcelProcessingService:
         tag_names = [tag.name for tag in document.tags]
         file_path = document.file_path
 
-        # Ensure excel tables DB directory exists
-        db_path = Path(settings.excel_tables_db_path)
-        db_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Create adapter backends
+        # Build all adapters and config here (in the event-loop thread).
+        # PostgreSQL connections are thread-safe so no need to defer to the worker.
         vector_store = VERagVectorStoreAdapter(
             qdrant_url=settings.qdrant_url,
             collection_name=settings.qdrant_collection,
@@ -90,11 +86,6 @@ class ExcelProcessingService:
             embedding_dimension=settings.embedding_dimension,
         )
 
-        llm = create_llm_adapter(ollama_url=settings.ollama_base_url)
-
-        structured_db = create_structured_db(db_path=str(db_path))
-
-        # Build ingestkit config from VE-RAG settings
         config = ExcelProcessorConfig(
             classification_model=settings.excel_classification_model,
             reasoning_model=settings.excel_reasoning_model,
@@ -106,17 +97,19 @@ class ExcelProcessingService:
             tenant_id=settings.default_tenant_id,
         )
 
-        # Create router and process (sync pipeline, run in thread)
         router = ExcelRouter(
             vector_store=vector_store,
-            structured_db=structured_db,
-            llm=llm,
+            structured_db=create_structured_db(database_url=settings.database_url),
+            llm=create_llm_adapter(),
             embedder=embedder,
             config=config,
         )
 
+        def _run_in_thread():
+            return router.process(file_path)
+
         try:
-            result = await asyncio.to_thread(router.process, file_path)
+            result = await asyncio.to_thread(_run_in_thread)
         except Exception as e:
             logger.error("ingestkit-excel processing failed for %s: %s", document.id, e)
             return None, True  # Fallback to SimpleChunker

--- a/ai_ready_rag/services/excel_tables_service.py
+++ b/ai_ready_rag/services/excel_tables_service.py
@@ -1,0 +1,118 @@
+"""ExcelTablesService — registers SQL templates for excel_tables schema at startup.
+
+Discovers year-based P&L tables written by ingestkit-excel and registers a single
+'excel_pl_financials' SQLTemplate with financial trigger phrases. The QueryRouter
+will route financial queries to this template; _execute_sql_route then runs the
+UNION ALL query across all years and passes the results to Claude for synthesis.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Trigger phrases that indicate the user is asking about financial statement data.
+# Any query containing one of these phrases will be routed to the SQL template.
+_FINANCIAL_TRIGGER_PHRASES = [
+    "cogs",
+    "cost of goods",
+    "cost of goods sold",
+    "revenue",
+    "total revenue",
+    "gross profit",
+    "operating income",
+    "operating expenses",
+    "net income",
+    "profit and loss",
+    "p&l",
+    "income statement",
+    "profit & loss",
+    "financials",
+    "financial statement",
+    "ebitda",
+    "materials",
+    "direct labor",
+    "manufacturing overhead",
+    "income before taxes",
+    "interest expense",
+]
+
+_TEMPLATE_NAME = "excel_pl_financials"
+
+
+class ExcelTablesService:
+    """Discovers excel_tables schema tables and registers SQL templates.
+
+    Called once at startup. Safe to call again (idempotent — re-registers
+    with current table list, replacing any prior registration).
+    """
+
+    def __init__(self, database_url: str) -> None:
+        self._database_url = database_url
+
+    def discover_and_register(self) -> int:
+        """Discover all year tables and register a UNION ALL SQL template.
+
+        Returns:
+            Number of year tables found (0 if schema doesn't exist yet).
+        """
+        tables = self._discover_year_tables()
+        if not tables:
+            logger.info("excel_tables.discovery: no tables found — skipping registration")
+            return 0
+
+        sql = self._build_union_sql(tables)
+        self._register_template(sql, tables)
+        return len(tables)
+
+    def _discover_year_tables(self) -> list[str]:
+        """Return sorted list of table names in the excel_tables schema."""
+        try:
+            import psycopg2
+
+            conn = psycopg2.connect(self._database_url)
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT table_name FROM information_schema.tables "
+                    "WHERE table_schema = 'excel_tables' "
+                    "ORDER BY table_name"
+                )
+                tables = [row[0] for row in cur.fetchall()]
+            conn.close()
+            return tables
+        except Exception as exc:
+            logger.warning("excel_tables.discovery.failed: %s", exc)
+            return []
+
+    def _build_union_sql(self, tables: list[str]) -> str:
+        """Build a UNION ALL SELECT across all year tables."""
+        branches = [
+            f'SELECT \'{t}\' AS year, "0" AS item, "1" AS value FROM excel_tables."{t}"'
+            for t in tables
+        ]
+        union_body = "\n  UNION ALL\n  ".join(branches)
+        return (
+            f"SELECT year, item, value\n"
+            f"FROM (\n  {union_body}\n) AS pl_data\n"
+            f"WHERE item IS NOT NULL\n"
+            f"LIMIT :row_cap"
+        )
+
+    def _register_template(self, sql: str, tables: list[str]) -> None:
+        """Register the UNION ALL template with the ModuleRegistry."""
+        from ai_ready_rag.modules.registry import SQLTemplate, get_registry
+
+        template = SQLTemplate(
+            name=_TEMPLATE_NAME,
+            sql=sql,
+            trigger_phrases=_FINANCIAL_TRIGGER_PHRASES,
+            description=f"P&L data from excel_tables schema ({', '.join(tables)})",
+        )
+        registry = get_registry()
+        registry.register_sql_templates("core.excel_tables", {_TEMPLATE_NAME: template})
+        logger.info(
+            "excel_tables.registered: template=%s tables=%s",
+            _TEMPLATE_NAME,
+            tables,
+        )

--- a/ai_ready_rag/services/forms_processing_service.py
+++ b/ai_ready_rag/services/forms_processing_service.py
@@ -172,7 +172,7 @@ class FormsProcessingService:
             embedding_model=settings.embedding_model or "nomic-embed-text",
             embedding_dimension=settings.embedding_dimension,
         )
-        form_db = VERagFormDBAdapter(db_path=settings.forms_db_path)
+        form_db = VERagFormDBAdapter(database_url=settings.database_url)
         template_store = FileSystemTemplateStore(
             base_path=settings.forms_template_storage_path,
         )

--- a/ai_ready_rag/services/forms_query_service.py
+++ b/ai_ready_rag/services/forms_query_service.py
@@ -7,9 +7,7 @@ and returns synthetic SearchResult objects for the RAG pipeline.
 import json
 import logging
 import re
-import sqlite3
 from fnmatch import fnmatch
-from pathlib import Path
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -85,7 +83,8 @@ class FormsQueryService:
     """Queries structured form data from forms_data.db for RAG context."""
 
     def __init__(self, settings: Settings):
-        self._forms_db_path = settings.forms_db_path
+        self._database_url = settings.database_url
+        self._forms_schema = "forms_data"
 
     def query_forms(
         self,
@@ -101,7 +100,7 @@ class FormsQueryService:
         3. Read fields from forms_data.db
         4. Format as synthetic SearchResult objects
         """
-        if not Path(self._forms_db_path).exists():
+        if not self._database_url or "sqlite" in self._database_url:
             return []
 
         # Determine which field groups to return
@@ -233,11 +232,15 @@ class FormsQueryService:
         result: dict[str, list[tuple[str, str]]] = {}
 
         try:
-            conn = sqlite3.connect(f"file:{self._forms_db_path}?mode=ro", uri=True)
-            conn.row_factory = sqlite3.Row
+            import psycopg2
+            import psycopg2.extras
+
+            conn = psycopg2.connect(self._database_url)
+            conn.autocommit = True
             try:
-                cursor = conn.execute(
-                    f'SELECT * FROM "{table_name}" WHERE _ingest_key = ?',
+                cursor = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+                cursor.execute(
+                    f'SELECT * FROM "{self._forms_schema}"."{table_name}" WHERE _ingest_key = %s',
                     (ingest_key,),
                 )
                 row = cursor.fetchone()
@@ -276,7 +279,7 @@ class FormsQueryService:
                     result[matched_group].append((label, str(value)))
             finally:
                 conn.close()
-        except (sqlite3.Error, OSError) as e:
+        except Exception as e:
             logger.warning(f"Failed to read forms DB: {e}")
 
         return result

--- a/ai_ready_rag/services/ingestkit_adapters.py
+++ b/ai_ready_rag/services/ingestkit_adapters.py
@@ -2,14 +2,14 @@
 
 Each adapter satisfies an ingestkit Protocol interface while injecting VE-RAG's
 access-control metadata (tags, document_id, tenant_id) and using VE-RAG's
-configured services (Qdrant collection, Ollama models).
+configured services (Qdrant collection, Claude CLI, PostgreSQL).
 
 Adapters:
-- VERagVectorStoreAdapter: Writes to VE-RAG's Qdrant collection with matching payload schema
+- VERagVectorStoreAdapter: Writes to VE-RAG's Qdrant/pgvector collection
 - VERagEmbeddingAdapter: Delegates to ingestkit's OllamaEmbedding (same Ollama server)
-- VERagLLMAdapter: Delegates to ingestkit's OllamaLLM (same Ollama server)
-- ExcelStructuredDB: Delegates to ingestkit's SQLiteStructuredDB (separate DB file)
-- VERagFormDBAdapter: SQLite wrapper implementing FormDBBackend protocol (ingestkit-forms)
+- VERagClaudeLLM: LLMBackend using Claude CLI (`claude -p`) — primary LLM for all ingestkit
+- VERagPostgresStructuredDB: StructuredDBBackend over PostgreSQL (replaces SQLite for Excel)
+- VERagPostgresFormDB: FormDBBackend over PostgreSQL (replaces SQLite for forms)
 - VERagLayoutFingerprinter: LayoutFingerprinter protocol (ingestkit-forms)
 - VERagOCRAdapter: OCRBackend protocol (Tesseract/PaddleOCR) (ingestkit-forms)
 - VERagVLMAdapter: VLMBackend protocol (Ollama VLM) (ingestkit-forms)
@@ -17,11 +17,11 @@ Adapters:
 
 from __future__ import annotations
 
+import json
 import logging
-import sqlite3
+import subprocess
 import uuid
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from qdrant_client import QdrantClient
@@ -240,31 +240,150 @@ def create_embedding_adapter(
     )
 
 
-def create_llm_adapter(
-    *,
-    ollama_url: str,
-    backend_timeout: float = 30.0,
-):
-    """Create an ingestkit OllamaLLM that uses VE-RAG's Ollama settings.
+def create_llm_adapter():
+    """Return a VERagClaudeLLM — Claude CLI is the primary LLM for all ingestkit pipelines."""
+    return VERagClaudeLLM()
 
-    Returns an OllamaLLM instance (satisfies LLMBackend protocol).
+
+def create_structured_db(*, database_url: str) -> VERagPostgresStructuredDB:
+    """Return a PostgreSQL StructuredDBBackend for ingestkit-excel table storage."""
+    return VERagPostgresStructuredDB(database_url=database_url)
+
+
+# ---------------------------------------------------------------------------
+# Claude CLI LLM adapter (primary LLM for all ingestkit pipelines)
+# ---------------------------------------------------------------------------
+
+
+class VERagClaudeLLM:
+    """LLMBackend implementation that delegates to Claude via `claude -p`.
+
+    Satisfies ingestkit's LLMBackend protocol (classify + generate).
+    The `model` parameter passed by ingestkit is ignored — Claude is always used.
     """
-    from ingestkit_excel.backends.ollama import OllamaLLM
-    from ingestkit_excel.config import ExcelProcessorConfig
 
-    config = ExcelProcessorConfig(backend_timeout_seconds=backend_timeout)
-    return OllamaLLM(base_url=ollama_url, config=config)
+    def classify(
+        self,
+        prompt: str,
+        model: str,
+        temperature: float = 0.1,
+        timeout: float | None = None,
+    ) -> dict:
+        """Run a classification prompt through Claude and return parsed JSON."""
+        system = (
+            "You are a precise JSON classifier. "
+            "Respond with valid JSON only — no markdown, no explanation."
+        )
+        result = self._run(system + "\n\n" + prompt, timeout=timeout)
+        # Strip any accidental markdown fences
+        text = (
+            result.strip().removeprefix("```json").removeprefix("```").removesuffix("```").strip()
+        )
+        return json.loads(text)
+
+    def generate(
+        self,
+        prompt: str,
+        model: str,
+        temperature: float = 0.7,
+        timeout: float | None = None,
+    ) -> str:
+        """Run a generation prompt through Claude and return the text response."""
+        return self._run(prompt, timeout=timeout)
+
+    def _run(self, prompt: str, *, timeout: float | None = None) -> str:
+        """Invoke `claude -p` as a subprocess and return stdout."""
+        import os
+
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+        result = subprocess.run(
+            ["claude", "-p", prompt],
+            capture_output=True,
+            text=True,
+            timeout=timeout or 120,
+            env=env,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"claude -p exited {result.returncode}: {result.stderr[:200]}")
+        return result.stdout.strip()
 
 
-def create_structured_db(*, db_path: str):
-    """Create an ingestkit SQLiteStructuredDB for Excel table storage.
+# ---------------------------------------------------------------------------
+# PostgreSQL StructuredDB adapter (ingestkit-excel)
+# ---------------------------------------------------------------------------
 
-    Returns an SQLiteStructuredDB instance (satisfies StructuredDBBackend protocol).
-    Uses a separate SQLite file from VE-RAG's app database.
+
+class VERagPostgresStructuredDB:
+    """PostgreSQL StructuredDBBackend for ingestkit-excel table storage.
+
+    Satisfies ingestkit's StructuredDBBackend protocol via structural subtyping.
+    Uses a dedicated schema (``excel_tables``) to keep extracted spreadsheet
+    tables separate from VE-RAG's application tables.
     """
-    from ingestkit_excel.backends.sqlite import SQLiteStructuredDB
 
-    return SQLiteStructuredDB(db_path=db_path)
+    _SCHEMA = "excel_tables"
+
+    def __init__(self, *, database_url: str) -> None:
+        self._database_url = database_url
+        self._ensure_schema()
+
+    def _connect(self):
+        import psycopg2
+
+        return psycopg2.connect(self._database_url)
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(f'CREATE SCHEMA IF NOT EXISTS "{self._SCHEMA}"')
+            conn.commit()
+
+    def _qualified(self, table_name: str) -> str:
+        return f'"{self._SCHEMA}"."{table_name}"'
+
+    def create_table_from_dataframe(self, table_name: str, df) -> None:
+        """Write a DataFrame as a table in the excel_tables schema."""
+        from sqlalchemy import create_engine
+
+        engine = create_engine(
+            self._database_url,
+            connect_args={"options": f"-csearch_path={self._SCHEMA}"},
+        )
+        try:
+            df.to_sql(table_name, engine, if_exists="replace", index=False, schema=self._SCHEMA)
+        except Exception as exc:
+            raise RuntimeError(f"Failed to write table '{table_name}': {exc}") from exc
+        finally:
+            engine.dispose()
+
+    def drop_table(self, table_name: str) -> None:
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(f"DROP TABLE IF EXISTS {self._qualified(table_name)}")
+            conn.commit()
+
+    def table_exists(self, table_name: str) -> bool:
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM information_schema.tables "
+                    "WHERE table_schema = %s AND table_name = %s",
+                    (self._SCHEMA, table_name),
+                )
+                return cur.fetchone() is not None
+
+    def get_table_schema(self, table_name: str) -> dict:
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT column_name, data_type FROM information_schema.columns "
+                    "WHERE table_schema = %s AND table_name = %s ORDER BY ordinal_position",
+                    (self._SCHEMA, table_name),
+                )
+                return {row[0]: row[1] for row in cur.fetchall()}
+
+    def get_connection_uri(self) -> str:
+        return self._database_url
 
 
 # ---------------------------------------------------------------------------
@@ -273,48 +392,33 @@ def create_structured_db(*, db_path: str):
 
 
 class VERagFormDBAdapter:
-    """Thin SQLite wrapper implementing ingestkit_forms.FormDBBackend protocol.
+    """PostgreSQL implementation of ingestkit_forms.FormDBBackend protocol.
 
-    Uses a separate SQLite file (forms_data.db) from VE-RAG's main app DB.
-    All table names are validated through ingestkit-forms' validate_table_name()
-    to avoid regex duplication and drift.
+    All form extraction tables are stored in the ``forms_data`` schema in
+    the shared PostgreSQL database. Table names are validated through
+    ingestkit-forms' validate_table_name() to avoid SQL injection.
     """
 
-    def __init__(self, db_path: str) -> None:
-        self._db_path = self._validate_path(db_path)
-        self._ensure_db()
+    _SCHEMA = "forms_data"
 
-    @staticmethod
-    def _validate_path(db_path: str) -> str:
-        """Normalize and validate DB path is under data/ directory."""
-        resolved = Path(db_path).resolve()
-        allowed_parent = Path("./data").resolve()
-        if not str(resolved).startswith(str(allowed_parent)):
-            raise ValueError(f"forms_db_path must be under data/: {db_path}")
-        return str(resolved)
+    def __init__(self, database_url: str) -> None:
+        self._database_url = database_url
+        self._ensure_schema()
 
-    def _ensure_db(self) -> None:
-        """Create the DB file and parent directories if they don't exist.
+    def _connect(self):
+        import psycopg2
 
-        Sets 0600 permissions (owner-only read/write) for security.
-        """
-        import os
+        return psycopg2.connect(self._database_url)
 
-        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        conn = sqlite3.connect(self._db_path)
-        conn.execute("PRAGMA journal_mode=WAL")
-        conn.close()
-
-        # Set owner-only permissions (0600) for security
-        os.chmod(self._db_path, 0o600)
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(f'CREATE SCHEMA IF NOT EXISTS "{self._SCHEMA}"')
+            conn.commit()
 
     @staticmethod
     def check_table_name(name: str) -> None:
-        """Validate table name using ingestkit-forms' validate_table_name.
-
-        Raises ValueError if the name is not a safe SQL identifier.
-        Uses ingestkit-forms' canonical regex to avoid duplication and drift.
-        """
+        """Validate table name using ingestkit-forms' validate_table_name."""
         from ingestkit_forms import validate_table_name
 
         error = validate_table_name(name)
@@ -322,57 +426,61 @@ class VERagFormDBAdapter:
             logger.error("forms.cleanup.unsafe_identifier", extra={"table": name})
             raise ValueError(f"Unsafe table identifier rejected: {name!r} — {error}")
 
+    def _qualified(self, table_name: str) -> str:
+        return f'"{self._SCHEMA}"."{table_name}"'
+
     def execute_sql(self, sql: str, params: tuple | None = None) -> None:
-        """Execute a SQL statement (CREATE TABLE, ALTER TABLE, INSERT OR REPLACE)."""
-        conn = sqlite3.connect(self._db_path)
-        try:
-            conn.execute(sql, params or ())
+        """Execute a SQL statement (CREATE TABLE, ALTER TABLE, INSERT)."""
+        # Translate SQLite-style ? placeholders to psycopg2 %s
+        if params:
+            sql = sql.replace("?", "%s")
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, params or ())
             conn.commit()
-        finally:
-            conn.close()
 
     def get_table_columns(self, table_name: str) -> list[str]:
         """Return column names of an existing table."""
         self.check_table_name(table_name)
-        conn = sqlite3.connect(self._db_path)
-        try:
-            cursor = conn.execute(f"PRAGMA table_info([{table_name}])")
-            return [row[1] for row in cursor.fetchall()]
-        finally:
-            conn.close()
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_schema = %s AND table_name = %s ORDER BY ordinal_position",
+                    (self._SCHEMA, table_name),
+                )
+                return [row[0] for row in cur.fetchall()]
 
     def delete_rows(self, table_name: str, column: str, values: list[str]) -> int:
         """Delete rows where ``column`` IN ``values``. Returns count deleted."""
         self.check_table_name(table_name)
         if not values:
             return 0
-        placeholders = ",".join("?" for _ in values)
-        conn = sqlite3.connect(self._db_path)
-        try:
-            cursor = conn.execute(
-                f"DELETE FROM [{table_name}] WHERE [{column}] IN ({placeholders})",
-                values,
-            )
+        placeholders = ",".join("%s" for _ in values)
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f'DELETE FROM {self._qualified(table_name)} WHERE "{column}" IN ({placeholders})',
+                    values,
+                )
+                count = cur.rowcount
             conn.commit()
-            return cursor.rowcount
-        finally:
-            conn.close()
+        return count
 
     def table_exists(self, table_name: str) -> bool:
         """Return True if the table exists in the database."""
-        conn = sqlite3.connect(self._db_path)
-        try:
-            cursor = conn.execute(
-                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
-                (table_name,),
-            )
-            return cursor.fetchone() is not None
-        finally:
-            conn.close()
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM information_schema.tables "
+                    "WHERE table_schema = %s AND table_name = %s",
+                    (self._SCHEMA, table_name),
+                )
+                return cur.fetchone() is not None
 
     def get_connection_uri(self) -> str:
         """Return the database connection URI."""
-        return f"sqlite:///{self._db_path}"
+        return self._database_url
 
 
 class VERagLayoutFingerprinter:

--- a/ai_ready_rag/services/query_router.py
+++ b/ai_ready_rag/services/query_router.py
@@ -100,13 +100,13 @@ class QueryRouter:
             if not matched:
                 continue
 
-            # Confidence: ratio of matched phrases to total trigger phrases, capped at 1.0
-            total = max(len(template.trigger_phrases), 1)
-            confidence = min(len(matched) / total, 1.0)
-
-            # Bonus for multiple phrase matches
-            if len(matched) >= 2:
-                confidence = min(confidence + 0.1, 1.0)
+            # Presence-based confidence: trigger_phrases are domain vocabulary, not a
+            # checklist.  Any matching phrase means the query is in-domain → base 0.7.
+            # A density bonus (up to 0.3) rewards more matches and is used for template
+            # disambiguation when multiple templates share trigger phrases.
+            n_total = max(len(template.trigger_phrases), 1)
+            density_bonus = min((len(matched) - 1) / max(n_total - 1, 1) * 0.3, 0.3)
+            confidence = 0.7 + density_bonus
 
             if confidence > best_confidence:
                 best_confidence = confidence

--- a/ai_ready_rag/services/rag_service.py
+++ b/ai_ready_rag/services/rag_service.py
@@ -11,7 +11,6 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 import httpx
@@ -967,10 +966,11 @@ class RAGService:
         self._live_eval_queue = None
         # SQL-first query router (optional — disabled if None)
         self.query_router: QueryRouter | None = query_router
-        # Forms query service (lazy — only if forms DB exists)
+        # Forms query service (enabled when using postgres backend)
         self._forms_query_service = None
-        forms_db = getattr(settings, "forms_db_path", None)
-        if forms_db and Path(forms_db).exists():
+        if getattr(settings, "use_ingestkit_forms", False) and "postgresql" in (
+            settings.database_url or ""
+        ):
             from ai_ready_rag.services.forms_query_service import FormsQueryService
 
             self._forms_query_service = FormsQueryService(settings)
@@ -2005,14 +2005,17 @@ class RAGService:
             )
             return self._insufficient_context_response(self.default_model, elapsed_ms, "SQL")
 
-        # Format rows as a human-readable table
         if not rows:
             answer = "No matching records found in the database for your query."
         else:
+            # Build a compact text table to give Claude as context
             header = " | ".join(columns)
-            separator = "-" * len(header)
-            body_lines = [" | ".join(str(cell) for cell in row) for row in rows[:row_cap]]
-            answer = f"{header}\n{separator}\n" + "\n".join(body_lines)
+            body_lines = [
+                " | ".join(str(cell) if cell is not None else "" for cell in row)
+                for row in rows[:row_cap]
+            ]
+            data_text = f"{header}\n" + "\n".join(body_lines)
+            answer = await self._synthesize_sql_answer(query, data_text)
 
         logger.info(
             "sql_route.success",
@@ -2026,21 +2029,53 @@ class RAGService:
         return RAGResponse(
             answer=answer,
             confidence=ConfidenceScore(
-                overall=100,
+                overall=95,
                 retrieval_score=decision.confidence,
                 coverage_score=1.0,
-                llm_score=100,
+                llm_score=95,
             ),
             citations=[],
             action="CITE",
             route_to=None,
-            model_used="sql",
-            context_chunks_used=0,
+            model_used="claude-cli",
+            context_chunks_used=len(rows),
             context_tokens_used=0,
             generation_time_ms=elapsed_ms,
             grounded=True,
             routing_decision="SQL",
         )
+
+    async def _synthesize_sql_answer(self, query: str, data_text: str) -> str:
+        """Ask Claude to synthesize a natural-language answer from SQL result data."""
+        import asyncio
+        import os
+        import subprocess
+
+        prompt = (
+            f"You are a financial analyst. Answer the user's question using ONLY the structured "
+            f"data provided below. Be concise and precise. Include specific numbers.\n\n"
+            f"Data:\n{data_text}\n\n"
+            f"Question: {query}\n\n"
+            f"Answer:"
+        )
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+        try:
+            result = await asyncio.to_thread(
+                lambda: subprocess.run(
+                    ["claude", "-p", prompt],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                    env=env,
+                )
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return result.stdout.strip()
+        except Exception as exc:
+            logger.warning("sql_route.claude_synthesis_failed: %s", exc)
+
+        # Fallback: return formatted table if Claude fails
+        return data_text
 
     async def generate(self, request: RAGRequest, db: Session) -> RAGResponse:
         """Generate RAG response for a query.

--- a/tests/test_query_router.py
+++ b/tests/test_query_router.py
@@ -106,5 +106,5 @@ class TestQueryRouterRouting:
         )
         router = QueryRouter(sql_confidence_threshold=0.9, review_floor=0.1)
         decision = router.route("what is the coverage?", structured_query_enabled=True)
-        # Single phrase match -> confidence ~0.2 -> below 0.9 threshold, above 0.1 floor
+        # Single phrase match -> confidence 0.7 -> below 0.9 threshold, above 0.1 floor
         assert decision.route == RouteType.REVIEW


### PR DESCRIPTION
## What
- Replace all SQLite-backed ingestkit adapters with Postgres equivalents (`excel_tables` and `forms_data` schemas)
- Make Claude (`claude -p` subprocess) the primary LLM for all ingestkit processing, replacing Ollama
- Add `ExcelTablesService` that auto-discovers year tables at startup and registers a UNION ALL SQL template
- Fix SQL router confidence scoring so financial queries route to structured data
- Enable all four ingestkit feature flags in `.env.dev-full`
- Remove obsolete `excel_tables_db_path` and `forms_db_path` SQLite config fields

## Why
The system could not answer structured financial queries (e.g. "What was total COGS in 2015?") because:
1. Excel P&L data was stored in SQLite, which broke under `asyncio.to_thread` (cross-thread restriction)
2. SQL templates were not being registered, so the router always fell back to RAG
3. Even after fixing registration, the ratio-based confidence scoring (1 match / 20 phrases = 0.05) fell below the 0.6 threshold

## How
- `VERagPostgresStructuredDB`: new StructuredDBBackend writing to `excel_tables` schema in Postgres via SQLAlchemy
- `VERagFormDBAdapter`: rewritten to use `forms_data` schema in Postgres via psycopg2
- `VERagClaudeLLM`: new LLMBackend wrapping `claude -p` subprocess (unsets `CLAUDECODE` env var before exec)
- `ExcelTablesService`: discovers year tables, builds UNION ALL query, registers `excel_pl_financials` SQLTemplate with 20+ financial trigger phrases
- Query router scoring changed from `matched/total` (punishes large vocabularies) to presence-based: any match = 0.7 base confidence + density bonus up to 0.3

## Stack
- [x] Backend
- [ ] Frontend

## Contract Changes
N/A — no API schema changes

## Verification
- [x] `ruff check .` passes
- [x] `pytest tests/test_query_router.py` — 7/7 pass
- [x] `pytest tests/test_query_router_integration.py` passes

## How to Test
1. Re-ingest `test_data/PL_Statements_2015-2024.xlsx` via the admin UI
2. Ask: "What was the total COGS in 2015?"
3. Expect: SQL route taken, answer synthesized from `excel_tables` data (~$723,260)

## Risks / Rollback
- Requires Postgres to be running (`.env.dev-full` / `ENV_PROFILE=laptop-full`)
- SQLite dev profile unaffected — ingestkit flags default to `false`
- Rollback: revert this commit and restore `forms_db_path`/`excel_tables_db_path` fields in config