### PR TITLE
fix: coerce integer column names to strings in table registration

### DIFF
--- a/ai_ready_rag/services/ingestkit_adapters.py
+++ b/ai_ready_rag/services/ingestkit_adapters.py
@@ -474,7 +474,7 @@ class VERagPostgresStructuredDB:
         from datetime import datetime
 
         try:
-            columns = list(df.columns.astype(str))
+            columns = [str(c) for c in df.columns]
             column_types = {str(col): str(dtype) for col, dtype in df.dtypes.items()}
             now = datetime.utcnow()
             # Embed access_tags in table_metadata so no schema migration is required.
@@ -544,7 +544,7 @@ class VERagPostgresStructuredDB:
         from ai_ready_rag.utils.signal_canon import sample_row_values
 
         try:
-            columns = list(df.columns.astype(str))
+            columns = [str(c) for c in df.columns]
             column_types = {str(col): str(dtype) for col, dtype in df.dtypes.items()}
             row_samples = sample_row_values(df)
             tenant_id = getattr(self, "_tenant_id", "default")

--- a/ai_ready_rag/services/table_registration_service.py
+++ b/ai_ready_rag/services/table_registration_service.py
@@ -202,11 +202,13 @@ class TableRegistrationService:
 
         try:
             col_list = json.loads(row["columns"]) if row["columns"] else []
+            col_list = [str(c) for c in col_list]  # ensure strings for any legacy int columns
         except (json.JSONDecodeError, TypeError):
             col_list = []
 
         try:
             col_types = json.loads(row["column_types"]) if row["column_types"] else {}
+            col_types = {str(k): v for k, v in col_types.items()}  # ensure string keys
         except (json.JSONDecodeError, TypeError):
             col_types = {}
 


### PR DESCRIPTION
## What
Fixes `'int' object has no attribute 'lower'` startup warnings for `25_26_d_o_policy_*` tables.

## Root Cause
DataFrames with integer column indices (`RangeIndex`) were serialized to JSON as integer values. On read-back, `col.lower()` in `ExcelTablesService._compute_column_signals` fails because `col` is an `int`.

## Changes
**Write path** (`ingestkit_adapters.py`, 2 sites):
```python
# Before
columns = list(df.columns.astype(str))
# After
columns = [str(c) for c in df.columns]  # guarantees native Python str
```

**Read path** (`table_registration_service.py`, defensive safeguard):
```python
col_list = [str(c) for c in col_list]        # fix legacy rows already stored
col_types = {str(k): v for k, v in col_types.items()}
```

## Verification
- [x] `ruff check` passes
- [x] Lint clean on both changed files

## Risks / Rollback
Low risk — str() coercion is a no-op for already-correct string columns.