### PR TITLE
fix: enforce account lockout after N failed login attempts (#456)

### DIFF
--- a/ai_ready_rag/api/auth.py
+++ b/ai_ready_rag/api/auth.py
@@ -1,7 +1,7 @@
 """Authentication endpoints."""
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy.orm import Session
@@ -32,6 +32,23 @@ async def login(
     """Authenticate user and return JWT token."""
     user = db.query(User).filter(User.email == credentials.email).first()
 
+    # Check account lockout BEFORE password verification (only if user exists)
+    if user and user.locked_until and user.locked_until > datetime.utcnow():
+        logger.warning(
+            "login_failed",
+            extra={
+                "email": credentials.email,
+                "reason": "account_locked",
+                "locked_until": user.locked_until.isoformat(),
+                "client_ip": request.client.host if request.client else None,
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_423_LOCKED,
+            detail=f"Account locked. Try again after {user.locked_until.strftime('%Y-%m-%d %H:%M:%S')} UTC",
+        )
+
+    # Validate credentials
     if not user or not verify_password(credentials.password, user.password_hash):
         logger.warning(
             "login_failed",
@@ -41,6 +58,21 @@ async def login(
                 "client_ip": request.client.host if request.client else None,
             },
         )
+        # Increment failed attempt counter if user exists
+        if user:
+            user.failed_login_attempts = (user.failed_login_attempts or 0) + 1
+            if user.failed_login_attempts >= settings.lockout_attempts:
+                user.locked_until = datetime.utcnow() + timedelta(minutes=settings.lockout_minutes)
+                user.failed_login_attempts = 0
+                logger.warning(
+                    "account_locked",
+                    extra={
+                        "email": credentials.email,
+                        "user_id": user.id,
+                        "locked_until": user.locked_until.isoformat(),
+                    },
+                )
+            db.commit()
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid email or password"
         )
@@ -62,6 +94,10 @@ async def login(
     token = create_access_token(data={"sub": user.id, "email": user.email, "role": user.role})
     jwt_hours = get_security_setting("jwt_expiration_hours", settings.jwt_expiration_hours)
     expires_in = jwt_hours * 3600
+
+    # Reset lockout counters on successful login
+    user.failed_login_attempts = 0
+    user.locked_until = None
 
     # Update last login
     user.last_login = datetime.utcnow()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,7 @@
 """Tests for authentication endpoints."""
 
+from datetime import datetime, timedelta
+
 
 class TestSetup:
     """Setup wizard tests."""
@@ -109,4 +111,75 @@ class TestLogout:
     def test_logout_unauthenticated(self, client):
         """Test logout without auth."""
         response = client.post("/api/auth/logout")
+        assert response.status_code == 401
+
+
+class TestAccountLockout:
+    """Account lockout tests."""
+
+    def test_failed_login_increments_counter(self, client, db, admin_user):
+        """Failed login attempt increments failed_login_attempts."""
+        assert admin_user.failed_login_attempts == 0
+        client.post(
+            "/api/auth/login", json={"email": "admin@test.com", "password": "WrongPassword123"}
+        )
+        db.refresh(admin_user)
+        assert admin_user.failed_login_attempts == 1
+
+    def test_lockout_after_max_attempts(self, client, db, admin_user):
+        """Account is locked after lockout_attempts (5) consecutive failures."""
+        for _ in range(5):
+            client.post(
+                "/api/auth/login",
+                json={"email": "admin@test.com", "password": "WrongPassword123"},
+            )
+        db.refresh(admin_user)
+        # After 5 failures the counter resets to 0 and locked_until is set
+        assert admin_user.locked_until is not None
+        assert admin_user.failed_login_attempts == 0
+        assert admin_user.locked_until > datetime.utcnow()
+
+    def test_locked_account_returns_423(self, client, db, admin_user):
+        """Locked account returns HTTP 423."""
+        # Lock the account directly
+        admin_user.locked_until = datetime.utcnow() + timedelta(minutes=15)
+        db.commit()
+
+        response = client.post(
+            "/api/auth/login", json={"email": "admin@test.com", "password": "AdminPassword123"}
+        )
+        assert response.status_code == 423
+        assert "locked" in response.json()["detail"].lower()
+
+    def test_successful_login_resets_counter(self, client, db, admin_user):
+        """Successful login resets failed_login_attempts and locked_until."""
+        # Set some failures
+        admin_user.failed_login_attempts = 3
+        db.commit()
+
+        response = client.post(
+            "/api/auth/login", json={"email": "admin@test.com", "password": "AdminPassword123"}
+        )
+        assert response.status_code == 200
+        db.refresh(admin_user)
+        assert admin_user.failed_login_attempts == 0
+        assert admin_user.locked_until is None
+
+    def test_expired_lockout_allows_login(self, client, db, admin_user):
+        """Account with expired locked_until can log in successfully."""
+        # Set lockout to the past
+        admin_user.locked_until = datetime.utcnow() - timedelta(minutes=1)
+        db.commit()
+
+        response = client.post(
+            "/api/auth/login", json={"email": "admin@test.com", "password": "AdminPassword123"}
+        )
+        assert response.status_code == 200
+
+    def test_nonexistent_user_not_affected_by_lockout(self, client):
+        """Login attempt for nonexistent user returns 401 without error."""
+        response = client.post(
+            "/api/auth/login",
+            json={"email": "ghost@test.com", "password": "WrongPassword123"},
+        )
         assert response.status_code == 401


### PR DESCRIPTION
## What
Wire up the existing lockout config (`lockout_attempts=5`, `lockout_minutes=15`) to the login endpoint.

## Why
Failed login attempts were never tracked or enforced, allowing unlimited brute-force attempts.

## How
- On failed login: increment `failed_login_attempts`; lock account for 15 min after 5 failures
- On successful login: reset counter and `locked_until` to clean state
- Locked accounts receive HTTP 423 with time-remaining message
- No migration needed — `failed_login_attempts` and `locked_until` columns were already on the `User` model

Closes #456

## Stack
- [x] Backend

## Verification
- [x] `ruff check .` passes
- [x] `pytest tests/test_auth.py` — 17/17 pass (6 new lockout tests added)
- [x] `pytest tests/test_auth.py tests/test_users.py tests/test_roles.py tests/test_health.py` — 71/71 pass
- [x] 1 pre-existing failure (`test_auto_tagging_config`) confirmed on main; unrelated to this change