### PR TITLE
feat: complete PgVectorService — embed(), get_extended_stats(), refresh_capabilities() (#448)

### DIFF
--- a/ai_ready_rag/schemas/admin.py
+++ b/ai_ready_rag/schemas/admin.py
@@ -928,7 +928,7 @@ class ReconcileResponse(BaseModel):
     """Response from reconciliation endpoint."""
 
     total_documents: int
-    total_qdrant_documents: int
+    total_vector_documents: int
     synced: int
     issues: list[ReconcileIssue]
     repairs: list[ReconcileRepair]

--- a/ai_ready_rag/services/pgvector_service.py
+++ b/ai_ready_rag/services/pgvector_service.py
@@ -288,3 +288,53 @@ class PgVectorService:
                 updated += 1
             db.commit()
         return updated
+
+    async def embed(self, text: str) -> list[float]:
+        """Public wrapper around _embed() for cache seeding and external callers."""
+        return await self._embed(text)
+
+    async def get_extended_stats(self) -> dict[str, Any]:
+        """Return per-document chunk counts and totals for admin endpoints."""
+        with SessionLocal() as db:
+            try:
+                # PostgreSQL: ->> operator
+                rows = db.execute(
+                    text(
+                        "SELECT document_id, "
+                        "metadata_->>'document_name' AS filename, "
+                        "COUNT(*) AS chunk_count "
+                        "FROM chunk_vectors "
+                        "WHERE tenant_id = :tenant "
+                        "GROUP BY document_id, metadata_->>'document_name'"
+                    ),
+                    {"tenant": self._tenant_id},
+                ).fetchall()
+            except Exception:
+                # SQLite fallback (used in tests)
+                rows = db.execute(
+                    text(
+                        "SELECT document_id, "
+                        "json_extract(metadata_, '$.document_name') AS filename, "
+                        "COUNT(*) AS chunk_count "
+                        "FROM chunk_vectors "
+                        "WHERE tenant_id = :tenant "
+                        "GROUP BY document_id, json_extract(metadata_, '$.document_name')"
+                    ),
+                    {"tenant": self._tenant_id},
+                ).fetchall()
+
+        files = [{"document_id": row[0], "filename": row[1], "chunk_count": row[2]} for row in rows]
+        return {
+            "total_chunks": sum(r["chunk_count"] for r in files),
+            "unique_files": len(files),
+            "collection_name": "chunk_vectors",
+            "collection_size_bytes": None,
+            "files": files,
+        }
+
+    async def refresh_capabilities(self) -> dict[str, Any]:
+        """Return backend capability descriptor (no-op for pgvector)."""
+        return {
+            "backend": "pgvector",
+            "capabilities": ["vector_search", "cosine_similarity", "tag_filtering"],
+        }

--- a/ai_ready_rag/services/reconciliation_service.py
+++ b/ai_ready_rag/services/reconciliation_service.py
@@ -1,11 +1,12 @@
-"""SQLite ↔ Qdrant reconciliation service.
+"""SQLite ↔ pgvector reconciliation service.
 
 Detects and optionally repairs drift between SQLite document metadata
-and Qdrant vector store.
+and the pgvector chunk_vectors table.
 """
 
 import logging
 
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from ai_ready_rag.db.models import Document
@@ -18,16 +19,16 @@ async def reconcile(
     vector_service,
     dry_run: bool = True,
 ) -> dict:
-    """Detect and optionally repair SQLite ↔ Qdrant drift.
+    """Detect and optionally repair SQLite ↔ pgvector drift.
 
     Scenarios detected:
-    - ghost_docs: SQLite status=ready but 0 vectors in Qdrant
-    - orphan_vectors: Qdrant has vectors for document_id not in SQLite
-    - chunk_count_mismatch: SQLite chunk_count != actual Qdrant vector count
+    - ghost_docs: SQLite status=ready but 0 vectors in chunk_vectors
+    - orphan_vectors: chunk_vectors has rows for document_id not in SQLite
+    - chunk_count_mismatch: SQLite chunk_count != actual vector count
 
     Args:
         db: SQLAlchemy session
-        vector_service: Initialized VectorService instance
+        vector_service: Initialized vector service instance (PgVectorService or VectorService)
         dry_run: If True, only detect issues. If False, also repair.
 
     Returns:
@@ -41,50 +42,38 @@ async def reconcile(
     sqlite_doc_ids = {doc.id for doc in all_docs}
     ready_docs = [d for d in all_docs if d.status == "ready"]
 
-    # 2. Get all unique document_ids from Qdrant (scroll in batches)
-    qdrant_doc_ids: set[str] = set()
-    qdrant_doc_counts: dict[str, int] = {}
+    # 2. Get all unique document_ids from chunk_vectors (pgvector SQL)
+    tenant_id = getattr(
+        vector_service, "_tenant_id", getattr(vector_service, "tenant_id", "default")
+    )
+    vector_doc_ids: set[str] = set()
+    vector_doc_counts: dict[str, int] = {}
 
-    from qdrant_client import models
+    rows = db.execute(
+        text(
+            "SELECT document_id, COUNT(*) AS chunk_count "
+            "FROM chunk_vectors "
+            "WHERE tenant_id = :tenant "
+            "GROUP BY document_id"
+        ),
+        {"tenant": tenant_id},
+    ).fetchall()
+    for row in rows:
+        vector_doc_ids.add(row[0])
+        vector_doc_counts[row[0]] = row[1]
 
-    offset = None
-    while True:
-        results, offset = await vector_service._qdrant.scroll(
-            collection_name=vector_service.collection_name,
-            limit=1000,
-            offset=offset,
-            with_payload=["document_id"],
-            scroll_filter=models.Filter(
-                must=[
-                    models.FieldCondition(
-                        key="tenant_id",
-                        match=models.MatchValue(value=vector_service.tenant_id),
-                    )
-                ]
-            ),
-        )
-        if not results:
-            break
-        for point in results:
-            if point.payload and "document_id" in point.payload:
-                doc_id = point.payload["document_id"]
-                qdrant_doc_ids.add(doc_id)
-                qdrant_doc_counts[doc_id] = qdrant_doc_counts.get(doc_id, 0) + 1
-        if offset is None:
-            break
-
-    # 3. Detect ghost docs: ready in SQLite but 0 vectors in Qdrant
+    # 3. Detect ghost docs: ready in SQLite but 0 vectors in chunk_vectors
     for doc in ready_docs:
-        qdrant_count = qdrant_doc_counts.get(doc.id, 0)
-        if qdrant_count == 0:
+        vector_count = vector_doc_counts.get(doc.id, 0)
+        if vector_count == 0:
             issues.append(
                 {
                     "document_id": doc.id,
                     "filename": doc.original_filename,
                     "issue": "ghost_doc",
-                    "detail": "status=ready in SQLite but 0 vectors in Qdrant",
+                    "detail": "status=ready in SQLite but 0 vectors in chunk_vectors",
                     "sqlite_chunks": doc.chunk_count,
-                    "qdrant_chunks": 0,
+                    "vector_chunks": 0,
                 }
             )
             if not dry_run:
@@ -98,17 +87,17 @@ async def reconcile(
                     }
                 )
 
-    # 4. Detect orphan vectors: in Qdrant but not in SQLite
-    orphan_ids = qdrant_doc_ids - sqlite_doc_ids
+    # 4. Detect orphan vectors: in chunk_vectors but not in SQLite
+    orphan_ids = vector_doc_ids - sqlite_doc_ids
     for orphan_id in orphan_ids:
         issues.append(
             {
                 "document_id": orphan_id,
                 "filename": None,
                 "issue": "orphan_vectors",
-                "detail": "Vectors exist in Qdrant but no SQLite record",
+                "detail": "Vectors exist in chunk_vectors but no SQLite record",
                 "sqlite_chunks": None,
-                "qdrant_chunks": qdrant_doc_counts.get(orphan_id, 0),
+                "vector_chunks": vector_doc_counts.get(orphan_id, 0),
             }
         )
         if not dry_run:
@@ -127,28 +116,29 @@ async def reconcile(
     for doc in ready_docs:
         if doc.id in orphan_ids:
             continue  # Already handled
-        qdrant_count = qdrant_doc_counts.get(doc.id, 0)
-        if qdrant_count == 0:
+        vector_count = vector_doc_counts.get(doc.id, 0)
+        if vector_count == 0:
             continue  # Already handled as ghost_doc
-        if doc.chunk_count is not None and doc.chunk_count != qdrant_count:
+        if doc.chunk_count is not None and doc.chunk_count != vector_count:
+            old_count = doc.chunk_count
             issues.append(
                 {
                     "document_id": doc.id,
                     "filename": doc.original_filename,
                     "issue": "chunk_count_mismatch",
-                    "detail": f"SQLite chunk_count={doc.chunk_count} != Qdrant vectors={qdrant_count}",
+                    "detail": f"SQLite chunk_count={doc.chunk_count} != vector chunks={vector_count}",
                     "sqlite_chunks": doc.chunk_count,
-                    "qdrant_chunks": qdrant_count,
+                    "vector_chunks": vector_count,
                 }
             )
             if not dry_run:
-                doc.chunk_count = qdrant_count
+                doc.chunk_count = vector_count
                 repairs.append(
                     {
                         "document_id": doc.id,
                         "action": "updated_chunk_count",
-                        "old_value": doc.chunk_count,
-                        "new_value": qdrant_count,
+                        "old_value": old_count,
+                        "new_value": vector_count,
                     }
                 )
 
@@ -161,7 +151,7 @@ async def reconcile(
 
     return {
         "total_documents": len(all_docs),
-        "total_qdrant_documents": len(qdrant_doc_ids),
+        "total_vector_documents": len(vector_doc_ids),
         "synced": max(synced, 0),
         "issues": issues,
         "repairs": repairs,

--- a/tests/test_pgvector_service.py
+++ b/tests/test_pgvector_service.py
@@ -1,8 +1,11 @@
 """Tests for PgVectorService (requires PostgreSQL + pgvector)."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
-from ai_ready_rag.services.pgvector_service import PgVectorService, SearchResult
+from ai_ready_rag.services.pgvector_service import PgVectorService
+from ai_ready_rag.services.vector_types import SearchResult
 
 
 class TestPgVectorServiceImport:
@@ -59,6 +62,82 @@ class TestPgVectorServiceImport:
         )
         assert r.tags is None
         assert r.section == "Introduction"
+
+    def test_has_embed_method(self):
+        """PgVectorService exposes public embed() method."""
+        svc = PgVectorService(database_url="sqlite:///test.db")
+        assert callable(getattr(svc, "embed", None))
+
+    def test_has_get_extended_stats_method(self):
+        """PgVectorService exposes get_extended_stats() method."""
+        svc = PgVectorService(database_url="sqlite:///test.db")
+        assert callable(getattr(svc, "get_extended_stats", None))
+
+    def test_has_refresh_capabilities_method(self):
+        """PgVectorService exposes refresh_capabilities() method."""
+        svc = PgVectorService(database_url="sqlite:///test.db")
+        assert callable(getattr(svc, "refresh_capabilities", None))
+
+
+class TestPgVectorServiceNewMethods:
+    """Unit tests for the 3 new methods — uses mocks, no DB required."""
+
+    @pytest.fixture
+    def svc(self):
+        return PgVectorService(database_url="sqlite:///test.db", tenant_id="test-tenant")
+
+    @pytest.mark.asyncio
+    async def test_embed_delegates_to_private_embed(self, svc):
+        """embed() is a thin wrapper around _embed()."""
+        svc._embed = AsyncMock(return_value=[0.1, 0.2, 0.3])
+        result = await svc.embed("hello world")
+        svc._embed.assert_called_once_with("hello world")
+        assert result == [0.1, 0.2, 0.3]
+
+    @pytest.mark.asyncio
+    async def test_refresh_capabilities_returns_pgvector_backend(self, svc):
+        """refresh_capabilities() returns pgvector backend descriptor."""
+        result = await svc.refresh_capabilities()
+        assert result["backend"] == "pgvector"
+        assert "vector_search" in result["capabilities"]
+        assert isinstance(result["capabilities"], list)
+
+    @pytest.mark.asyncio
+    async def test_get_extended_stats_empty_db(self, svc):
+        """get_extended_stats() returns zero totals when chunk_vectors is empty."""
+        mock_db = MagicMock()
+        mock_db.__enter__ = MagicMock(return_value=mock_db)
+        mock_db.__exit__ = MagicMock(return_value=False)
+        mock_db.execute.return_value.fetchall.return_value = []
+
+        with patch("ai_ready_rag.services.pgvector_service.SessionLocal", return_value=mock_db):
+            result = await svc.get_extended_stats()
+
+        assert result["total_chunks"] == 0
+        assert result["unique_files"] == 0
+        assert result["files"] == []
+        assert result["collection_name"] == "chunk_vectors"
+
+    @pytest.mark.asyncio
+    async def test_get_extended_stats_with_data(self, svc):
+        """get_extended_stats() aggregates file counts correctly."""
+        mock_db = MagicMock()
+        mock_db.__enter__ = MagicMock(return_value=mock_db)
+        mock_db.__exit__ = MagicMock(return_value=False)
+        # Simulate 2 documents: 10 + 5 chunks
+        mock_db.execute.return_value.fetchall.return_value = [
+            ("doc-1", "policy.pdf", 10),
+            ("doc-2", "guide.pdf", 5),
+        ]
+
+        with patch("ai_ready_rag.services.pgvector_service.SessionLocal", return_value=mock_db):
+            result = await svc.get_extended_stats()
+
+        assert result["total_chunks"] == 15
+        assert result["unique_files"] == 2
+        assert len(result["files"]) == 2
+        filenames = [f["filename"] for f in result["files"]]
+        assert "policy.pdf" in filenames
 
 
 @pytest.mark.requires_postgres

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -30,7 +30,7 @@ class TestReconcileEndpoint:
         """Dry run with no drift returns empty issues list."""
         mock_reconcile.return_value = {
             "total_documents": 10,
-            "total_qdrant_documents": 10,
+            "total_vector_documents": 10,
             "synced": 10,
             "issues": [],
             "repairs": [],
@@ -55,16 +55,16 @@ class TestReconcileEndpoint:
         """Ghost doc (ready in SQLite, 0 vectors) is detected."""
         mock_reconcile.return_value = {
             "total_documents": 5,
-            "total_qdrant_documents": 4,
+            "total_vector_documents": 4,
             "synced": 4,
             "issues": [
                 {
                     "document_id": "abc-123",
                     "filename": "report.pdf",
                     "issue": "ghost_doc",
-                    "detail": "status=ready in SQLite but 0 vectors in Qdrant",
+                    "detail": "status=ready in SQLite but 0 vectors in chunk_vectors",
                     "sqlite_chunks": 36,
-                    "qdrant_chunks": 0,
+                    "vector_chunks": 0,
                 }
             ],
             "repairs": [],
@@ -87,16 +87,16 @@ class TestReconcileEndpoint:
         """Repair mode returns repairs list."""
         mock_reconcile.return_value = {
             "total_documents": 5,
-            "total_qdrant_documents": 6,
+            "total_vector_documents": 6,
             "synced": 4,
             "issues": [
                 {
                     "document_id": "orphan-1",
                     "filename": None,
                     "issue": "orphan_vectors",
-                    "detail": "Vectors exist in Qdrant but no SQLite record",
+                    "detail": "Vectors exist in chunk_vectors but no SQLite record",
                     "sqlite_chunks": None,
-                    "qdrant_chunks": 14,
+                    "vector_chunks": 14,
                 }
             ],
             "repairs": [


### PR DESCRIPTION
## Summary

- Adds `embed()` — public wrapper around `_embed()` for `/cache/seed` endpoint
- Adds `get_extended_stats()` — SQL aggregation over `chunk_vectors` with PostgreSQL (`->>`) and SQLite (`json_extract()`) fallback
- Adds `refresh_capabilities()` — returns pgvector backend descriptor
- Rewrites `reconciliation_service.py` to query `chunk_vectors` via SQL instead of Qdrant scroll API; removes `from qdrant_client import models`
- Updates `ReconcileResponse` schema: `total_qdrant_documents` → `total_vector_documents`
- Adds 7 unit tests for new methods (`TestPgVectorServiceNewMethods`)
- Updates `test_reconciliation.py` mock data to use new field names

## Test plan

- [x] `pytest tests/test_pgvector_service.py tests/test_reconciliation.py -v` — 17 passed, 1 skipped
- [x] All 21 failures are pre-existing (verified against main before changes)

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)