### PR TITLE
fix: replace insured_name entity isolation with tag-based approach (#487)

### DIFF
--- a/ai_ready_rag/services/forms_processing_service.py
+++ b/ai_ready_rag/services/forms_processing_service.py
@@ -635,10 +635,6 @@ class FormsProcessingService:
                     extra={"document_id": document.id, "error": str(exc)},
                 )
 
-        # Inject insured entity name into adapter so all chunks carry insured_name metadata.
-        if hasattr(vector_store, "set_entity_name"):
-            vector_store.set_entity_name(insured_name or None)
-
         # Write all chunks (rechunked + synopsis) in a single upsert call.
         count = vector_store.upsert_chunks("", chunks_to_upsert)
 

--- a/ai_ready_rag/services/forms_query_service.py
+++ b/ai_ready_rag/services/forms_query_service.py
@@ -135,18 +135,6 @@ class FormsQueryService:
             # Read fields from forms_data.db
             grouped_fields = self._read_form_fields(table_names[0], ingest_key, field_groups)
 
-            # Entity isolation: skip documents belonging to a different named entity.
-            if getattr(intent, "entity_name", None):
-                # Look for insured name in the Named Insured group fields
-                named_insured_fields = grouped_fields.get("Named Insured", [])
-                form_insured = ""
-                for label, value in named_insured_fields:
-                    if "Full Name" in label or "Named" in label or "Name" in label:
-                        form_insured = value.strip()
-                        break
-                if form_insured and intent.entity_name.lower() not in form_insured.lower():
-                    continue  # Skip — belongs to a different entity
-
             # Most recent doc (rank 0) gets 0.97, older docs get 0.93
             score = 0.97 if doc_rank == 0 else 0.93
 

--- a/ai_ready_rag/services/ingestkit_adapters.py
+++ b/ai_ready_rag/services/ingestkit_adapters.py
@@ -51,7 +51,6 @@ class VERagVectorStoreAdapter:
         tags: list[str],
         uploaded_by: str,
         tenant_id: str = "default",
-        entity_name: str | None = None,
     ) -> None:
         self._database_url = database_url
         self._embedding_dimension = embedding_dimension
@@ -61,11 +60,6 @@ class VERagVectorStoreAdapter:
         self._uploaded_by = uploaded_by
         self._tenant_id = tenant_id
         self._uploaded_at = datetime.now(UTC).isoformat()
-        self._entity_name = entity_name
-
-    def set_entity_name(self, name: str | None) -> None:
-        """Set the insured entity name for metadata injection into chunks."""
-        self._entity_name = name
 
     def ensure_collection(self, collection: str, vector_size: int) -> None:
         """No-op — chunk_vectors table is managed by Alembic migrations."""
@@ -125,8 +119,6 @@ class VERagVectorStoreAdapter:
                         metadata["ingestkit_columns"] = meta.columns
                     if hasattr(meta, "sheet_name"):
                         metadata["ingestkit_sheet_name"] = meta.sheet_name
-                    if self._entity_name:
-                        metadata["insured_name"] = self._entity_name
 
                     vector = chunk.vector  # pre-computed by VERagEmbeddingAdapter
                     if vector:

--- a/ai_ready_rag/services/pgvector_service.py
+++ b/ai_ready_rag/services/pgvector_service.py
@@ -163,7 +163,6 @@ class PgVectorService:
         tags: list[str],
         uploaded_by: str,
         tenant_id: str | None = None,
-        entity_name: str | None = None,
     ) -> None:
         """Insert a synthetic synopsis chunk into chunk_vectors.
 
@@ -182,8 +181,6 @@ class PgVectorService:
             "uploaded_by": uploaded_by,
             "chunk_type": "synopsis",
         }
-        if entity_name:
-            metadata["insured_name"] = entity_name
         chunk_id = str(uuid.uuid4())
         with SessionLocal() as db:
             # Remove any previous synopsis chunk for this document
@@ -287,11 +284,11 @@ class PgVectorService:
             if user_tags and not any(t in doc_tags for t in user_tags):
                 continue
 
-            # Entity isolation: drop chunks belonging to a different named entity.
-            # Chunks with no insured_name key pass through (non-forms / general docs).
+            # Entity isolation: drop chunks not tagged with the detected customer tag.
+            # Chunks with no matching tag key pass through (non-forms / general docs).
             if entity_hint:
-                chunk_entity = meta.get("insured_name")
-                if chunk_entity and entity_hint.lower() not in chunk_entity.lower():
+                chunk_tags = meta.get("tags", [])
+                if entity_hint not in chunk_tags:
                     continue
 
             score = float(row.score or 0)

--- a/ai_ready_rag/services/rag_service.py
+++ b/ai_ready_rag/services/rag_service.py
@@ -238,7 +238,7 @@ class QueryIntent:
     confidence: float  # 0.0-1.0
     forms_eligible: bool = False  # True when intent matches structured form data
     intent_labels: list[str] | None = None  # All matched labels e.g. ["active_policy", "gl"]
-    entity_name: str | None = None  # Detected entity/insured name from query
+    entity_name: str | None = None  # Customer tag for entity isolation e.g. "client:walnut-creek"
 
 
 # Insurance domain intent patterns: (compiled_regex, preferred_tags, label)
@@ -468,27 +468,16 @@ _ENTITY_CACHE_TTL: float = 300.0  # 5 minutes
 
 
 def _get_known_entities(db: Session, tenant_id: str = "default") -> list[str]:
-    """Load distinct insured_name values from chunk metadata. Cached 5 min."""
-    import time
-
-    from sqlalchemy import text
+    """Load customer tag names (client:*) from tags table. Cached 5 min."""
+    from ai_ready_rag.db.models.user import Tag
 
     global _ENTITY_CACHE_TIME
     now = time.monotonic()
     if tenant_id in _ENTITY_CACHE and (now - _ENTITY_CACHE_TIME) < _ENTITY_CACHE_TTL:
         return _ENTITY_CACHE[tenant_id]
     try:
-        rows = db.execute(
-            text(
-                "SELECT DISTINCT metadata_::jsonb->>'insured_name' AS entity_name "
-                "FROM chunk_vectors "
-                "WHERE tenant_id = :tenant "
-                "  AND metadata_::jsonb->>'insured_name' IS NOT NULL "
-                "  AND metadata_::jsonb->>'insured_name' != ''"
-            ),
-            {"tenant": tenant_id},
-        ).fetchall()
-        entities = [r[0] for r in rows if r[0]]
+        tags = db.query(Tag).filter(Tag.name.like("client:%")).all()
+        entities = [tag.name for tag in tags]
     except Exception:
         entities = []
     _ENTITY_CACHE[tenant_id] = entities
@@ -497,13 +486,20 @@ def _get_known_entities(db: Session, tenant_id: str = "default") -> list[str]:
 
 
 def detect_entity_in_query(query: str, db: Session, tenant_id: str = "default") -> str | None:
-    """Return the known entity name that appears in the query, or None."""
-    entities = _get_known_entities(db, tenant_id)
-    query_lower = query.lower()
-    matches = [e for e in entities if e.lower() in query_lower]
-    if not matches:
-        return None
-    return max(matches, key=len)  # Longest match = most specific
+    """Return the customer tag (client:*) detected in the query, or None.
+
+    Uses existing _get_tag_patterns() word-boundary regex matching.
+    Returns None if zero or multiple customer tags match (avoids wrong customer).
+    """
+    patterns = _get_tag_patterns(db)
+    matched = [
+        tag_name
+        for tag_name, namespace, pattern in patterns
+        if namespace == "client" and pattern.search(query)
+    ]
+    if len(matched) == 1:
+        return matched[0]  # e.g., "client:walnut-creek"
+    return None  # Zero or multiple matches: no entity isolation
 
 
 def extract_key_terms(text: str) -> set[str]:


### PR DESCRIPTION
## What
Replaces the broken `insured_name`-based entity isolation from #483 with tag-based isolation using the existing `client:*` tag infrastructure.

## Why
The #483 approach was broken because `insured_name` is never populated in existing chunk metadata (all docs were ingested before the fix). The replacement uses `_get_tag_patterns()` and `enrich_intent_with_tags()` — already working infrastructure — so entity isolation works immediately without reprocessing any documents.

Closes #487

## How
- **`ingestkit_adapters.py`**: Removed `entity_name` param, `set_entity_name()` setter, and `insured_name` metadata injection
- **`forms_processing_service.py`**: Removed `set_entity_name()` call before upsert (kept synopsis header text)
- **`pgvector_service.py`**: Replaced `insured_name` string-match filter in `search()` with exact tag membership check: `if entity_hint not in chunk_tags: continue`. Removed `entity_name` from `add_synopsis_chunk()`
- **`forms_query_service.py`**: Removed OCR-field-based entity isolation block
- **`rag_service.py`**: Replaced `_get_known_entities()` (was querying empty insured_name field) to query `Tag` table for `client:*` entries. Replaced `detect_entity_in_query()` to use `_get_tag_patterns()` word-boundary regex

## Stack
- [x] Backend

## Verification
- [x] `ruff check` passes
- [x] 1095 tests pass
- [x] No new failures introduced

## Artifacts
`.agents/outputs/plan-487-030126.md`, `.agents/outputs/plan-check-487-030126.md`, `.agents/outputs/patch-487-030126.md`