### PR TITLE
fix: add .convert('RGB') to PIL image before pytesseract OCR (#457)

### DIFF
--- a/ai_ready_rag/services/ingestkit_adapters.py
+++ b/ai_ready_rag/services/ingestkit_adapters.py
@@ -785,7 +785,7 @@ class VERagImageOCRAdapter:
         lang = language or self._language
         tess_config = config or self._config or "--psm 6"
 
-        img = Image.open(io.BytesIO(image_bytes))
+        img = Image.open(io.BytesIO(image_bytes)).convert("RGB")
         data = pytesseract.image_to_data(
             img, lang=lang, config=tess_config, output_type=pytesseract.Output.DICT
         )


### PR DESCRIPTION
## What
Add `.convert('RGB')` after `Image.open()` in `VERagImageOCRAdapter.ocr_image()` to handle lazy JPEG PIL images.

## Why
pytesseract cannot handle lazy JPEG PIL images — raises `TypeError: Unsupported image format/type`. Converting to RGB normalizes the image before OCR processing.

Closes #457

## Stack
- [x] Backend

## Verification
- [ ] `ruff check .` passes
- [ ] `pytest -q` passes