### PR TITLE
fix: remove extra mode argument from reindex_knowledge_base enqueue call (#459)

### DIFF
--- a/tests/test_arq_warming_reindex.py
+++ b/tests/test_arq_warming_reindex.py
@@ -52,6 +52,25 @@ class TestReindexKnowledgeBaseTask:
             assert result["job_id"] == "job-456"
             assert "DB connection lost" in result["error"]
 
+    def test_reindex_task_signature_has_no_mode_param(self):
+        """ARQ task accepts (ctx, job_id) only — no mode parameter.
+
+        Regression test for issue #459: admin.py was passing request.mode as
+        a third positional arg, causing TypeError at runtime.
+        The task signature must remain (ctx, job_id) with no mode parameter.
+        """
+        import inspect
+
+        from ai_ready_rag.workers.tasks.reindex import reindex_knowledge_base
+
+        sig = inspect.signature(reindex_knowledge_base)
+        params = list(sig.parameters.keys())
+
+        assert params == ["ctx", "job_id"], (
+            f"Expected (ctx, job_id) but got {params}. "
+            "If mode was added, update the enqueue call in admin.py too."
+        )
+
 
 class TestWorkerSettingsRegistration:
     """Test tasks are registered in WorkerSettings."""


### PR DESCRIPTION
## What
Add regression test confirming `reindex_knowledge_base(ctx, job_id)` accepts no `mode` parameter.

The underlying fix — removing `request.mode` from `enqueue_job("reindex_knowledge_base", job.id, request.mode)` — was already applied to main in commit `eb19f63` during manual test plan execution (T8.2). This PR closes the issue and adds a guard to prevent regression.

## Why
ARQ task signature is `(ctx, job_id)`. Passing `mode` as a third positional argument caused:
```
TypeError: reindex_knowledge_base() takes 2 positional arguments but 3 were given
```

The regression test (`test_reindex_task_signature_has_no_mode_param`) uses `inspect.signature` to assert the task parameters are exactly `[ctx, job_id]`, with a clear error message pointing to the admin.py enqueue call if the signature ever changes.

Closes #459

## Stack
- [x] Backend

## Verification
- [x] `ruff check .` passes
- [x] `pytest tests/test_arq_warming_reindex.py -v` — 8 passed (2 pre-existing errors from unrelated `duplicate column name: forms_template_id` schema bug, not introduced here)
- [x] Fix confirmed in `ai_ready_rag/api/admin.py` line 2088: `await redis.enqueue_job("reindex_knowledge_base", job.id)`