### PR TITLE
chore: fix stale Qdrant/SQLite labels in runtime API responses (#462)

### DIFF
--- a/ai_ready_rag/api/admin.py
+++ b/ai_ready_rag/api/admin.py
@@ -704,20 +704,13 @@ async def get_architecture_info(
 
     try:
         health = await vector_service.health_check()
-        # Handle both Qdrant (named tuple) and ChromaDB (dict) responses
-        if isinstance(health, dict):
-            vector_db_status = "healthy" if health.get("healthy", False) else "unhealthy"
-            # Check Ollama separately for ChromaDB
-            try:
-                async with httpx.AsyncClient(timeout=5.0) as client:
-                    resp = await client.get(f"{settings.ollama_base_url}/api/tags")
-                    ollama_status = "healthy" if resp.status_code == 200 else "unhealthy"
-            except Exception:
-                ollama_status = "unhealthy"
-        else:
-            # Qdrant returns named tuple
-            ollama_status = "healthy" if health.ollama_healthy else "unhealthy"
-            vector_db_status = "healthy" if health.qdrant_healthy else "unhealthy"
+        vector_db_status = "healthy" if health.get("healthy", False) else "unhealthy"
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(f"{settings.ollama_base_url}/api/tags")
+                ollama_status = "healthy" if resp.status_code == 200 else "unhealthy"
+        except Exception:
+            ollama_status = "unhealthy"
     except Exception as e:
         logger.warning(f"Health check failed: {e}")
         ollama_status = "unhealthy"
@@ -761,7 +754,7 @@ async def get_architecture_info(
             model=get_model_setting("embedding_model", settings.embedding_model),
             dimensions=settings.embedding_dimension,
             vector_store=settings.vector_backend,
-            vector_store_url=settings.qdrant_url,
+            vector_store_url=settings.database_url,
         ),
         chat_model=ChatModelInfo(
             name=get_model_setting("chat_model", settings.chat_model),
@@ -1152,7 +1145,7 @@ async def get_detailed_health(
             status="healthy" if vector_healthy else "unhealthy",
             version=vector_db_version,
             details={
-                "collection": settings.qdrant_collection,
+                "table": "chunk_vectors",
                 "chunks": total_chunks,
             },
         ),
@@ -2610,13 +2603,13 @@ async def get_cache_stats(
 
     # Estimate storage size (rough calculation)
     # Each entry: ~10KB average (query_text + answer + embedding + sources)
-    storage_bytes = stats.sqlite_entries * 10240 if stats.sqlite_entries else None
+    storage_bytes = stats.db_entries * 10240 if stats.db_entries else None
 
     return CacheStatsResponse(
         enabled=stats.enabled,
         total_entries=stats.total_entries,
         memory_entries=stats.memory_entries,
-        sqlite_entries=stats.sqlite_entries,
+        db_entries=stats.db_entries,
         hit_count=stats.hit_count,
         miss_count=stats.miss_count,
         hit_rate=stats.hit_rate,
@@ -2633,7 +2626,7 @@ async def clear_cache(
 ):
     """Clear all cache entries.
 
-    Removes all entries from both memory and SQLite cache.
+    Removes all entries from both memory and database cache.
     Admin only.
     """
     from ai_ready_rag.services.cache_service import CacheService
@@ -4671,7 +4664,7 @@ async def reconcile_stores(
     current_user: User = Depends(require_system_admin),
     db: Session = Depends(get_db),
 ):
-    """Detect and optionally repair SQLite ↔ Qdrant drift.
+    """Detect and optionally repair PostgreSQL ↔ pgvector drift.
 
     Use dry_run=true (default) to detect issues without making changes.
     Set dry_run=false to auto-repair detected issues.

--- a/ai_ready_rag/api/health.py
+++ b/ai_ready_rag/api/health.py
@@ -156,7 +156,6 @@ def _build_hybrid_search_status(request: Request) -> dict:
 
     collection_has_sparse = getattr(vector_service, "_collection_has_sparse", False)
     checked_at = getattr(vector_service, "_capabilities_checked_at", None)
-    sparse_available = getattr(vector_service, "_sparse_available", False)
 
     active_mode = "hybrid" if (enabled and collection_has_sparse) else "dense_only"
     active_threshold = getattr(vector_service, "min_similarity_score", None)
@@ -165,7 +164,7 @@ def _build_hybrid_search_status(request: Request) -> dict:
         "enabled": enabled,
         "collection_has_sparse": collection_has_sparse,
         "capabilities_checked_at": checked_at.isoformat() if checked_at else None,
-        "sparse_model": "Qdrant/bm25" if sparse_available else None,
+        "sparse_model": None,
         "active_mode": active_mode,
         "active_threshold": active_threshold,
     }

--- a/ai_ready_rag/schemas/admin.py
+++ b/ai_ready_rag/schemas/admin.py
@@ -672,7 +672,7 @@ class CacheStatsResponse(BaseModel):
     enabled: bool
     total_entries: int
     memory_entries: int
-    sqlite_entries: int
+    db_entries: int
     hit_count: int
     miss_count: int
     hit_rate: float
@@ -901,7 +901,7 @@ class SwitchActiveStrategyRequest(BaseModel):
 
 
 class ReconcileRequest(BaseModel):
-    """Request to reconcile SQLite ↔ Qdrant state."""
+    """Request to reconcile PostgreSQL ↔ pgvector state."""
 
     dry_run: bool = True
 
@@ -913,8 +913,8 @@ class ReconcileIssue(BaseModel):
     filename: str | None = None
     issue: str
     detail: str
-    sqlite_chunks: int | None = None
-    qdrant_chunks: int | None = None
+    db_chunks: int | None = None
+    vector_chunks: int | None = None
 
 
 class ReconcileRepair(BaseModel):

--- a/ai_ready_rag/services/cache_service.py
+++ b/ai_ready_rag/services/cache_service.py
@@ -61,7 +61,7 @@ class CacheStats:
     enabled: bool
     total_entries: int
     memory_entries: int
-    sqlite_entries: int
+    db_entries: int
     hit_count: int = 0
     miss_count: int = 0
 
@@ -720,13 +720,13 @@ class CacheService:
 
         db = self._get_session()
         try:
-            sqlite_count = db.query(ResponseCache).count()
+            db_count = db.query(ResponseCache).count()
 
             return CacheStats(
                 enabled=self.enabled,
-                total_entries=sqlite_count,  # SQLite is source of truth
+                total_entries=db_count,
                 memory_entries=len(self.memory),
-                sqlite_entries=sqlite_count,
+                db_entries=db_count,
                 hit_count=self._hit_count,
                 miss_count=self._miss_count,
             )

--- a/ai_ready_rag/services/reconciliation_service.py
+++ b/ai_ready_rag/services/reconciliation_service.py
@@ -1,6 +1,6 @@
-"""SQLite ↔ pgvector reconciliation service.
+"""PostgreSQL ↔ pgvector reconciliation service.
 
-Detects and optionally repairs drift between SQLite document metadata
+Detects and optionally repairs drift between PostgreSQL document metadata
 and the pgvector chunk_vectors table.
 """
 
@@ -19,12 +19,12 @@ async def reconcile(
     vector_service,
     dry_run: bool = True,
 ) -> dict:
-    """Detect and optionally repair SQLite ↔ pgvector drift.
+    """Detect and optionally repair PostgreSQL ↔ pgvector drift.
 
     Scenarios detected:
-    - ghost_docs: SQLite status=ready but 0 vectors in chunk_vectors
-    - orphan_vectors: chunk_vectors has rows for document_id not in SQLite
-    - chunk_count_mismatch: SQLite chunk_count != actual vector count
+    - ghost_docs: PostgreSQL status=ready but 0 vectors in chunk_vectors
+    - orphan_vectors: chunk_vectors has rows for document_id not in PostgreSQL
+    - chunk_count_mismatch: PostgreSQL chunk_count != actual vector count
 
     Args:
         db: SQLAlchemy session
@@ -37,9 +37,9 @@ async def reconcile(
     issues: list[dict] = []
     repairs: list[dict] = []
 
-    # 1. Get all documents from SQLite
+    # 1. Get all documents from PostgreSQL
     all_docs = db.query(Document).all()
-    sqlite_doc_ids = {doc.id for doc in all_docs}
+    db_doc_ids = {doc.id for doc in all_docs}
     ready_docs = [d for d in all_docs if d.status == "ready"]
 
     # 2. Get all unique document_ids from chunk_vectors (pgvector SQL)
@@ -62,7 +62,7 @@ async def reconcile(
         vector_doc_ids.add(row[0])
         vector_doc_counts[row[0]] = row[1]
 
-    # 3. Detect ghost docs: ready in SQLite but 0 vectors in chunk_vectors
+    # 3. Detect ghost docs: ready in PostgreSQL but 0 vectors in chunk_vectors
     for doc in ready_docs:
         vector_count = vector_doc_counts.get(doc.id, 0)
         if vector_count == 0:
@@ -71,8 +71,8 @@ async def reconcile(
                     "document_id": doc.id,
                     "filename": doc.original_filename,
                     "issue": "ghost_doc",
-                    "detail": "status=ready in SQLite but 0 vectors in chunk_vectors",
-                    "sqlite_chunks": doc.chunk_count,
+                    "detail": "status=ready in PostgreSQL but 0 vectors in chunk_vectors",
+                    "db_chunks": doc.chunk_count,
                     "vector_chunks": 0,
                 }
             )
@@ -87,16 +87,16 @@ async def reconcile(
                     }
                 )
 
-    # 4. Detect orphan vectors: in chunk_vectors but not in SQLite
-    orphan_ids = vector_doc_ids - sqlite_doc_ids
+    # 4. Detect orphan vectors: in chunk_vectors but not in PostgreSQL
+    orphan_ids = vector_doc_ids - db_doc_ids
     for orphan_id in orphan_ids:
         issues.append(
             {
                 "document_id": orphan_id,
                 "filename": None,
                 "issue": "orphan_vectors",
-                "detail": "Vectors exist in chunk_vectors but no SQLite record",
-                "sqlite_chunks": None,
+                "detail": "Vectors exist in chunk_vectors but no PostgreSQL record",
+                "db_chunks": None,
                 "vector_chunks": vector_doc_counts.get(orphan_id, 0),
             }
         )
@@ -126,8 +126,8 @@ async def reconcile(
                     "document_id": doc.id,
                     "filename": doc.original_filename,
                     "issue": "chunk_count_mismatch",
-                    "detail": f"SQLite chunk_count={doc.chunk_count} != vector chunks={vector_count}",
-                    "sqlite_chunks": doc.chunk_count,
+                    "detail": f"DB chunk_count={doc.chunk_count} != vector chunks={vector_count}",
+                    "db_chunks": doc.chunk_count,
                     "vector_chunks": vector_count,
                 }
             )

--- a/tests/test_admin_cache.py
+++ b/tests/test_admin_cache.py
@@ -260,7 +260,7 @@ class TestCacheStats:
         assert "enabled" in data
         assert "total_entries" in data
         assert "memory_entries" in data
-        assert "sqlite_entries" in data
+        assert "db_entries" in data
         assert "hit_count" in data
         assert "miss_count" in data
         assert "hit_rate" in data
@@ -296,7 +296,7 @@ class TestCacheStats:
         # Assert
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert data["sqlite_entries"] == 3
+        assert data["db_entries"] == 3
 
     def test_returns_timestamp_fields(self, client, admin_headers, db):
         """GET /cache/stats returns oldest_entry and newest_entry."""

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -62,8 +62,8 @@ class TestReconcileEndpoint:
                     "document_id": "abc-123",
                     "filename": "report.pdf",
                     "issue": "ghost_doc",
-                    "detail": "status=ready in SQLite but 0 vectors in chunk_vectors",
-                    "sqlite_chunks": 36,
+                    "detail": "status=ready in PostgreSQL but 0 vectors in chunk_vectors",
+                    "db_chunks": 36,
                     "vector_chunks": 0,
                 }
             ],
@@ -94,8 +94,8 @@ class TestReconcileEndpoint:
                     "document_id": "orphan-1",
                     "filename": None,
                     "issue": "orphan_vectors",
-                    "detail": "Vectors exist in chunk_vectors but no SQLite record",
-                    "sqlite_chunks": None,
+                    "detail": "Vectors exist in chunk_vectors but no PostgreSQL record",
+                    "db_chunks": None,
                     "vector_chunks": 14,
                 }
             ],


### PR DESCRIPTION
## What
Replace all runtime-visible references to the old Qdrant and SQLite backends with correct pgvector/PostgreSQL equivalents.

## Why
After the Qdrant→pgvector and SQLite→PostgreSQL migrations, several strings visible in API responses still referenced the old backends — misleading the frontend, admin tooling, and API consumers.

Closes #462

## How

| File | Change |
|------|--------|
| `api/admin.py` | Remove dead Qdrant named-tuple health path; all backends now return `dict` from `health_check()` |
| `api/admin.py` | `vector_store_url` now uses `settings.database_url` (PostgreSQL), not `settings.qdrant_url` (port 6333) |
| `api/admin.py` | `vector_db.details` uses `"table": "chunk_vectors"` instead of `"collection": settings.qdrant_collection` |
| `api/health.py` | `sparse_model` always `None` — pgvector has no BM25; remove now-unused `sparse_available` variable |
| `schemas/admin.py` | `CacheStatsResponse.sqlite_entries` → `db_entries` |
| `schemas/admin.py` | `ReconcileIssue.sqlite_chunks` → `db_chunks`, `.qdrant_chunks` → `vector_chunks` |
| `schemas/admin.py` | `ReconcileRequest` docstring updated |
| `cache_service.py` | `CacheStats.sqlite_entries` → `db_entries` |
| `reconciliation_service.py` | SQLite → PostgreSQL throughout: docstring, comments, detail strings returned to clients |
| `tests/` | Field names and detail strings updated to match |

## Stack
- [x] Backend
- [ ] Frontend

## Contract Changes
Renamed response fields (breaking for any client reading these):
- `GET /api/admin/cache/stats`: `sqlite_entries` → `db_entries`
- `POST /api/admin/reconcile` issue objects: `sqlite_chunks` → `db_chunks`, `qdrant_chunks` → `vector_chunks`
- `GET /api/admin/architecture`: `embeddings.vector_store_url` now PostgreSQL URL; `vector_db.details.collection` → `table`
- `GET /health`: `hybrid_search.sparse_model` always `null`

## Verification
- [x] `ruff check .` passes
- [x] `pytest -q` passes (263 passed; 1 pre-existing unrelated failure in test_auto_tagging_config)
- Targeted: `pytest tests/test_admin_cache.py tests/test_reconciliation.py tests/test_health.py` — 44/44 pass

## How to Test
1. `GET /api/admin/architecture` → `embeddings.vector_store_url` contains PostgreSQL URL, not `:6333`
2. `GET /api/admin/architecture` → `vector_db.details` has `"table": "chunk_vectors"` not `"collection"`
3. `GET /health` → `hybrid_search.sparse_model` is `null`
4. `GET /api/admin/cache/stats` → response has `db_entries` field not `sqlite_entries`
5. `POST /api/admin/reconcile` → issue objects have `db_chunks` and `vector_chunks` fields

## Risks / Rollback
Low risk — cosmetic label changes only. No logic changes. Any frontend code reading the renamed fields (`sqlite_entries`, `qdrant_chunks`, `sqlite_chunks`) will need updating.