### PR TITLE
fix: extract SearchResult into vector_types.py to break qdrant-client import chain (#447)

### DIFF
--- a/ai_ready_rag/services/__init__.py
+++ b/ai_ready_rag/services/__init__.py
@@ -22,9 +22,9 @@ from ai_ready_rag.services.vector_service import (
     CollectionStats,
     HealthStatus,
     IndexResult,
-    SearchResult,
     VectorService,
 )
+from ai_ready_rag.services.vector_types import SearchResult
 from ai_ready_rag.services.vector_utils import (
     RESERVED_TAGS,
     generate_chunk_id,

--- a/ai_ready_rag/services/forms_query_service.py
+++ b/ai_ready_rag/services/forms_query_service.py
@@ -17,7 +17,7 @@ from ai_ready_rag.db.models.base import document_tags
 from ai_ready_rag.db.models.document import Document
 from ai_ready_rag.db.models.user import Tag
 from ai_ready_rag.services.forms_processing_service import ACORD_25_GROUPS
-from ai_ready_rag.services.vector_service import SearchResult
+from ai_ready_rag.services.vector_types import SearchResult
 
 logger = logging.getLogger(__name__)
 

--- a/ai_ready_rag/services/pgvector_service.py
+++ b/ai_ready_rag/services/pgvector_service.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import json
 import logging
 import uuid
-from dataclasses import dataclass, field
 from typing import Any
 
 import httpx
@@ -20,23 +19,9 @@ from sqlalchemy import text
 
 from ai_ready_rag.core.exceptions import EmbeddingError, SearchError
 from ai_ready_rag.db.database import SessionLocal
+from ai_ready_rag.services.vector_types import SearchResult
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class SearchResult:
-    """Single search result with metadata."""
-
-    chunk_id: str
-    document_id: str
-    document_name: str
-    chunk_text: str
-    chunk_index: int
-    score: float
-    page_number: int | None
-    section: str | None
-    tags: list[str] | None = field(default=None)
 
 
 class PgVectorService:

--- a/ai_ready_rag/services/rag_service.py
+++ b/ai_ready_rag/services/rag_service.py
@@ -36,7 +36,7 @@ from ai_ready_rag.services.rag_constants import (
     STOPWORDS,
 )
 from ai_ready_rag.services.settings_service import get_rag_setting
-from ai_ready_rag.services.vector_service import SearchResult
+from ai_ready_rag.services.vector_types import SearchResult
 
 if TYPE_CHECKING:
     from ai_ready_rag.services.protocols import VectorServiceProtocol

--- a/ai_ready_rag/services/vector_chroma.py
+++ b/ai_ready_rag/services/vector_chroma.py
@@ -6,7 +6,7 @@ from typing import Any
 import chromadb
 from chromadb.config import Settings as ChromaSettings
 
-from ai_ready_rag.services.vector_service import SearchResult
+from ai_ready_rag.services.vector_types import SearchResult
 
 logger = logging.getLogger(__name__)
 

--- a/ai_ready_rag/services/vector_service.py
+++ b/ai_ready_rag/services/vector_service.py
@@ -26,6 +26,7 @@ from qdrant_client.http.exceptions import ResponseHandlingException
 from qdrant_client.http.models import Fusion, FusionQuery, Prefetch
 
 from ai_ready_rag.core.exceptions import EmbeddingError, IndexingError, SearchError
+from ai_ready_rag.services.vector_types import SearchResult
 from ai_ready_rag.services.vector_utils import generate_chunk_id
 
 logger = logging.getLogger(__name__)
@@ -69,21 +70,6 @@ class IndexResult:
     embedding_time_ms: float
     indexing_time_ms: float
     sparse_indexed: bool = True  # Default True for backward compat
-
-
-@dataclass
-class SearchResult:
-    """Single search result with metadata."""
-
-    chunk_id: str
-    document_id: str
-    document_name: str
-    chunk_text: str
-    chunk_index: int
-    score: float  # 0.0 to 1.0 (cosine similarity)
-    page_number: int | None
-    section: str | None
-    tags: list[str] | None = None  # For recency boost from year tags
 
 
 @dataclass

--- a/ai_ready_rag/services/vector_types.py
+++ b/ai_ready_rag/services/vector_types.py
@@ -1,0 +1,24 @@
+"""Zero-dependency type definitions for vector search results.
+
+Extracted from vector_service.py so that rag_service.py and other modules
+can import SearchResult without pulling in qdrant-client at import time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SearchResult:
+    """Single search result with metadata."""
+
+    chunk_id: str
+    document_id: str
+    document_name: str
+    chunk_text: str
+    chunk_index: int
+    score: float
+    page_number: int | None
+    section: str | None
+    tags: list[str] | None = field(default=None)


### PR DESCRIPTION
## Summary

- Creates `ai_ready_rag/services/vector_types.py` with zero-dependency `SearchResult` dataclass
- Updates 4 import sites (`rag_service`, `forms_query_service`, `vector_chroma`, `vector_service`) to import from `vector_types`
- Removes duplicate `SearchResult` class from `pgvector_service.py`
- Updates `services/__init__.py` re-exports

## Problem

`rag_service.py` imported `SearchResult` from `vector_service.py`, which unconditionally imports `qdrant-client`. This caused startup crashes on pgvector deployments when `qdrant-client` is absent.

## Test plan

- [x] `pytest tests/ -q` passes (1 pre-existing failure unrelated to this change)
- [x] `grep -r "from.*vector_service import SearchResult"` returns zero results
- [x] Import chain broken: `rag_service → vector_types` (no qdrant dependency)

Closes #447
Unblocks #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)