### PR TITLE
feat: cross-entity aggregate COI query support (#484)

### DIFF
--- a/ai_ready_rag/services/forms_query_service.py
+++ b/ai_ready_rag/services/forms_query_service.py
@@ -284,6 +284,192 @@ class FormsQueryService:
 
         return result
 
+    @staticmethod
+    def _parse_acord_date(date_str: str):
+        """Parse ACORD form date string to datetime. Returns None on failure.
+
+        Supports MM/DD/YYYY, MM/DD/YY, and YYYY-MM-DD formats.
+        """
+        from datetime import datetime
+
+        if not date_str or not date_str.strip():
+            return None
+        for fmt in ("%m/%d/%Y", "%m/%d/%y", "%Y-%m-%d"):
+            try:
+                return datetime.strptime(date_str.strip(), fmt)
+            except ValueError:
+                continue
+        return None
+
+    def _extract_coi_summary(self, grouped_fields: dict) -> dict:
+        """Extract COI summary fields using substring label matching.
+
+        Returns dict with keys: insured, exp_date, insurers, policy_numbers.
+        Uses substring matching because ACORD 25 labels vary by row suffix (A, B, C...).
+        """
+        result: dict = {"insured": "", "exp_date": "", "insurers": [], "policy_numbers": []}
+
+        # Named insured — look in Named Insured group first
+        for _label, value in grouped_fields.get("Named Insured", []):
+            if value and not result["insured"]:
+                result["insured"] = value.strip()
+                break
+
+        # Scan all groups for expiration dates, insurers, policy numbers
+        for group_fields in grouped_fields.values():
+            for label, value in group_fields:
+                if not value or not value.strip():
+                    continue
+                label_lower = label.lower()
+                if ("expir" in label_lower or "exp date" in label_lower) and not result["exp_date"]:
+                    result["exp_date"] = value.strip()
+                elif "insurer" in label_lower or "carrier" in label_lower:
+                    if value.strip() and value.strip() not in result["insurers"]:
+                        result["insurers"].append(value.strip())
+                elif (
+                    "policy" in label_lower
+                    and "number" in label_lower
+                    and value.strip()
+                    and value.strip() not in result["policy_numbers"]
+                ):
+                    result["policy_numbers"].append(value.strip())
+
+        return result
+
+    def query_forms_aggregate(
+        self,
+        intent,
+        user_tags: list[str] | None,
+        db: Session,
+        max_docs: int = 20,
+    ) -> list[SearchResult]:
+        """Return COI summary for ALL accessible customers (cross-entity aggregate query).
+
+        Iterates all accessible ACORD 25 documents, returns one SearchResult per
+        unique insured name. Returns [] for SQLite (dev/test guard).
+        """
+        if not self._database_url or "sqlite" in self._database_url:
+            return []
+
+        documents = self._get_accessible_form_documents(user_tags, db)
+        documents = self._sort_by_recency(documents)
+        results: list[SearchResult] = []
+        seen_insureds: set[str] = set()
+        chunk_index = 0
+
+        for doc in documents[:max_docs]:
+            try:
+                table_names = json.loads(doc.forms_db_table_names)
+                if not table_names or not doc.forms_ingest_key:
+                    continue
+                grouped_fields = self._read_form_fields(table_names[0], doc.forms_ingest_key, None)
+                summary = self._extract_coi_summary(grouped_fields)
+                insured = summary["insured"]
+                if insured in seen_insureds:
+                    continue
+                seen_insureds.add(insured)
+
+                insurers = ", ".join(summary["insurers"][:3]) if summary["insurers"] else "N/A"
+                policies = (
+                    ", ".join(summary["policy_numbers"][:3]) if summary["policy_numbers"] else "N/A"
+                )
+                exp_date = summary["exp_date"] or "N/A"
+
+                text = (
+                    f"ACORD 25 - Certificate of Liability Insurance\n"
+                    f"Customer: {insured}\n"
+                    f"Insurer(s): {insurers}\n"
+                    f"Policy Number(s): {policies}\n"
+                    f"Expiration Date: {exp_date}"
+                )
+                doc_tags = [tag.name for tag in doc.tags] if doc.tags else []
+                results.append(
+                    SearchResult(
+                        chunk_id=f"{doc.id}_agg_{chunk_index}",
+                        document_id=doc.id,
+                        document_name=doc.original_filename,
+                        chunk_text=text,
+                        chunk_index=9500 + chunk_index,
+                        score=0.9,
+                        page_number=1,
+                        section="Aggregate",
+                        tags=doc_tags,
+                    )
+                )
+                chunk_index += 1
+            except Exception:
+                continue
+
+        return results
+
+    def query_forms_expiring(
+        self,
+        intent,
+        user_tags: list[str] | None,
+        db: Session,
+        n: int = 10,
+    ) -> list[SearchResult]:
+        """Return the N soonest-expiring COI policies across all accessible customers.
+
+        Parses expiration dates, filters to future dates, sorts ascending.
+        Returns [] for SQLite (dev/test guard).
+        """
+        from datetime import datetime
+
+        if not self._database_url or "sqlite" in self._database_url:
+            return []
+
+        documents = self._get_accessible_form_documents(user_tags, db)
+        dated_results: list[tuple] = []
+
+        for doc in documents:
+            try:
+                table_names = json.loads(doc.forms_db_table_names)
+                if not table_names or not doc.forms_ingest_key:
+                    continue
+                grouped_fields = self._read_form_fields(table_names[0], doc.forms_ingest_key, None)
+                summary = self._extract_coi_summary(grouped_fields)
+                insured = summary["insured"]
+                exp_str = summary["exp_date"]
+                exp_dt = self._parse_acord_date(exp_str)
+                if exp_dt is None:
+                    continue
+
+                insurers = ", ".join(summary["insurers"][:3]) if summary["insurers"] else "N/A"
+                policies = (
+                    ", ".join(summary["policy_numbers"][:3]) if summary["policy_numbers"] else "N/A"
+                )
+
+                text = (
+                    f"ACORD 25 - Certificate of Liability Insurance\n"
+                    f"Customer: {insured}\n"
+                    f"Insurer(s): {insurers}\n"
+                    f"Policy Number(s): {policies}\n"
+                    f"Expiration Date: {exp_str}"
+                )
+                doc_tags = [tag.name for tag in doc.tags] if doc.tags else []
+                result = SearchResult(
+                    chunk_id=f"{doc.id}_exp_0",
+                    document_id=doc.id,
+                    document_name=doc.original_filename,
+                    chunk_text=text,
+                    chunk_index=9600,
+                    score=0.9,
+                    page_number=1,
+                    section="Expiring",
+                    tags=doc_tags,
+                )
+                dated_results.append((exp_dt, result))
+            except Exception:
+                continue
+
+        # Sort by expiration date ascending (soonest first)
+        dated_results.sort(key=lambda x: x[0])
+        now = datetime.utcnow()
+        future = [(dt, r) for dt, r in dated_results if dt >= now]
+        top = future[:n] if future else dated_results[:n]
+        return [r for _, r in top]
+
     def _format_as_search_result(
         self,
         document: Document,

--- a/ai_ready_rag/services/rag_service.py
+++ b/ai_ready_rag/services/rag_service.py
@@ -239,6 +239,7 @@ class QueryIntent:
     forms_eligible: bool = False  # True when intent matches structured form data
     intent_labels: list[str] | None = None  # All matched labels e.g. ["active_policy", "gl"]
     entity_name: str | None = None  # Customer tag for entity isolation e.g. "client:walnut-creek"
+    is_cross_entity: bool = False  # True when query spans all customers (aggregate/list queries)
 
 
 # Insurance domain intent patterns: (compiled_regex, preferred_tags, label)
@@ -360,6 +361,18 @@ INTENT_PATTERNS: list[tuple[re.Pattern, list[str], str]] = [
 ]
 
 
+CROSS_ENTITY_PATTERNS = [
+    re.compile(r"\ball\s+customers?\b", re.IGNORECASE),
+    re.compile(r"\ball\s+clients?\b", re.IGNORECASE),
+    re.compile(r"\bevery\s+customer\b", re.IGNORECASE),
+    re.compile(r"\beach\s+customer\b", re.IGNORECASE),
+    re.compile(r"\blist\s+all\b", re.IGNORECASE),
+    re.compile(r"\bnext\s+\d+\s+expir", re.IGNORECASE),
+    re.compile(r"\bexpiring\s+(soon|this|next)\b", re.IGNORECASE),
+    re.compile(r"\bupcoming\s+expir", re.IGNORECASE),
+]
+
+
 def detect_query_intent(query: str) -> QueryIntent:
     """Detect intent from user query using regex patterns.
 
@@ -388,12 +401,19 @@ def detect_query_intent(query: str) -> QueryIntent:
 
     forms_eligible = any(label in FORMS_ELIGIBLE_INTENTS for label in labels)
 
+    is_cross_entity = any(p.search(query) for p in CROSS_ENTITY_PATTERNS)
+    if is_cross_entity and re.search(
+        r"\b(coi|certificate|certif|expir|policy|policies)\b", query, re.IGNORECASE
+    ):
+        forms_eligible = True
+
     return QueryIntent(
         preferred_tags=preferred_tags,
         intent_label=labels[0] if labels else None,
         confidence=min(1.0, len(labels) * 0.5) if labels else 0.0,
         forms_eligible=forms_eligible,
         intent_labels=labels if labels else None,
+        is_cross_entity=is_cross_entity,
     )
 
 
@@ -512,6 +532,29 @@ def extract_key_terms(text: str) -> set[str]:
     """
     words = re.findall(r"\b[a-z0-9]+\b", text.lower())
     return {w for w in words if w not in STOPWORDS and len(w) >= 3}
+
+
+def _is_expiring_query(query: str) -> bool:
+    """Return True if the query is asking about expiring/upcoming policies."""
+    expiry_patterns = [
+        re.compile(r"\bexpir", re.IGNORECASE),
+        re.compile(r"\brenew", re.IGNORECASE),
+        re.compile(r"\bupcoming\b", re.IGNORECASE),
+    ]
+    return any(p.search(query) for p in expiry_patterns)
+
+
+def _extract_limit_from_query(query: str, default: int = 10) -> int:
+    """Extract a numeric limit from a query like 'next 5 expiring'. Returns default if not found."""
+    m = re.search(r"\bnext\s+(\d+)\b", query, re.IGNORECASE)
+    if m:
+        val = int(m.group(1))
+        return min(val, 50)  # cap at 50
+    m = re.search(r"\b(\d+)\s+expir", query, re.IGNORECASE)
+    if m:
+        val = int(m.group(1))
+        return min(val, 50)
+    return default
 
 
 def expand_query(question: str, db: Session | None = None) -> list[str]:
@@ -1299,6 +1342,11 @@ class RAGService:
                 intent.entity_name = entity_name
                 logger.info(f"Entity detected in query: {entity_name}")
 
+            # Cross-entity detection: aggregate queries span all customers, disable entity filter
+            if intent.is_cross_entity and intent.entity_name:
+                intent.entity_name = None  # cross-entity overrides single-entity isolation
+                logger.info("Cross-entity query: entity isolation suppressed")
+
             if self.enable_query_expansion:
                 queries = expand_query(query, db=db_session)
                 logger.debug(f"Query expansion: {len(queries)} variants")
@@ -1306,13 +1354,39 @@ class RAGService:
                 queries = [query]
 
             # 1.5 Query forms DB for structured context
-            if intent.forms_eligible and self._forms_query_service:
+            _forms_cap = (
+                min(20, max_chunks * 2) if intent.is_cross_entity else min(4, max_chunks // 2)
+            )
+            if intent.is_cross_entity and self._forms_query_service:
+                try:
+                    if _is_expiring_query(query):
+                        limit = _extract_limit_from_query(query)
+                        forms_results = self._forms_query_service.query_forms_expiring(
+                            intent=intent,
+                            user_tags=user_tags,
+                            db=db_session,
+                            n=limit,
+                        )
+                    else:
+                        forms_results = self._forms_query_service.query_forms_aggregate(
+                            intent=intent,
+                            user_tags=user_tags,
+                            db=db_session,
+                            max_docs=_forms_cap,
+                        )
+                    if forms_results:
+                        logger.info(f"Cross-entity forms query: {len(forms_results)} results")
+                except Exception as e:
+                    logger.warning(
+                        f"Cross-entity forms query failed, continuing with vector only: {e}"
+                    )
+            elif intent.forms_eligible and self._forms_query_service:
                 try:
                     forms_results = self._forms_query_service.query_forms(
                         intent=intent,
                         user_tags=user_tags,
                         db=db_session,
-                        max_results=min(4, max_chunks // 2),
+                        max_results=_forms_cap,
                     )
                     if forms_results:
                         logger.info(


### PR DESCRIPTION
## What
Adds a generic structured query framework so users can ask aggregate questions like "list all COI insurers, policy numbers, and expiration dates for all customers" or "what are the next 10 expiring COIs".

## Why
Previously the system capped forms results at 4 documents and had no way to answer cross-entity (all customers) queries — it would either return one customer's data or contaminated mixed results. Closes #484.

## How
### `rag_service.py`
- Added `is_cross_entity: bool = False` to `QueryIntent` dataclass
- Added `CROSS_ENTITY_PATTERNS` (8 regexes: "all customers", "list all", "next N expiring", "expiring soon", etc.)
- Added `_is_expiring_query()` and `_extract_limit_from_query()` helpers
- Updated `get_quality_context()`: when `is_cross_entity=True`, suppresses entity isolation and dispatches to `query_forms_expiring()` or `query_forms_aggregate()` instead of the single-entity `query_forms()`
- Forms cap raised from `min(4, max_chunks//2)` to `min(20, max_chunks*2)` for cross-entity queries

### `forms_query_service.py`
- Added `_parse_acord_date()` — parses `MM/DD/YYYY` (and two fallback formats)
- Added `_extract_coi_summary()` — uses substring label matching for dynamic ACORD 25 field names
- Added `query_forms_aggregate()` — one `SearchResult` per unique insured across all accessible docs
- Added `query_forms_expiring()` — N soonest future-expiring COIs sorted ascending

## Stack
- [x] Backend

## Verification
- [x] `ruff check` passes (clean)
- [x] 158 relevant tests pass (rag_service, vector_service, vector_utils)
- [x] No regressions

## Artifacts
`.agents/outputs/plan-484-030126.md`, `.agents/outputs/plan-check-484-030126.md`, `.agents/outputs/patch-484-030126.md`