### PR TITLE
feat: Text-to-SQL with schema-aware routing for Excel tables (#453)

### DIFF
--- a/ai_ready_rag/db/models/__init__.py
+++ b/ai_ready_rag/db/models/__init__.py
@@ -28,6 +28,7 @@ from ai_ready_rag.db.models.evaluation import (
     EvaluationSample,
     LiveEvaluationScore,
 )
+from ai_ready_rag.db.models.excel_tables import ExcelTableRegistry
 from ai_ready_rag.db.models.rag import CuratedQA, CuratedQAKeyword, QuerySynonym
 from ai_ready_rag.db.models.review import ReviewItem
 from ai_ready_rag.db.models.suggestion import TagSuggestion
@@ -67,4 +68,5 @@ __all__ = [
     "EnrichmentSynopsis",
     "EnrichmentEntity",
     "ReviewItem",
+    "ExcelTableRegistry",
 ]

--- a/ai_ready_rag/db/models/excel_tables.py
+++ b/ai_ready_rag/db/models/excel_tables.py
@@ -1,0 +1,45 @@
+"""SQLAlchemy model for the excel_table_registry table.
+
+Stores schema metadata for tables written to the excel_tables schema by
+ingestkit-excel, enabling schema-aware NL2SQL routing.
+"""
+
+from sqlalchemy import Column, DateTime, Index, Integer, String, Text
+
+from ai_ready_rag.db.database import Base
+from ai_ready_rag.db.models.base import generate_uuid
+
+
+class ExcelTableRegistry(Base):
+    """Registry of tables written to the excel_tables schema.
+
+    Each row represents one table written by ingestkit-excel. The columns/
+    column_types fields carry the DataFrame schema as JSON, used by
+    ExcelTablesService to build column_signals for schema-aware routing.
+    """
+
+    __tablename__ = "excel_table_registry"
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    table_name = Column(String, nullable=False)
+    schema_name = Column(String, nullable=False, default="excel_tables")
+    columns = Column(Text, nullable=False)  # JSON list of column names
+    column_types = Column(Text, nullable=True)  # JSON dict of col -> dtype string
+    document_name = Column(String, nullable=True)
+    document_id = Column(String, nullable=True)
+    tenant_id = Column(String, nullable=False, default="default")
+    row_count = Column(Integer, nullable=True)
+    table_metadata = Column(Text, nullable=True)  # JSON extras (sheet name, etc.)
+    created_at = Column(DateTime, nullable=True)
+    updated_at = Column(DateTime, nullable=True)
+
+    __table_args__ = (
+        Index("ix_excel_table_registry_table_name", "table_name"),
+        Index("ix_excel_table_registry_tenant_id", "tenant_id"),
+        Index(
+            "ix_excel_table_registry_schema_table",
+            "schema_name",
+            "table_name",
+            unique=True,
+        ),
+    )

--- a/ai_ready_rag/main.py
+++ b/ai_ready_rag/main.py
@@ -120,8 +120,8 @@ async def lifespan(app: FastAPI):
     if settings.use_ingestkit_excel and "postgresql" in settings.database_url:
         from ai_ready_rag.services.excel_tables_service import ExcelTablesService
 
-        n = ExcelTablesService(settings.database_url).discover_and_register()
-        logger.info("excel_tables_service: registered %d year tables", n)
+        n = ExcelTablesService(settings.database_url).discover_and_register_all()
+        logger.info("excel_tables_service: registered %d sql templates", n)
 
     # Verify evaluation tables exist (fail-fast if eval_enabled and tables missing)
     if settings.eval_enabled:

--- a/ai_ready_rag/modules/registry.py
+++ b/ai_ready_rag/modules/registry.py
@@ -38,6 +38,7 @@ class SQLTemplate:
     sql: str
     trigger_phrases: list[str] = field(default_factory=list)
     description: str = ""
+    column_signals: dict[str, list[str]] | None = field(default=None)
 
 
 # ─── SQL template safety guards ─────────────────────────────────────────────

--- a/ai_ready_rag/services/excel_tables_service.py
+++ b/ai_ready_rag/services/excel_tables_service.py
@@ -1,20 +1,26 @@
 """ExcelTablesService — registers SQL templates for excel_tables schema at startup.
 
-Discovers year-based P&L tables written by ingestkit-excel and registers a single
-'excel_pl_financials' SQLTemplate with financial trigger phrases. The QueryRouter
-will route financial queries to this template; _execute_sql_route then runs the
-UNION ALL query across all years and passes the results to Claude for synthesis.
+Queries the excel_table_registry table (written by ingestkit-excel at ingest time)
+and registers:
+  - One UNION ALL SQLTemplate for P&L tables (backward-compatible, trigger-phrase based)
+  - One per-table SQLTemplate with column_signals for all other tables (NL2SQL path)
+
+The QueryRouter scores column_signals for non-P&L queries; _execute_nl2sql_route in
+RAGService then generates and executes the SQL via Claude.
 """
 
 from __future__ import annotations
 
+import json
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
-# Trigger phrases that indicate the user is asking about financial statement data.
-# Any query containing one of these phrases will be routed to the SQL template.
-_FINANCIAL_TRIGGER_PHRASES = [
+# ---------------------------------------------------------------------------
+# P&L trigger phrases (kept for backward compatibility with financial tables)
+# ---------------------------------------------------------------------------
+_PL_TRIGGER_PHRASES = [
     "cogs",
     "cost of goods",
     "cost of goods sold",
@@ -38,7 +44,80 @@ _FINANCIAL_TRIGGER_PHRASES = [
     "interest expense",
 ]
 
-_TEMPLATE_NAME = "excel_pl_financials"
+# Column names that strongly indicate a P&L financial table
+_PL_COLUMN_INDICATORS = {
+    "revenue",
+    "cogs",
+    "net income",
+    "gross profit",
+    "operating income",
+    "operating expenses",
+    "ebitda",
+    "item",
+    "value",
+    "year",
+    "income before taxes",
+    "interest expense",
+    "materials",
+    "direct labor",
+    "manufacturing overhead",
+}
+
+_PL_TEMPLATE_NAME = "excel_pl_financials"
+
+# Quantitative signals that indicate a user wants a SQL-answerable query
+QUANTITATIVE_SIGNALS = [
+    "how many",
+    "how much",
+    "total",
+    "sum",
+    "count",
+    "average",
+    "on hand",
+    "balance",
+    "amount due",
+    "list all",
+    "show me all",
+    "give me",
+    "quantity",
+    "in stock",
+    "remaining",
+    "what is the",
+    "show me",
+    "outstanding",
+    "aged",
+]
+
+
+# ---------------------------------------------------------------------------
+# SQL injection guard
+# ---------------------------------------------------------------------------
+
+
+class SqlInjectionGuard:
+    """Validates that Claude-generated SQL is a plain SELECT with no side effects."""
+
+    _FORBIDDEN = re.compile(
+        r"\b(INSERT|UPDATE|DELETE|DROP|TRUNCATE|ALTER|CREATE|REPLACE|MERGE|EXEC|EXECUTE|GRANT|REVOKE)\b",
+        re.IGNORECASE,
+    )
+
+    def validate(self, sql: str) -> None:
+        """Raise ValueError if sql is not a safe SELECT statement."""
+        stripped = sql.strip()
+        if not re.search(r"^\s*SELECT\b", stripped, re.IGNORECASE):
+            raise ValueError(
+                f"SQL injection guard: only SELECT statements are allowed. Got: {stripped[:60]}"
+            )
+        if self._FORBIDDEN.search(stripped):
+            raise ValueError(
+                f"SQL injection guard: forbidden statement in generated SQL: {stripped[:80]}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# ExcelTablesService
+# ---------------------------------------------------------------------------
 
 
 class ExcelTablesService:
@@ -52,22 +131,135 @@ class ExcelTablesService:
         self._database_url = database_url
 
     def discover_and_register(self) -> int:
-        """Discover all year tables and register a UNION ALL SQL template.
+        """Discover tables from excel_table_registry and register SQL templates.
+
+        Queries the excel_table_registry table (populated by ingestkit-excel at
+        ingest time) to get the current set of tables and their schemas.
 
         Returns:
-            Number of year tables found (0 if schema doesn't exist yet).
+            Total number of SQL templates registered (P&L union + per-table).
         """
-        tables = self._discover_year_tables()
-        if not tables:
-            logger.info("excel_tables.discovery: no tables found — skipping registration")
-            return 0
+        return self.discover_and_register_all()
 
-        sql = self._build_union_sql(tables)
-        self._register_template(sql, tables)
-        return len(tables)
+    def discover_and_register_all(self) -> int:
+        """Query excel_table_registry and register all tables as SQL templates.
 
-    def _discover_year_tables(self) -> list[str]:
-        """Return sorted list of table names in the excel_tables schema."""
+        - P&L tables (detected by column overlap with financial vocabulary) are
+          registered as a single UNION ALL template with trigger phrases.
+        - Non-P&L tables are registered one-per-table with column_signals for
+          the NL2SQL path.
+
+        Returns:
+            Total number of SQL templates registered.
+        """
+        registry_rows = self._discover_registry_tables()
+
+        if not registry_rows:
+            # Fall back to the old information_schema discovery for P&L only
+            logger.info("excel_tables.discover_all: registry empty — trying legacy discovery")
+            pl_tables = self._discover_year_tables_legacy()
+            if not pl_tables:
+                logger.info("excel_tables.discover_all: no tables found — skipping registration")
+                return 0
+            sql = self._build_union_sql(pl_tables)
+            self._register_pl_template(sql, pl_tables)
+            return 1
+
+        pl_tables: list[str] = []
+        non_pl_rows: list[dict] = []
+
+        for row in registry_rows:
+            table_name = row["table_name"]
+            schema_name = row.get("schema_name", "excel_tables")
+            try:
+                col_list = json.loads(row["columns"])
+            except (json.JSONDecodeError, KeyError):
+                col_list = []
+
+            try:
+                col_types = json.loads(row.get("column_types") or "{}")
+            except json.JSONDecodeError:
+                col_types = {}
+
+            if self._is_pl_table(col_list):
+                pl_tables.append(table_name)
+            else:
+                non_pl_rows.append(
+                    {
+                        "table_name": table_name,
+                        "schema_name": schema_name,
+                        "columns": col_list,
+                        "column_types": col_types,
+                    }
+                )
+
+        registered = 0
+
+        # Register P&L union template (backward compat)
+        if pl_tables:
+            sql = self._build_union_sql(pl_tables)
+            self._register_pl_template(sql, pl_tables)
+            registered += 1
+
+        # Register one template per non-P&L table with column_signals
+        for row in non_pl_rows:
+            self._register_table_template(
+                table_name=row["table_name"],
+                schema_name=row["schema_name"],
+                columns=row["columns"],
+                column_types=row["column_types"],
+            )
+            registered += 1
+
+        logger.info(
+            "excel_tables.discover_all: registered %d templates (%d P&L, %d per-table)",
+            registered,
+            1 if pl_tables else 0,
+            len(non_pl_rows),
+        )
+        return registered
+
+    # -----------------------------------------------------------------------
+    # Discovery helpers
+    # -----------------------------------------------------------------------
+
+    def _discover_registry_tables(self) -> list[dict]:
+        """Query excel_table_registry for all registered tables.
+
+        Returns:
+            List of dicts with table_name, schema_name, columns, column_types keys.
+            Returns [] on exception (table may not exist yet).
+        """
+        try:
+            import psycopg2
+
+            conn = psycopg2.connect(self._database_url)
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT table_name, schema_name, columns, column_types "
+                    "FROM excel_table_registry "
+                    "ORDER BY table_name"
+                )
+                rows = cur.fetchall()
+            conn.close()
+            return [
+                {
+                    "table_name": row[0],
+                    "schema_name": row[1],
+                    "columns": row[2],
+                    "column_types": row[3],
+                }
+                for row in rows
+            ]
+        except Exception as exc:
+            logger.warning("excel_tables.registry_query.failed: %s", exc)
+            return []
+
+    def _discover_year_tables_legacy(self) -> list[str]:
+        """Legacy: query information_schema for tables in excel_tables schema.
+
+        Used as fallback when excel_table_registry does not exist yet.
+        """
         try:
             import psycopg2
 
@@ -82,11 +274,57 @@ class ExcelTablesService:
             conn.close()
             return tables
         except Exception as exc:
-            logger.warning("excel_tables.discovery.failed: %s", exc)
+            logger.warning("excel_tables.legacy_discovery.failed: %s", exc)
             return []
 
+    # -----------------------------------------------------------------------
+    # Classification helpers
+    # -----------------------------------------------------------------------
+
+    def _is_pl_table(self, col_list: list[str]) -> bool:
+        """Return True if the column list looks like a P&L financial table."""
+        col_lower = {c.lower() for c in col_list}
+        overlap = col_lower & _PL_COLUMN_INDICATORS
+        return len(overlap) >= 2
+
+    def _compute_column_signals(
+        self, table_name: str, columns: list[str], column_types: dict
+    ) -> dict[str, list[str]]:
+        """Build a column_signals dict for the given table.
+
+        The signals dict has:
+        - One key per column name with synonyms derived from the column name
+        - A "__quantitative__" key with the global quantitative signal list
+
+        Args:
+            table_name: Name of the table (for generating table-level synonyms).
+            columns: List of column names from the DataFrame.
+            column_types: Dict mapping column name -> dtype string (may be empty).
+
+        Returns:
+            Dict suitable for SQLTemplate.column_signals.
+        """
+        signals: dict[str, list[str]] = {}
+
+        for col in columns:
+            col_lower = col.lower().replace("_", " ").strip()
+            synonyms = [col_lower]
+            # Add the original column name (with underscores) as well
+            if "_" in col:
+                synonyms.append(col.lower())
+            signals[col] = synonyms
+
+        # Always add quantitative signals under sentinel key
+        signals["__quantitative__"] = list(QUANTITATIVE_SIGNALS)
+
+        return signals
+
+    # -----------------------------------------------------------------------
+    # SQL builders
+    # -----------------------------------------------------------------------
+
     def _build_union_sql(self, tables: list[str]) -> str:
-        """Build a UNION ALL SELECT across all year tables."""
+        """Build a UNION ALL SELECT across all year tables (P&L path)."""
         branches = [
             f'SELECT \'{t}\' AS year, "0" AS item, "1" AS value FROM excel_tables."{t}"'
             for t in tables
@@ -99,20 +337,72 @@ class ExcelTablesService:
             f"LIMIT :row_cap"
         )
 
-    def _register_template(self, sql: str, tables: list[str]) -> None:
-        """Register the UNION ALL template with the ModuleRegistry."""
+    # -----------------------------------------------------------------------
+    # Registration helpers
+    # -----------------------------------------------------------------------
+
+    def _register_pl_template(self, sql: str, tables: list[str]) -> None:
+        """Register the UNION ALL P&L template with trigger phrases."""
         from ai_ready_rag.modules.registry import SQLTemplate, get_registry
 
         template = SQLTemplate(
-            name=_TEMPLATE_NAME,
+            name=_PL_TEMPLATE_NAME,
             sql=sql,
-            trigger_phrases=_FINANCIAL_TRIGGER_PHRASES,
+            trigger_phrases=_PL_TRIGGER_PHRASES,
             description=f"P&L data from excel_tables schema ({', '.join(tables)})",
+            column_signals=None,
         )
         registry = get_registry()
-        registry.register_sql_templates("core.excel_tables", {_TEMPLATE_NAME: template})
+        registry.register_sql_templates("core.excel_tables", {_PL_TEMPLATE_NAME: template})
         logger.info(
             "excel_tables.registered: template=%s tables=%s",
-            _TEMPLATE_NAME,
+            _PL_TEMPLATE_NAME,
             tables,
         )
+
+    def _register_table_template(
+        self,
+        table_name: str,
+        schema_name: str,
+        columns: list[str],
+        column_types: dict,
+    ) -> None:
+        """Register a per-table NL2SQL template with column_signals.
+
+        The SQL is a simple placeholder SELECT; actual SQL is generated by Claude
+        at query time via _execute_nl2sql_route in RAGService.
+        """
+        from ai_ready_rag.modules.registry import SQLTemplate, get_registry
+
+        # Build a simple fallback SQL (used when column_signals is set, the
+        # actual NL2SQL generation happens at query time — but we still need
+        # a valid SQL to pass _validate_sql_template which requires LIMIT).
+        quoted_cols = ", ".join(f'"{c}"' for c in columns[:10]) if columns else "*"
+        sql = f'SELECT {quoted_cols} FROM "{schema_name}"."{table_name}" LIMIT :row_cap'
+
+        column_signals = self._compute_column_signals(table_name, columns, column_types)
+
+        template_name = f"excel_{table_name}"
+        template = SQLTemplate(
+            name=template_name,
+            sql=sql,
+            trigger_phrases=[],
+            description=f"Table {schema_name}.{table_name} — NL2SQL via column signals",
+            column_signals=column_signals,
+        )
+
+        registry = get_registry()
+        registry.register_sql_templates("core.excel_tables", {template_name: template})
+        logger.info(
+            "excel_tables.registered_table_template: name=%s columns=%d",
+            template_name,
+            len(columns),
+        )
+
+    # -----------------------------------------------------------------------
+    # Legacy method kept for callers that call _register_template directly
+    # -----------------------------------------------------------------------
+
+    def _register_template(self, sql: str, tables: list[str]) -> None:
+        """Legacy alias for _register_pl_template (backward compat)."""
+        self._register_pl_template(sql, tables)

--- a/ai_ready_rag/services/ingestkit_adapters.py
+++ b/ai_ready_rag/services/ingestkit_adapters.py
@@ -347,10 +347,65 @@ class VERagPostgresStructuredDB:
         )
         try:
             df.to_sql(table_name, engine, if_exists="replace", index=False, schema=self._SCHEMA)
+            # Register schema metadata in excel_table_registry for NL2SQL discovery
+            self._register_table_in_registry(table_name, df)
         except Exception as exc:
             raise RuntimeError(f"Failed to write table '{table_name}': {exc}") from exc
         finally:
             engine.dispose()
+
+    def _register_table_in_registry(self, table_name: str, df) -> None:
+        """Write table schema to excel_table_registry for NL2SQL discovery.
+
+        Uses UPSERT so re-ingesting the same file updates the existing row
+        rather than creating a duplicate. Failures are logged but never raised
+        (registry write must not break ingest).
+        """
+        import uuid as _uuid
+        from datetime import datetime
+
+        try:
+            columns = list(df.columns.astype(str))
+            column_types = {str(col): str(dtype) for col, dtype in df.dtypes.items()}
+            now = datetime.utcnow()
+
+            with self._connect() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        INSERT INTO excel_table_registry
+                            (id, table_name, schema_name, columns, column_types,
+                             tenant_id, row_count, created_at, updated_at)
+                        VALUES
+                            (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        ON CONFLICT (schema_name, table_name)
+                        DO UPDATE SET
+                            columns = EXCLUDED.columns,
+                            column_types = EXCLUDED.column_types,
+                            row_count = EXCLUDED.row_count,
+                            updated_at = EXCLUDED.updated_at
+                        """,
+                        (
+                            str(_uuid.uuid4()),
+                            table_name,
+                            self._SCHEMA,
+                            json.dumps(columns),
+                            json.dumps(column_types),
+                            getattr(self, "_tenant_id", "default"),
+                            len(df),
+                            now,
+                            now,
+                        ),
+                    )
+                conn.commit()
+            logger.info(
+                "excel_table_registry.written: table=%s columns=%d rows=%d",
+                table_name,
+                len(columns),
+                len(df),
+            )
+        except Exception as exc:
+            logger.warning("excel_table_registry.write_failed: %s", exc)
 
     def drop_table(self, table_name: str) -> None:
         with self._connect() as conn:

--- a/ai_ready_rag/services/query_router.py
+++ b/ai_ready_rag/services/query_router.py
@@ -2,9 +2,11 @@
 
 No LLM call is made during routing. Routing decisions are:
 1. SQL-first: if entity extraction + trigger phrases + confidence >= threshold -> structured query
-2. RAG fallback: all other queries -> vector search
+2. SQL-first: if quantitative signals + column signals match and confidence >= threshold -> NL2SQL
+3. RAG fallback: all other queries -> vector search
 
 Modules contribute SQL templates and trigger phrases via ModuleRegistry.register_sql_templates().
+Templates with column_signals set are eligible for quantitative signal scoring (NL2SQL path).
 """
 
 from __future__ import annotations
@@ -15,6 +17,31 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 logger = logging.getLogger(__name__)
+
+# Quantitative signals that indicate a user wants a data-lookup/aggregation answer.
+# When a template has column_signals set, both a quantitative signal AND a column signal
+# must appear in the query to produce a confidence score >= sql_confidence_threshold.
+QUANTITATIVE_SIGNALS = [
+    "how many",
+    "how much",
+    "total",
+    "sum",
+    "count",
+    "average",
+    "on hand",
+    "balance",
+    "amount due",
+    "list all",
+    "show me all",
+    "give me",
+    "quantity",
+    "in stock",
+    "remaining",
+    "what is the",
+    "show me",
+    "outstanding",
+    "aged",
+]
 
 
 class RouteType(str, Enum):
@@ -97,21 +124,29 @@ class QueryRouter:
                 if re.search(r"\b" + re.escape(phrase.lower()) + r"\b", query_lower):
                     matched.append(phrase)
 
-            if not matched:
-                continue
+            if matched:
+                # Presence-based confidence: trigger_phrases are domain vocabulary, not a
+                # checklist.  Any matching phrase means the query is in-domain → base 0.7.
+                # A density bonus (up to 0.3) rewards more matches and is used for template
+                # disambiguation when multiple templates share trigger phrases.
+                n_total = max(len(template.trigger_phrases), 1)
+                density_bonus = min((len(matched) - 1) / max(n_total - 1, 1) * 0.3, 0.3)
+                confidence = 0.7 + density_bonus
 
-            # Presence-based confidence: trigger_phrases are domain vocabulary, not a
-            # checklist.  Any matching phrase means the query is in-domain → base 0.7.
-            # A density bonus (up to 0.3) rewards more matches and is used for template
-            # disambiguation when multiple templates share trigger phrases.
-            n_total = max(len(template.trigger_phrases), 1)
-            density_bonus = min((len(matched) - 1) / max(n_total - 1, 1) * 0.3, 0.3)
-            confidence = 0.7 + density_bonus
+                if confidence > best_confidence:
+                    best_confidence = confidence
+                    best_template = name
+                    best_phrases = matched
 
-            if confidence > best_confidence:
-                best_confidence = confidence
-                best_template = name
-                best_phrases = matched
+            elif template.column_signals is not None:
+                # No phrase match — try quantitative signal scoring for NL2SQL templates
+                signal_confidence = self._score_quantitative_signals(
+                    query_lower, template.column_signals
+                )
+                if signal_confidence > best_confidence:
+                    best_confidence = signal_confidence
+                    best_template = name
+                    best_phrases = ["<quantitative_signal>"]
 
         if best_template is None:
             return RoutingDecision(
@@ -153,3 +188,50 @@ class QueryRouter:
             matched_phrases=best_phrases,
             reason="below_sql_threshold",
         )
+
+    def _score_quantitative_signals(
+        self, query_lower: str, column_signals: dict[str, list[str]]
+    ) -> float:
+        """Score a query against column_signals for NL2SQL routing.
+
+        Algorithm:
+          - base score 0.5 if any QUANTITATIVE_SIGNALS phrase appears in the query
+          - column bonus 0.25 if any column synonym from column_signals appears
+          - Returns 0.75 when both hit (above 0.6 threshold → SQL route)
+          - Returns 0.5 when only quantitative hit (below 0.6 threshold → RAG)
+          - Returns 0.0 when neither hit
+
+        Args:
+            query_lower: Lowercased query string.
+            column_signals: Dict from SQLTemplate.column_signals.
+
+        Returns:
+            Confidence float in range [0.0, 0.75].
+        """
+        # Check quantitative signals
+        quantitative_hit = False
+        quant_signals = column_signals.get("__quantitative__", QUANTITATIVE_SIGNALS)
+        for signal in quant_signals:
+            if re.search(r"\b" + re.escape(signal.lower()) + r"\b", query_lower):
+                quantitative_hit = True
+                break
+
+        if not quantitative_hit:
+            return 0.0
+
+        # Check column name signals (exclude __quantitative__ sentinel key)
+        column_hit = False
+        for col_key, synonyms in column_signals.items():
+            if col_key == "__quantitative__":
+                continue
+            for syn in synonyms:
+                if re.search(r"\b" + re.escape(syn.lower()) + r"\b", query_lower):
+                    column_hit = True
+                    break
+            if column_hit:
+                break
+
+        # Score: 0.5 base + 0.25 column bonus = 0.75 total (above 0.6 threshold)
+        base = 0.5
+        column_bonus = 0.25 if column_hit else 0.0
+        return base + column_bonus

--- a/ai_ready_rag/services/rag_service.py
+++ b/ai_ready_rag/services/rag_service.py
@@ -39,6 +39,7 @@ from ai_ready_rag.services.settings_service import get_rag_setting
 from ai_ready_rag.services.vector_types import SearchResult
 
 if TYPE_CHECKING:
+    from ai_ready_rag.modules.registry import SQLTemplate
     from ai_ready_rag.services.protocols import VectorServiceProtocol
     from ai_ready_rag.services.query_router import QueryRouter, RoutingDecision
 
@@ -1993,6 +1994,16 @@ class RAGService:
             )
             return self._insufficient_context_response(self.default_model, elapsed_ms, "SQL")
 
+        # NL2SQL path: templates with column_signals need Claude to generate the SQL
+        if sql_template.column_signals is not None:
+            return await self._execute_nl2sql_route(
+                decision=decision,
+                query=query,
+                db=db,
+                elapsed_ms=elapsed_ms,
+                sql_template=sql_template,
+            )
+
         row_cap = getattr(self.settings, "structured_query_row_cap", 100)
         try:
             result = db.execute(sa_text(sql_template.sql), {"row_cap": row_cap})
@@ -2076,6 +2087,170 @@ class RAGService:
 
         # Fallback: return formatted table if Claude fails
         return data_text
+
+    async def _execute_nl2sql_route(
+        self,
+        decision: RoutingDecision,
+        query: str,
+        db: Session,
+        elapsed_ms: float,
+        sql_template: SQLTemplate,
+    ) -> RAGResponse:
+        """Execute NL2SQL: generate SQL via Claude, validate, run it, synthesize answer.
+
+        This path is taken when a SQL template has column_signals set (non-P&L tables).
+        Claude generates a schema-aware SELECT statement; the injection guard validates
+        it before execution.
+
+        Args:
+            decision: Routing decision that selected this template.
+            query: Original user query.
+            db: SQLAlchemy session for executing the generated SQL.
+            elapsed_ms: Elapsed time so far for latency tracking.
+            sql_template: The matched SQLTemplate with column_signals.
+
+        Returns:
+            RAGResponse with routing_decision="SQL".
+        """
+        from sqlalchemy import text as sa_text
+
+        from ai_ready_rag.services.excel_tables_service import SqlInjectionGuard
+
+        template_name = sql_template.name
+        column_signals = sql_template.column_signals or {}
+        columns = [k for k in column_signals if k != "__quantitative__"]
+
+        # 1. Build schema context for Claude
+        # Extract table name from template name (template name is "excel_<table_name>")
+        table_name = template_name
+        if template_name.startswith("excel_"):
+            table_name = template_name[len("excel_") :]
+
+        schema_context = (
+            f'Table: excel_tables."{table_name}"\n'
+            f"Columns: {', '.join(str(c) for c in columns)}\n"
+            f"Write a safe PostgreSQL SELECT query to answer this question.\n"
+            f"Use ILIKE for text matching. Quote column names with double quotes.\n"
+            f"Return ONLY the SQL, no explanation, no markdown."
+        )
+
+        # 2. Generate SQL via Claude
+        generated_sql = await self._generate_sql_from_schema(query, schema_context)
+
+        if not generated_sql:
+            logger.info("nl2sql.no_sql_generated — falling back to insufficient context")
+            return self._insufficient_context_response(self.default_model, elapsed_ms, "SQL")
+
+        # 3. SQL injection guard
+        try:
+            SqlInjectionGuard().validate(generated_sql)
+        except ValueError as exc:
+            logger.warning("nl2sql.injection_guard_blocked: %s", exc)
+            return self._insufficient_context_response(self.default_model, elapsed_ms, "SQL")
+
+        # 4. Execute the generated SQL
+        try:
+            result = db.execute(sa_text(generated_sql))
+            rows = result.fetchall()
+            col_names = list(result.keys())
+        except Exception as exc:
+            logger.warning(
+                "nl2sql.execution_failed: %s | SQL: %s",
+                exc,
+                generated_sql[:200],
+            )
+            return self._insufficient_context_response(self.default_model, elapsed_ms, "SQL")
+
+        # 5. Synthesize natural-language answer
+        if not rows:
+            answer = "No matching records found in the database for your query."
+        else:
+            row_cap = getattr(self.settings, "structured_query_row_cap", 100)
+            header = " | ".join(col_names)
+            body_lines = [
+                " | ".join(str(cell) if cell is not None else "" for cell in row)
+                for row in rows[:row_cap]
+            ]
+            data_text = f"{header}\n" + "\n".join(body_lines)
+            answer = await self._synthesize_sql_answer(query, data_text)
+
+        logger.info(
+            "nl2sql.success",
+            extra={
+                "template": template_name,
+                "rows_returned": len(rows),
+                "confidence": decision.confidence,
+            },
+        )
+
+        return RAGResponse(
+            answer=answer,
+            confidence=ConfidenceScore(
+                overall=90,
+                retrieval_score=decision.confidence,
+                coverage_score=1.0,
+                llm_score=90,
+            ),
+            citations=[],
+            action="CITE",
+            route_to=None,
+            model_used="claude-cli",
+            context_chunks_used=len(rows),
+            context_tokens_used=0,
+            generation_time_ms=elapsed_ms,
+            grounded=True,
+            routing_decision="SQL",
+        )
+
+    async def _generate_sql_from_schema(self, query: str, schema_context: str) -> str:
+        """Ask Claude to generate a PostgreSQL SELECT statement given schema context.
+
+        Args:
+            query: User's natural-language question.
+            schema_context: Table name and column info for the prompt.
+
+        Returns:
+            Generated SQL string, or empty string on failure.
+        """
+        import asyncio
+        import os
+        import subprocess
+
+        prompt = (
+            f"You are a PostgreSQL expert. Generate a single SQL SELECT query.\n\n"
+            f"{schema_context}\n\n"
+            f"Rules:\n"
+            f"- Return ONLY the SQL query, no explanation, no markdown fences\n"
+            f'- Use double-quoted column names (e.g., "On Hand", "Item")\n'
+            f"- Add LIMIT 100 unless the query is an aggregate (COUNT, SUM, etc.)\n"
+            f"- Use ILIKE for text matching\n\n"
+            f"User question: {query}\n\n"
+            f"SQL:"
+        )
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+        try:
+            result = await asyncio.to_thread(
+                lambda: subprocess.run(
+                    ["claude", "-p", prompt],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    env=env,
+                )
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                generated = result.stdout.strip()
+                # Strip markdown code fences if Claude added them
+                if generated.startswith("```"):
+                    lines = generated.split("\n")
+                    generated = "\n".join(
+                        line for line in lines if not line.startswith("```")
+                    ).strip()
+                return generated
+        except Exception as exc:
+            logger.warning("nl2sql.generation_failed: %s", exc)
+
+        return ""
 
     async def generate(self, request: RAGRequest, db: Session) -> RAGResponse:
         """Generate RAG response for a query.

--- a/alembic/versions/008_excel_table_registry.py
+++ b/alembic/versions/008_excel_table_registry.py
@@ -1,0 +1,69 @@
+"""Add excel_table_registry table
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-02-28
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "008"
+down_revision = "007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+
+    op.create_table(
+        "excel_table_registry",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("table_name", sa.String(), nullable=False),
+        sa.Column(
+            "schema_name",
+            sa.String(),
+            nullable=False,
+            server_default="excel_tables",
+        ),
+        sa.Column("columns", sa.Text(), nullable=False),  # JSON list of column names
+        sa.Column("column_types", sa.Text(), nullable=True),  # JSON dict of col -> dtype
+        sa.Column("document_name", sa.String(), nullable=True),
+        sa.Column("document_id", sa.String(), nullable=True),
+        sa.Column("tenant_id", sa.String(), nullable=False, server_default="default"),
+        sa.Column("row_count", sa.Integer(), nullable=True),
+        sa.Column("table_metadata", sa.Text(), nullable=True),  # JSON extras
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_excel_table_registry_table_name",
+        "excel_table_registry",
+        ["table_name"],
+    )
+    op.create_index(
+        "ix_excel_table_registry_tenant_id",
+        "excel_table_registry",
+        ["tenant_id"],
+    )
+    op.create_index(
+        "ix_excel_table_registry_schema_table",
+        "excel_table_registry",
+        ["schema_name", "table_name"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+
+    op.drop_index("ix_excel_table_registry_schema_table", "excel_table_registry")
+    op.drop_index("ix_excel_table_registry_tenant_id", "excel_table_registry")
+    op.drop_index("ix_excel_table_registry_table_name", "excel_table_registry")
+    op.drop_table("excel_table_registry")

--- a/tests/test_excel_tables_service.py
+++ b/tests/test_excel_tables_service.py
@@ -1,0 +1,442 @@
+"""Tests for ExcelTablesService, SqlInjectionGuard, and NL2SQL routing.
+
+Tests from issue #453: Text-to-SQL with schema-aware routing.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ai_ready_rag.modules.registry import ModuleRegistry, SQLTemplate
+from ai_ready_rag.services.excel_tables_service import ExcelTablesService, SqlInjectionGuard
+from ai_ready_rag.services.query_router import QueryRouter
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    """Reset registry singleton between tests."""
+    ModuleRegistry.reset()
+    yield
+    ModuleRegistry.reset()
+
+
+@pytest.fixture
+def sql_guard():
+    """SqlInjectionGuard instance."""
+    return SqlInjectionGuard()
+
+
+@pytest.fixture
+def router_with_inventory_template():
+    """QueryRouter with an inventory SQLTemplate with column_signals registered."""
+    registry = ModuleRegistry.get_instance()
+    registry.register_sql_templates(
+        "test_inventory",
+        {
+            "excel_inventory_report": SQLTemplate(
+                name="excel_inventory_report",
+                sql='SELECT "SKU", "Item", "On Hand" FROM "excel_tables"."inventory_report" LIMIT :row_cap',
+                trigger_phrases=[],
+                description="Inventory report with stock levels",
+                column_signals={
+                    "SKU": ["sku", "part number", "part"],
+                    "Item": ["item", "product", "description"],
+                    "On Hand": ["on hand", "quantity", "stock", "in stock", "inventory"],
+                    "__quantitative__": [
+                        "how many",
+                        "how much",
+                        "total",
+                        "count",
+                        "on hand",
+                        "quantity",
+                        "in stock",
+                    ],
+                },
+            )
+        },
+    )
+    return QueryRouter(sql_confidence_threshold=0.6)
+
+
+# =============================================================================
+# TestSqlInjectionGuard
+# =============================================================================
+
+
+class TestSqlInjectionGuard:
+    """Unit tests for SqlInjectionGuard.validate()."""
+
+    def test_valid_select_passes(self, sql_guard):
+        """A plain SELECT statement passes without raising."""
+        sql = "SELECT * FROM excel_tables.inventory LIMIT 100"
+        sql_guard.validate(sql)  # Should not raise
+
+    def test_valid_select_with_where_passes(self, sql_guard):
+        """A SELECT with WHERE clause passes."""
+        sql = 'SELECT "Item", "On Hand" FROM excel_tables.inventory WHERE "SKU" ILIKE \'%plug%\' LIMIT 100'
+        sql_guard.validate(sql)  # Should not raise
+
+    def test_rejects_delete(self, sql_guard):
+        """DELETE statement raises ValueError."""
+        with pytest.raises(ValueError, match="forbidden|only SELECT"):
+            sql_guard.validate("DELETE FROM excel_tables.inventory WHERE id = 1")
+
+    def test_rejects_drop(self, sql_guard):
+        """DROP statement raises ValueError."""
+        with pytest.raises(ValueError, match="forbidden|only SELECT"):
+            sql_guard.validate("DROP TABLE excel_tables.inventory")
+
+    def test_rejects_insert(self, sql_guard):
+        """INSERT statement raises ValueError."""
+        with pytest.raises(ValueError, match="forbidden|only SELECT"):
+            sql_guard.validate("INSERT INTO t VALUES (1, 2, 3)")
+
+    def test_rejects_update(self, sql_guard):
+        """UPDATE statement raises ValueError."""
+        with pytest.raises(ValueError, match="forbidden|only SELECT"):
+            sql_guard.validate("UPDATE excel_tables.inventory SET qty = 0")
+
+    def test_rejects_non_select_start(self, sql_guard):
+        """SQL that starts with non-SELECT raises ValueError."""
+        with pytest.raises(ValueError, match="only SELECT"):
+            sql_guard.validate("TRUNCATE TABLE excel_tables.inventory")
+
+    def test_rejects_select_with_embedded_drop(self, sql_guard):
+        """SQL containing DROP keyword anywhere raises ValueError."""
+        with pytest.raises(ValueError, match="forbidden"):
+            sql_guard.validate("SELECT * FROM t; DROP TABLE t")
+
+
+# =============================================================================
+# TestQueryRouterQuantitativeSignals
+# =============================================================================
+
+
+class TestQueryRouterQuantitativeSignals:
+    """Tests for QueryRouter with quantitative signal scoring."""
+
+    def test_how_many_routes_to_sql(self, router_with_inventory_template):
+        """'how many X on hand' routes to SQL via quantitative signals."""
+        from ai_ready_rag.services.query_router import RouteType
+
+        decision = router_with_inventory_template.route(
+            "how many EndCore Plugger sets on hand?",
+            structured_query_enabled=True,
+        )
+        assert decision.route == RouteType.SQL
+        assert decision.confidence >= 0.6
+
+    def test_total_routes_to_sql(self, router_with_inventory_template):
+        """'total on hand for item' routes to SQL via quantitative signals."""
+        from ai_ready_rag.services.query_router import RouteType
+
+        decision = router_with_inventory_template.route(
+            "what is the total on hand quantity for item X?",
+            structured_query_enabled=True,
+        )
+        assert decision.route == RouteType.SQL
+
+    def test_on_hand_routes_to_sql(self, router_with_inventory_template):
+        """'items on hand' routes to SQL via column signal match."""
+        from ai_ready_rag.services.query_router import RouteType
+
+        decision = router_with_inventory_template.route(
+            "how many items are currently in stock?",
+            structured_query_enabled=True,
+        )
+        assert decision.route == RouteType.SQL
+
+    def test_vacation_policy_stays_rag(self, router_with_inventory_template):
+        """Unrelated query does not match any signal and routes to RAG."""
+        from ai_ready_rag.services.query_router import RouteType
+
+        decision = router_with_inventory_template.route(
+            "what is the vacation policy?",
+            structured_query_enabled=True,
+        )
+        assert decision.route == RouteType.RAG
+
+    def test_structured_disabled_stays_rag(self, router_with_inventory_template):
+        """When structured_query_enabled=False, all queries route to RAG."""
+        from ai_ready_rag.services.query_router import RouteType
+
+        decision = router_with_inventory_template.route(
+            "how many items on hand?",
+            structured_query_enabled=False,
+        )
+        assert decision.route == RouteType.RAG
+
+    def test_count_routes_to_sql(self, router_with_inventory_template):
+        """'count of items in inventory' routes to SQL."""
+        from ai_ready_rag.services.query_router import RouteType
+
+        decision = router_with_inventory_template.route(
+            "count of all items in stock",
+            structured_query_enabled=True,
+        )
+        assert decision.route == RouteType.SQL
+
+    def test_quantitative_only_stays_rag(self):
+        """Quantitative signal alone (no column signal) does NOT route to SQL."""
+        from ai_ready_rag.services.query_router import RouteType
+
+        registry = ModuleRegistry.get_instance()
+        registry.register_sql_templates(
+            "test_table",
+            {
+                "excel_my_table": SQLTemplate(
+                    name="excel_my_table",
+                    sql='SELECT "col" FROM "excel_tables"."my_table" LIMIT :row_cap',
+                    trigger_phrases=[],
+                    description="test",
+                    column_signals={
+                        "SomeObscureColumn": ["xyzzy123"],
+                        "__quantitative__": ["how many", "total"],
+                    },
+                )
+            },
+        )
+        router = QueryRouter(sql_confidence_threshold=0.6)
+
+        # Query has quantitative signal ("how many") but NOT the column synonym ("xyzzy123")
+        decision = router.route(
+            "how many things are there?",
+            structured_query_enabled=True,
+        )
+        # Score should be 0.5 (quantitative hit only) which is below threshold 0.6
+        assert decision.route == RouteType.RAG
+
+
+# =============================================================================
+# TestExcelTableRegistryDiscover
+# =============================================================================
+
+
+class TestExcelTableRegistryDiscover:
+    """Tests for ExcelTablesService registry-based discovery."""
+
+    def test_discover_queries_registry_not_information_schema(self):
+        """discover_and_register_all() queries excel_table_registry, not information_schema."""
+        service = ExcelTablesService("postgresql://fake/db")
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_cursor.fetchall.return_value = []
+        mock_conn.cursor.return_value = mock_cursor
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("psycopg2.connect", return_value=mock_conn),
+            # Prevent get_registry() from raising RuntimeError
+            patch(
+                "ai_ready_rag.services.excel_tables_service.ExcelTablesService"
+                "._discover_year_tables_legacy",
+                return_value=[],
+            ),
+        ):
+            service.discover_and_register_all()
+
+        # Check that the cursor.execute was called with a query containing
+        # "excel_table_registry" and NOT "information_schema"
+        execute_calls = mock_cursor.execute.call_args_list
+        assert len(execute_calls) > 0, "Expected at least one cursor.execute call"
+        first_call_sql = execute_calls[0][0][0]
+        assert "excel_table_registry" in first_call_sql
+        assert "information_schema" not in first_call_sql
+
+    def test_discover_skips_info_schema_when_registry_has_rows(self):
+        """When registry has rows, information_schema is not queried."""
+        service = ExcelTablesService("postgresql://fake/db")
+
+        inventory_columns = json.dumps(["SKU", "Item", "On Hand"])
+        inventory_types = json.dumps({"SKU": "object", "Item": "object", "On Hand": "int64"})
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_cursor.fetchall.return_value = [
+            ("inventory_report", "excel_tables", inventory_columns, inventory_types)
+        ]
+        mock_conn.cursor.return_value = mock_cursor
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.close = MagicMock()
+
+        with patch("psycopg2.connect", return_value=mock_conn):
+            # Call _discover_registry_tables directly — no get_registry involved
+            service._discover_registry_tables()
+
+        execute_calls = mock_cursor.execute.call_args_list
+        for c in execute_calls:
+            sql = c[0][0] if c[0] else ""
+            assert "information_schema" not in sql
+
+
+# =============================================================================
+# TestBackwardCompatibility
+# =============================================================================
+
+
+class TestBackwardCompatibility:
+    """Verify P&L trigger phrases still work after the refactor."""
+
+    def test_pl_revenue_still_routes_to_sql(self):
+        """Financial trigger phrase 'revenue' still routes to SQL."""
+        from ai_ready_rag.services.query_router import RouteType
+
+        registry = ModuleRegistry.get_instance()
+        registry.register_sql_templates(
+            "core.excel_tables",
+            {
+                "excel_pl_financials": SQLTemplate(
+                    name="excel_pl_financials",
+                    sql=(
+                        "SELECT year, item, value FROM ("
+                        'SELECT \'2024\' AS year, "0" AS item, "1" AS value '
+                        'FROM excel_tables."pl_2024"'
+                        ") AS pl_data WHERE item IS NOT NULL LIMIT :row_cap"
+                    ),
+                    trigger_phrases=[
+                        "revenue",
+                        "cogs",
+                        "gross profit",
+                        "net income",
+                        "profit and loss",
+                    ],
+                    description="P&L data",
+                    column_signals=None,
+                )
+            },
+        )
+        router = QueryRouter(sql_confidence_threshold=0.6)
+
+        decision = router.route(
+            "what was total revenue in 2024?",
+            structured_query_enabled=True,
+        )
+        assert decision.route == RouteType.SQL
+
+    def test_pl_cogs_still_routes_to_sql(self):
+        """Financial trigger phrase 'cogs' still routes to SQL."""
+        from ai_ready_rag.services.query_router import RouteType
+
+        registry = ModuleRegistry.get_instance()
+        registry.register_sql_templates(
+            "core.excel_tables",
+            {
+                "excel_pl_financials": SQLTemplate(
+                    name="excel_pl_financials",
+                    sql=(
+                        "SELECT year, item, value FROM ("
+                        'SELECT \'2024\' AS year, "0" AS item, "1" AS value '
+                        'FROM excel_tables."pl_2024"'
+                        ") AS pl_data WHERE item IS NOT NULL LIMIT :row_cap"
+                    ),
+                    trigger_phrases=["cogs", "cost of goods", "revenue", "net income"],
+                    description="P&L data",
+                    column_signals=None,
+                )
+            },
+        )
+        router = QueryRouter(sql_confidence_threshold=0.6)
+
+        decision = router.route(
+            "show me COGS for last year",
+            structured_query_enabled=True,
+        )
+        assert decision.route == RouteType.SQL
+
+
+# =============================================================================
+# TestIngestKitRegistryWrite
+# =============================================================================
+
+
+class TestIngestKitRegistryWrite:
+    """Tests for VERagPostgresStructuredDB._register_table_in_registry."""
+
+    def _make_df(self):
+        """Return a minimal pandas DataFrame for testing."""
+        try:
+            import pandas as pd
+
+            return pd.DataFrame(
+                {
+                    "SKU": ["A1", "A2"],
+                    "Item": ["Widget", "Gadget"],
+                    "On Hand": [100, 50],
+                }
+            )
+        except ImportError:
+            pytest.skip("pandas not available")
+
+    def test_registry_write_on_ingest(self):
+        """_register_table_in_registry calls INSERT into excel_table_registry."""
+        from ai_ready_rag.services.ingestkit_adapters import VERagPostgresStructuredDB
+
+        df = self._make_df()
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cursor
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        with patch("psycopg2.connect", return_value=mock_conn):
+            adapter = VERagPostgresStructuredDB.__new__(VERagPostgresStructuredDB)
+            adapter._database_url = "postgresql://fake/db"
+            adapter._SCHEMA = "excel_tables"
+            adapter._register_table_in_registry("inventory_report", df)
+
+        # Verify cursor.execute was called with INSERT SQL
+        assert mock_cursor.execute.called
+        call_sql = mock_cursor.execute.call_args[0][0]
+        assert "INSERT INTO excel_table_registry" in call_sql
+        assert "ON CONFLICT" in call_sql
+
+    def test_registry_write_contains_correct_table_name(self):
+        """_register_table_in_registry includes correct table_name in params."""
+        from ai_ready_rag.services.ingestkit_adapters import VERagPostgresStructuredDB
+
+        df = self._make_df()
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cursor
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        with patch("psycopg2.connect", return_value=mock_conn):
+            adapter = VERagPostgresStructuredDB.__new__(VERagPostgresStructuredDB)
+            adapter._database_url = "postgresql://fake/db"
+            adapter._SCHEMA = "excel_tables"
+            adapter._register_table_in_registry("my_test_table", df)
+
+        call_params = mock_cursor.execute.call_args[0][1]
+        assert "my_test_table" in call_params
+
+    def test_registry_write_failure_does_not_raise(self):
+        """Registry write failure is silently logged, never raised."""
+        from ai_ready_rag.services.ingestkit_adapters import VERagPostgresStructuredDB
+
+        df = self._make_df()
+
+        with patch("psycopg2.connect", side_effect=Exception("db unreachable")):
+            adapter = VERagPostgresStructuredDB.__new__(VERagPostgresStructuredDB)
+            adapter._database_url = "postgresql://fake/db"
+            adapter._SCHEMA = "excel_tables"
+            # Should not raise
+            adapter._register_table_in_registry("inventory_report", df)


### PR DESCRIPTION
## Summary

- Adds `excel_table_registry` DB table (migration 008) — stores column metadata per ingested Excel file at ingest time
- `QueryRouter` gains quantitative signal detection (`"how many"`, `"on hand"`, `"total"`, etc.) to route any Excel table query to SQL — no manual trigger-phrase curation needed
- `ClaudeQueryService` CLI generates SQL from natural language + table schema (NL2SQL); `SqlInjectionGuard` enforces SELECT-only
- `ExcelTablesService` now discovers all registered tables (not just P&L year tables) and registers per-table NL2SQL templates automatically
- All existing P&L trigger-phrase routing unchanged

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `pytest tests/test_excel_tables_service.py` — 22/22 passed
  - SQL injection guard (8 tests)
  - Quantitative signal routing (7 tests)
  - Registry discovery (2 tests)
  - ingestkit registry write (3 tests)
  - P&L backward compat (2 tests)
- [x] "How many EndCore Plugger sets on hand?" routes to SQL → exact answer (244)

## Files changed
| File | Change |
|------|--------|
| `alembic/versions/008_excel_table_registry.py` | New migration |
| `ai_ready_rag/db/models/excel_tables.py` | New `ExcelTableRegistry` model |
| `ai_ready_rag/modules/registry.py` | Add `column_signals` field to `SQLTemplate` |
| `ai_ready_rag/services/excel_tables_service.py` | Registry-backed discovery + `SqlInjectionGuard` |
| `ai_ready_rag/services/query_router.py` | `_score_quantitative_signals()` |
| `ai_ready_rag/services/ingestkit_adapters.py` | Write to registry after `df.to_sql()` |
| `ai_ready_rag/services/rag_service.py` | `_execute_nl2sql_route()` |
| `ai_ready_rag/db/models/__init__.py` | Import new model |
| `ai_ready_rag/main.py` | Wire updated service |
| `tests/test_excel_tables_service.py` | 22 new tests |

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)